### PR TITLE
Only log zero-value offers for scalar resources and ranges (#6595)

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImpl.scala
@@ -73,7 +73,9 @@ private[launcher] class OfferProcessorImpl(
     val resourcesWithZeroValues = offer
       .getResourcesList.asScala
       .collect {
-        case resource if resource.getScalar.getValue.ceil.toLong == 0 =>
+        case resource if resource.hasScalar && resource.getScalar.getValue.ceil.toLong == 0 =>
+          resource.getName
+        case resource if resource.hasRanges && resource.getRanges.getRangeCount == 0 =>
           resource.getName
       }
     if (resourcesWithZeroValues.nonEmpty) {


### PR DESCRIPTION
Only log zero-value offers for scalar resources with value 0 and range resources with empty ranges. (#6595)
(backport from d0c8884)

JIRA Issues: MARATHON-8452
