### PR TITLE
Write out correct version in ZkId. (#6601)

### DIFF
--- a/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
+++ b/src/main/scala/mesosphere/marathon/raml/DefaultConversions.scala
@@ -65,7 +65,7 @@ trait DefaultConversions {
   }
 
   implicit object OffsetDateTimeWrite extends play.api.libs.json.Writes[OffsetDateTime] {
-    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.WriteFormatter))
+    def writes(o: OffsetDateTime) = JsString(o.format(Timestamp.formatter))
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -28,7 +28,7 @@ abstract case class Timestamp private (private val instant: Instant) extends Ord
   def youngerThan(that: Timestamp): Boolean = this.after(that)
   def olderThan(that: Timestamp): Boolean = this.before(that)
 
-  override def toString: String = Timestamp.WriteFormatter.format(instant)
+  override def toString: String = Timestamp.formatter.format(instant)
 
   def toInstant: Instant = instant
 
@@ -69,7 +69,7 @@ object Timestamp {
   /**
     * Returns a new Timestamp representing the supplied time.
     */
-  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time, ReadFormatter)) match {
+  def apply(time: String): Timestamp = Timestamp(Try(OffsetDateTime.parse(time)) match {
     case Success(parsed) => parsed
     case Failure(e: DateTimeParseException) => throw new IllegalArgumentException(s"Invalid timestamp provided '$time'. Expecting ISO-8601 datetime string.", e)
     case Failure(e) => throw e
@@ -104,6 +104,5 @@ object Timestamp {
   /*
    * .toString in java.time is truncating zeros in millis part, so we use custom formatter to keep them
    */
-  val WriteFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
-  val ReadFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC)
 }

--- a/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/DeploymentRepositoryImpl.scala
@@ -48,16 +48,15 @@ case class StoredPlan(
   def toProto: Protos.DeploymentPlanDefinition = {
     Protos.DeploymentPlanDefinition.newBuilder
       .setId(id)
-      .setOriginalRootVersion(StoredPlan.WriteDateFormat.format(originalVersion))
-      .setTargetRootVersion(StoredPlan.WriteDateFormat.format(targetVersion))
-      .setTimestamp(StoredPlan.WriteDateFormat.format(version))
+      .setOriginalRootVersion(StoredPlan.DateFormat.format(originalVersion))
+      .setTargetRootVersion(StoredPlan.DateFormat.format(targetVersion))
+      .setTimestamp(StoredPlan.DateFormat.format(version))
       .build()
   }
 }
 
 object StoredPlan {
-  val ReadDateFormat = Timestamp.ReadFormatter
-  val WriteDateFormat = Timestamp.WriteFormatter
+  val DateFormat = StoredGroup.DateFormat
 
   def apply(deploymentPlan: DeploymentPlan): StoredPlan = {
     StoredPlan(deploymentPlan.id, deploymentPlan.original.version.toOffsetDateTime,
@@ -66,14 +65,14 @@ object StoredPlan {
 
   def apply(proto: Protos.DeploymentPlanDefinition): StoredPlan = {
     val version = if (proto.hasTimestamp) {
-      OffsetDateTime.parse(proto.getTimestamp, ReadDateFormat)
+      OffsetDateTime.parse(proto.getTimestamp, DateFormat)
     } else {
       OffsetDateTime.MIN
     }
     StoredPlan(
       proto.getId,
-      OffsetDateTime.parse(proto.getOriginalRootVersion, ReadDateFormat),
-      OffsetDateTime.parse(proto.getTargetRootVersion, ReadDateFormat),
+      OffsetDateTime.parse(proto.getOriginalRootVersion, DateFormat),
+      OffsetDateTime.parse(proto.getTargetRootVersion, DateFormat),
       version)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreTest.scala
@@ -73,28 +73,30 @@ class ZkPersistenceStoreTest extends AkkaUnitTest
   behave like basicPersistenceStore("ZookeeperPersistenceStore", defaultStore)
   behave like backupRestoreStore("ZookeeperPersistenceStore", defaultStore)
 
+  "ZkId should trim anything but millis after serialization" in {
+    val dateTime = OffsetDateTime.of(2015, 5, 14, 15, 43, 21, 0, ZoneOffset.UTC)
+    val withNanos = dateTime.withNano(123456789)
+    val zkId = ZkId("cat", "path", Some(withNanos))
+    val zkIdVersion = zkId.path.reverse.takeWhile(_ != '/').reverse
+    zkIdVersion shouldEqual "2015-05-14T15:43:21.123Z"
+    ZkId("cat", "path", Some(OffsetDateTime.parse(zkIdVersion))).path shouldEqual zkId.path
+  }
+
   def trimmingTest(offsetDateTime: OffsetDateTime): Unit = {
     val store = defaultStore
     implicit val clock = new SettableClock()
-
-    val offsetDateTimeOnlyMillisStr = offsetDateTime.format(Timestamp.WriteFormatter)
-    val offsetDateTimeOnlyMillis = OffsetDateTime.parse(offsetDateTimeOnlyMillisStr, Timestamp.ReadFormatter)
-
+    val offsetDateTimeOnlyMillisStr = offsetDateTime.format(Timestamp.formatter)
+    val offsetDateTimeOnlyMillis = OffsetDateTime.parse(offsetDateTimeOnlyMillisStr)
     val tc = TestClass1("abc", 1, offsetDateTime)
-
     store.store("test", tc).futureValue shouldEqual Done
     store.versions("test").runWith(Sink.seq).futureValue shouldEqual Seq(offsetDateTimeOnlyMillis)
   }
-
   "handle nanoseconds when providing versions" in {
     val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123456789, ZoneOffset.UTC)
-
     trimmingTest(offsetDateTime)
   }
-
   "handle milliseconds when providing versions" in {
     val offsetDateTime = OffsetDateTime.of(2015, 2, 3, 12, 30, 15, 123000000, ZoneOffset.UTC)
-
     trimmingTest(offsetDateTime)
   }
 }

--- a/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/TimestampTest.scala
@@ -71,24 +71,5 @@ class TimestampTest extends UnitTest {
         timestamp.millis shouldEqual instant.truncatedTo(ChronoUnit.SECONDS).toEpochMilli
       }
     }
-    "converting to/from OffsetDateTime" should {
-      "be compatible" in {
-
-        val dateTimeStr = "2018-09-26T12:46:13.587Z"
-
-        val timestamp = Timestamp(dateTimeStr)
-        val timestampString = timestamp.toString
-
-        val offsetDateTime = OffsetDateTime.parse(timestampString)
-
-        val formatted = Timestamp.WriteFormatter.format(offsetDateTime)
-
-        Timestamp(offsetDateTime) shouldEqual timestamp
-        Timestamp(timestampString) shouldEqual timestamp
-        Timestamp(formatted) shouldEqual timestamp
-
-        OffsetDateTime.parse(dateTimeStr, Timestamp.ReadFormatter).format(Timestamp.WriteFormatter) shouldEqual timestamp.toString
-      }
-    }
   }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -54,8 +54,8 @@ case class ITEnrichedTask(
     host: String,
     ports: Option[Seq[Int]],
     slaveId: Option[String],
-    startedAt: Option[Date],
-    stagedAt: Option[Date],
+    startedAt: Option[Timestamp],
+    stagedAt: Option[Timestamp],
     state: String,
     version: Option[String],
     region: Option[String],
@@ -124,8 +124,8 @@ class MarathonFacade(
     (__ \ "host").format[String] ~
     (__ \ "ports").formatNullable[Seq[Int]] ~
     (__ \ "slaveId").formatNullable[String] ~
-    (__ \ "startedAt").formatNullable[Date] ~
-    (__ \ "stagedAt").formatNullable[Date] ~
+    (__ \ "startedAt").formatNullable[Timestamp] ~
+    (__ \ "stagedAt").formatNullable[Timestamp] ~
     (__ \ "state").format[String] ~
     (__ \ "version").formatNullable[String] ~
     (__ \ "region").formatNullable[String] ~


### PR DESCRIPTION
Summary:
With #6558 we started to include the micro seconds in app versions even
when they were zero. Older Marathon versions would drop the zeros. We
would not find apps from previous versions though since the string representation is different.

Commit that introduced storing timestamps with trailing zeros was reverted (since it generated a lot of flakes), and now we truncate microsecond instead of changing the formatter.

JIRA issues: MARATHON-8461

(cherry picked from commit 6495c6938c7010b2f8a8f3649daa6dcc8e46d900)
