### PR TITLE
Write out correct version in ZkId. (#6601)

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStore.scala
@@ -2,6 +2,8 @@ package mesosphere.marathon
 package core.storage.store.impl.zk
 
 import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 import akka.stream.Materializer
@@ -14,7 +16,6 @@ import mesosphere.marathon.core.storage.backup.BackupItem
 import mesosphere.marathon.core.storage.repository.RepositoryConstants
 import mesosphere.marathon.core.storage.store.impl.{BasePersistenceStore, CategorizedKey}
 import mesosphere.marathon.metrics.Metrics
-import mesosphere.marathon.state.Timestamp
 import mesosphere.marathon.storage.migration.{Migration, StorageVersions}
 import mesosphere.marathon.util.{WorkQueue, toRichFuture}
 import org.apache.zookeeper.KeeperException
@@ -31,13 +32,13 @@ case class ZkId(category: String, id: String, version: Option[OffsetDateTime]) {
 
   // BUG: id = "" for the root group this results in "Path must not end with / character" in curator
   def path: String = version.fold(f"/$category/$bucket%x/$id") { v =>
-    f"/$category/$bucket%x/$id/${ZkId.WriteDateFormat.format(v)}"
+    val truncatedVersion = v.truncatedTo(ChronoUnit.MILLIS)
+    f"/$category/$bucket%x/$id/${ZkId.DateFormat.format(truncatedVersion)}"
   }
 }
 
 object ZkId {
-  val WriteDateFormat = Timestamp.WriteFormatter // WriteDateFormat is following our formatting style
-  val ReadDateFormat = Timestamp.ReadFormatter // ReadDateFormat is compatible with every possible ISO-8601 string
+  val DateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME
   val HashBucketSize = 16
 }
 
@@ -136,7 +137,7 @@ class ZkPersistenceStore(
         await(client.children(path).asTry) match {
           case Success(Children(_, _, nodes)) =>
             nodes.map { path =>
-              OffsetDateTime.parse(path, ZkId.ReadDateFormat)
+              OffsetDateTime.parse(path, ZkId.DateFormat)
             }
           case Failure(_: NoNodeException) =>
             Seq.empty

--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -65,7 +65,7 @@ trait DefaultConversions {
   }
 
   implicit object OffsetDateTimeWrite extends play.api.libs.json.Writes[OffsetDateTime] {
-    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.WriteFormatter))
+    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.formatter))
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -28,7 +28,7 @@ abstract case class Timestamp private (private val instant: Instant) extends Ord
   def youngerThan(that: Timestamp): Boolean = this.after(that)
   def olderThan(that: Timestamp): Boolean = this.before(that)
 
-  override def toString: String = Timestamp.WriteFormatter.format(instant)
+  override def toString: String = Timestamp.formatter.format(instant)
 
   def toInstant: Instant = instant
 
@@ -69,7 +69,7 @@ object Timestamp {
   /**
     * Returns a new Timestamp representing the supplied time.
     */
-  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time, ReadFormatter)) match {
+  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time)) match {
     case Success(parsed) => parsed
     case Failure(e: DateTimeParseException) => throw new IllegalArgumentException(s"Invalid timestamp provided '$time'. Expecting ISO-8601 datetime string.", e)
     case Failure(e) => throw e
@@ -104,6 +104,5 @@ object Timestamp {
   /*
    * .toString in java.time is truncating zeros in millis part, so we use custom formatter to keep them
    */
-  val WriteFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
-  val ReadFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -48,16 +48,15 @@ case class StoredPlan(
   def toProto: Protos.DeploymentPlanDefinition = {
     Protos.DeploymentPlanDefinition.newBuilder
       .setId(id)
-      .setOriginalRootVersion(StoredPlan.WriteDateFormat.format(originalVersion))
-      .setTargetRootVersion(StoredPlan.WriteDateFormat.format(targetVersion))
-      .setTimestamp(StoredPlan.WriteDateFormat.format(version))
+      .setOriginalRootVersion(StoredPlan.DateFormat.format(originalVersion))
+      .setTargetRootVersion(StoredPlan.DateFormat.format(targetVersion))
+      .setTimestamp(StoredPlan.DateFormat.format(version))
       .build()
   }
 }
 
 object StoredPlan {
-  val ReadDateFormat = Timestamp.ReadFormatter
-  val WriteDateFormat = Timestamp.WriteFormatter
+  val DateFormat = StoredGroup.DateFormat
 
   def apply(deploymentPlan: DeploymentPlan): StoredPlan = {
     StoredPlan(deploymentPlan.id, deploymentPlan.original.version.toOffsetDateTime,
@@ -66,14 +65,14 @@ object StoredPlan {
 
   def apply(proto: Protos.DeploymentPlanDefinition): StoredPlan = {
     val version = if (proto.hasTimestamp) {
-      OffsetDateTime.parse(proto.getTimestamp, ReadDateFormat)
+      OffsetDateTime.parse(proto.getTimestamp, DateFormat)
     } else {
       OffsetDateTime.MIN
     }
     StoredPlan(
       proto.getId,
-      OffsetDateTime.parse(proto.getOriginalRootVersion, ReadDateFormat),
-      OffsetDateTime.parse(proto.getTargetRootVersion, ReadDateFormat),
+      OffsetDateTime.parse(proto.getOriginalRootVersion, DateFormat),
+      OffsetDateTime.parse(proto.getTargetRootVersion, DateFormat),
       version)
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -2,6 +2,8 @@ package mesosphere.marathon
 package storage.repository
 
 import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
@@ -44,6 +46,8 @@ case class StoredGroup(
         case NonFatal(ex) =>
           logger.error(s"Failed to load $appId:$appVersion for group $id ($version)", ex)
           throw ex
+      }.map { maybeAppDef =>
+        (appId, maybeAppDef)
       }
     }
     val podFutures = podIds.map {
@@ -51,28 +55,34 @@ case class StoredGroup(
         case NonFatal(ex) =>
           logger.error(s"Failed to load $podId:$podVersion for group $id ($version)", ex)
           throw ex
+      }.map { maybePodDef =>
+        (podId, maybePodDef)
       }
     }
 
     val groupFutures = storedGroups.map(_.resolve(appRepository, podRepository))
 
     val allApps = await(Future.sequence(appFutures))
-    if (allApps.exists(_.isEmpty)) {
-      logger.warn(s"Group $id $version is missing ${allApps.count(_.isEmpty)} apps")
+    if (allApps.exists { case (_, maybeAppDef) => maybeAppDef.isEmpty }) {
+      val missingApps = allApps.filter { case (_, maybeAppDef) => maybeAppDef.isEmpty }
+      val summarizedMissingApps = summarize(missingApps.toIterator.map(_._1))
+      logger.warn(s"Group $id $version is missing apps: $summarizedMissingApps")
     }
 
     val allPods = await(Future.sequence(podFutures))
-    if (allPods.exists(_.isEmpty)) {
-      logger.warn(s"Group $id $version is missing ${allPods.count(_.isEmpty)} pods")
+    if (allPods.exists { case (_, maybePodDef) => maybePodDef.isEmpty }) {
+      val missingPods = allPods.filter { case (_, maybePodDef) => maybePodDef.isEmpty }
+      val summarizedMissingPods = summarize(missingPods.toIterator.map(_._1))
+      logger.warn(s"Group $id $version is missing pods: $summarizedMissingPods")
     }
 
-    val apps: Map[PathId, AppDefinition] = await(Future.sequence(appFutures)).collect {
-      case Some(app: AppDefinition) =>
+    val apps: Map[PathId, AppDefinition] = allApps.collect {
+      case (_, Some(app: AppDefinition)) =>
         app.id -> app
     }(collection.breakOut)
 
-    val pods: Map[PathId, PodDefinition] = await(Future.sequence(podFutures)).collect {
-      case Some(pod: PodDefinition) =>
+    val pods: Map[PathId, PodDefinition] = allPods.collect {
+      case (_, Some(pod: PodDefinition)) =>
         pod.id -> pod
     }(collection.breakOut)
 
@@ -91,18 +101,18 @@ case class StoredGroup(
   }
 
   def toProto: Protos.GroupDefinition = {
-    import StoredGroup.WriteDateFormat
+    import StoredGroup.DateFormat
 
     val b = Protos.GroupDefinition.newBuilder
       .setId(id.safePath)
-      .setVersion(WriteDateFormat.format(version))
+      .setVersion(DateFormat.format(version))
 
     appIds.foreach {
       case (app, appVersion) =>
         b.addApps(
           Protos.GroupDefinition.AppReference.newBuilder()
             .setId(app.safePath)
-            .setVersion(WriteDateFormat.format(appVersion)))
+            .setVersion(DateFormat.format(appVersion)))
     }
 
     podIds.foreach {
@@ -110,7 +120,7 @@ case class StoredGroup(
         b.addPods(
           Protos.GroupDefinition.AppReference.newBuilder()
             .setId(pod.safePath)
-            .setVersion(WriteDateFormat.format(podVersion)))
+            .setVersion(DateFormat.format(podVersion)))
     }
 
     storedGroups.foreach { storedGroup => b.addGroups(storedGroup.toProto) }
@@ -121,8 +131,7 @@ case class StoredGroup(
 }
 
 object StoredGroup {
-  val ReadDateFormat = Timestamp.ReadFormatter
-  val WriteDateFormat = Timestamp.WriteFormatter
+  val DateFormat = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
   def apply(group: Group): StoredGroup =
     StoredGroup(
@@ -135,11 +144,11 @@ object StoredGroup {
 
   def apply(proto: Protos.GroupDefinition): StoredGroup = {
     val apps: Map[PathId, OffsetDateTime] = proto.getAppsList.map { appId =>
-      PathId.fromSafePath(appId.getId) -> OffsetDateTime.parse(appId.getVersion, ReadDateFormat)
+      PathId.fromSafePath(appId.getId) -> OffsetDateTime.parse(appId.getVersion, DateFormat)
     }(collection.breakOut)
 
     val pods: Map[PathId, OffsetDateTime] = proto.getPodsList.map { podId =>
-      PathId.fromSafePath(podId.getId) -> OffsetDateTime.parse(podId.getVersion, ReadDateFormat)
+      PathId.fromSafePath(podId.getId) -> OffsetDateTime.parse(podId.getVersion, DateFormat)
     }(collection.breakOut)
 
     val groups = proto.getGroupsList.map(StoredGroup(_))
@@ -150,7 +159,7 @@ object StoredGroup {
       podIds = pods,
       storedGroups = groups.toIndexedSeq,
       dependencies = proto.getDependenciesList.map(PathId.fromSafePath)(collection.breakOut),
-      version = OffsetDateTime.parse(proto.getVersion, ReadDateFormat)
+      version = OffsetDateTime.parse(proto.getVersion, DateFormat)
     )
   }
 }

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -71,24 +71,5 @@ class TimestampTest extends UnitTest {
         timestamp.millis shouldEqual instant.truncatedTo(ChronoUnit.SECONDS).toEpochMilli
       }
     }
-    "converting to/from OffsetDateTime" should {
-      "be compatible" in {
-
-        val dateTimeStr = "2018-09-26T12:46:13.587Z"
-
-        val timestamp = Timestamp(dateTimeStr)
-        val timestampString = timestamp.toString
-
-        val offsetDateTime = OffsetDateTime.parse(timestampString)
-
-        val formatted = Timestamp.WriteFormatter.format(offsetDateTime)
-
-        Timestamp(offsetDateTime) shouldEqual timestamp
-        Timestamp(timestampString) shouldEqual timestamp
-        Timestamp(formatted) shouldEqual timestamp
-
-        OffsetDateTime.parse(dateTimeStr, Timestamp.ReadFormatter).format(Timestamp.WriteFormatter) shouldEqual timestamp.toString
-      }
-    }
   }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -55,8 +55,8 @@ case class ITEnrichedTask(
     host: String,
     ports: Option[Seq[Int]],
     slaveId: Option[String],
-    startedAt: Option[Date],
-    stagedAt: Option[Date],
+    startedAt: Option[Timestamp],
+    stagedAt: Option[Timestamp],
     state: String,
     version: Option[String],
     region: Option[String],
@@ -125,8 +125,8 @@ class MarathonFacade(
     (__ \ "host").format[String] ~
     (__ \ "ports").formatNullable[Seq[Int]] ~
     (__ \ "slaveId").formatNullable[String] ~
-    (__ \ "startedAt").formatNullable[Date] ~
-    (__ \ "stagedAt").formatNullable[Date] ~
+    (__ \ "startedAt").formatNullable[Timestamp] ~
+    (__ \ "stagedAt").formatNullable[Timestamp] ~
     (__ \ "state").format[String] ~
     (__ \ "version").formatNullable[String] ~
     (__ \ "region").formatNullable[String] ~


### PR DESCRIPTION
Summary:
With #6558 we started to include the micro seconds in app versions even
when they were zero. Older Marathon versions would drop the zeros. We
would not find apps from previous versions though since the string representation is different.

Commit that introduced storing timestamps with trailing zeros was reverted (since it generated a lot of flakes), and now we truncate microsecond instead of changing the formatter.

JIRA issues: MARATHON-8461

(cherry picked from commit 6495c6938c7010b2f8a8f3649daa6dcc8e46d900)
