### PR TITLE
`TaskOverdueActor` now respects `--kill_retry_timeout` parameter (#6596)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changes from 1.5.11 to 1.5.12 (unreleased)
 
+### Default for "kill_retry_timeout" was increased to 30 seconds
+
+Sending frequent kill requests to an agent can in certain cases lead to overloading the Docker daemon (if the tasks are docker containers run by the Docker containerizer). Thirty seconds seems to be a more sensible default here. 
+
 ### Marathon framework ID generation is now very conservative
 
 Previously, Marathon would automatically request a new framework ID from Mesos if the old one was marked as torn down in Mesos, or if the framework ID record was removed from Zookeeper. This has led to more trouble than it has helped. The new behavior is:

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -432,10 +432,9 @@ class SchedulerActions(
         s"RunSpec $unknownId exists in InstanceTracker, but not store. " +
           "The run spec was likely terminated. Will now expunge."
       )
-      instances.specInstances(unknownId).foreach { orphanTask =>
-        logger.info(s"Killing ${orphanTask.instanceId}")
-        killService.killInstance(orphanTask, KillReason.Orphaned)
-      }
+      val orphanedInstances = instances.specInstances(unknownId)
+      logger.info(s"Killing orphaned instances of the runSpec $unknownId : [${orphanedInstances.map(_.instanceId)}]")
+      killService.killInstancesAndForget(orphanedInstances, KillReason.Orphaned)
     }
 
     logger.info("Requesting task reconciliation with the Mesos master")

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -93,7 +93,11 @@ class CoreModuleImpl @Inject() (
 
   // this one can't be lazy right now because it wouldn't be instantiated soon enough ...
   override val taskTerminationModule = new TaskTerminationModule(
-    taskTrackerModule, leadershipModule, marathonSchedulerDriverHolder, marathonConf, clock)
+    taskTrackerModule,
+    leadershipModule,
+    marathonSchedulerDriverHolder,
+    marathonConf,
+    clock)
 
   // OFFER MATCHING AND LAUNCHING TASKS
 

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -154,7 +154,7 @@ private[health] class HealthCheckActor(
             timestamp = health.lastFailure.getOrElse(Timestamp.now()).toString
           )
         )
-        killService.killInstance(instance, KillReason.FailedHealthChecks)
+        killService.killInstancesAndForget(Seq(instance), KillReason.FailedHealthChecks)
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/TaskJobsModule.scala
@@ -4,10 +4,9 @@ package core.task.jobs
 import java.time.Clock
 
 import mesosphere.marathon.core.leadership.LeadershipModule
-import mesosphere.marathon.core.task.jobs.impl.{ ExpungeOverdueLostTasksActor, OverdueTasksActor }
+import mesosphere.marathon.core.task.jobs.impl.{ ExpungeOverdueLostTasksActor, OverdueInstancesActor }
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.{ TaskStateOpProcessor, InstanceTracker }
-import mesosphere.marathon.MarathonConf
 
 /**
   * This module contains periodically running jobs interacting with the task tracker.
@@ -18,7 +17,7 @@ class TaskJobsModule(config: MarathonConf, leadershipModule: LeadershipModule, c
     taskStateOpProcessor: TaskStateOpProcessor,
     killService: KillService): Unit = {
     leadershipModule.startWhenLeader(
-      OverdueTasksActor.props(
+      OverdueInstancesActor.props(
         config,
         taskTracker,
         taskStateOpProcessor,

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueInstancesActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueInstancesActor.scala
@@ -18,14 +18,14 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
-private[jobs] object OverdueTasksActor {
+private[jobs] object OverdueInstancesActor {
   def props(
     config: MarathonConf,
     taskTracker: InstanceTracker,
     taskStateOpProcessor: TaskStateOpProcessor,
     killService: KillService,
     clock: Clock): Props = {
-    Props(new OverdueTasksActor(new Support(config, taskTracker, taskStateOpProcessor, killService, clock)))
+    Props(new OverdueInstancesActor(new Support(config, taskTracker, taskStateOpProcessor, killService, clock)))
   }
 
   /**
@@ -52,13 +52,12 @@ private[jobs] object OverdueTasksActor {
     }
 
     private[this] def killOverdueInstances(now: Timestamp, instances: Seq[Instance]): Unit = {
-      overdueTasks(now, instances).foreach { overdueTask =>
-        logger.info(s"Killing overdue ${overdueTask.instanceId}")
-        killService.killInstance(overdueTask, KillReason.Overdue)
-      }
+      val instancesToKill = overdueInstances(now, instances)
+      logger.info(s"Killing overdue instances: ${instancesToKill.map(_.instanceId).mkString(", ")}")
+      killService.killInstancesAndForget(instancesToKill, KillReason.Overdue)
     }
 
-    private[this] def overdueTasks(now: Timestamp, instances: Seq[Instance]): Seq[Instance] = {
+    private[this] def overdueInstances(now: Timestamp, instances: Seq[Instance]): Seq[Instance] = {
       // stagedAt is set when the task is created by the scheduler
       val stagedExpire = now - config.taskLaunchTimeout().millis
       val unconfirmedExpire = now - config.taskLaunchConfirmTimeout().millis
@@ -104,17 +103,21 @@ private[jobs] object OverdueTasksActor {
   }
 
   private[jobs] case class Check(maybeAck: Option[ActorRef])
+  private[jobs] val overdueTaskActorInitialDelay: FiniteDuration = 30.seconds
+  private[jobs] val overdueTaskActorCheckInterval: FiniteDuration = 5.seconds
 }
 
-private class OverdueTasksActor(support: OverdueTasksActor.Support) extends Actor {
+private class OverdueInstancesActor(support: OverdueInstancesActor.Support) extends Actor {
   var checkTicker: Cancellable = _
   private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def preStart(): Unit = {
     import context.dispatcher
     checkTicker = context.system.scheduler.schedule(
-      30.seconds, 5.seconds, self,
-      OverdueTasksActor.Check(maybeAck = None)
+      OverdueInstancesActor.overdueTaskActorInitialDelay,
+      OverdueInstancesActor.overdueTaskActorCheckInterval,
+      self,
+      OverdueInstancesActor.Check(maybeAck = None)
     )
   }
 
@@ -123,7 +126,7 @@ private class OverdueTasksActor(support: OverdueTasksActor.Support) extends Acto
   }
 
   override def receive: Receive = {
-    case OverdueTasksActor.Check(maybeAck) =>
+    case OverdueInstancesActor.Check(maybeAck) =>
       val resultFuture = support.check()
       maybeAck match {
         case Some(ack) =>

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillConfig.scala
@@ -23,7 +23,7 @@ trait KillConfig extends ScallopConf {
       "The timeout after which unconfirmed instance kills will be retried.",
     noshort = true,
     hidden = true,
-    default = Some(10.seconds.toMillis)
+    default = Some(30.seconds.toMillis)
   )
 
   lazy val killChunkSize: Int = _killChunkSize()

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
@@ -13,24 +13,34 @@ import scala.concurrent.Future
   */
 trait KillService {
   /**
-    * Kill the given tasks and return a future that is completed when all of the tasks
+    * Kill the given instances and return a future that is completed when all of the tasks
     * have been reported as terminal.
     *
-    * @param tasks the tasks that shall be killed.
+    * @param instances the tasks that shall be killed.
     * @param reason the reason why the task shall be killed.
     * @return a future that is completed when all tasks are killed.
     */
-  def killInstances(tasks: Seq[Instance], reason: KillReason): Future[Done]
+  def killInstances(instances: Seq[Instance], reason: KillReason): Future[Done]
 
   /**
-    * Kill the given task. The implementation should add the task onto
+    * Kill the given instance. The implementation should add the task onto
     * a queue that is processed short term and will eventually kill the task.
     *
-    * @param task the task that shall be killed.
+    * @param instance the task that shall be killed.
     * @param reason the reason why the task shall be killed.
     * @return a future that is completed when all tasks are killed.
     */
-  def killInstance(task: Instance, reason: KillReason): Future[Done]
+  def killInstance(instance: Instance, reason: KillReason): Future[Done]
+
+  /**
+    * Kill the passed instances. Similarly to the [[killUnknownTask()]] method the implementation will *not* create a
+    * [[mesosphere.marathon.core.task.termination.impl.KillStreamWatcher]] internally saving resources in cases when
+    * the caller is not interested in the result.
+    *
+    * @param instances
+    * @param reason
+    */
+  def killInstancesAndForget(instances: Seq[Instance], reason: KillReason): Unit
 
   /**
     * Kill the given unknown task by ID and do not try to fetch its state

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -4,7 +4,6 @@ package core.task.termination
 import java.time.Clock
 
 import akka.actor.{ ActorRef, Props }
-import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.termination.impl.{ KillServiceActor, KillServiceDelegate }
 import mesosphere.marathon.core.task.tracker.InstanceTrackerModule

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -79,7 +79,10 @@ private[impl] class KillServiceActor(
       killUnknownTaskById(taskId)
 
     case KillInstances(instances, promise) =>
-      killInstances(instances, promise)
+      killInstances(instances, Some(promise))
+
+    case KillInstancesAndForget(instances) =>
+      killInstances(instances, None)
 
     case InstanceChanged(id, _, _, condition, _) if considerTerminal(condition) &&
       (inFlight.contains(id) || instancesToKill.contains(id)) =>
@@ -94,22 +97,27 @@ private[impl] class KillServiceActor(
 
   def killUnknownTaskById(taskId: Task.Id): Unit = {
     logger.debug(s"Received KillUnknownTaskById($taskId)")
-    instancesToKill.update(taskId.instanceId, ToKill(taskId.instanceId, Seq(taskId), maybeInstance = None, attempts = 0))
-    processKills()
+    if (!inFlight.contains(taskId.instanceId)) {
+      instancesToKill.update(taskId.instanceId, ToKill(taskId.instanceId, Seq(taskId), maybeInstance = None, attempts = 0))
+      processKills()
+    }
   }
 
-  def killInstances(instances: Seq[Instance], promise: Promise[Done]): Unit = {
+  def killInstances(instances: Seq[Instance], maybePromise: Option[Promise[Done]]): Unit = {
     val instanceIds = instances.map(_.instanceId)
-    logger.debug(s"Adding instances $instanceIds to queue; setting up child actor to track progress")
-    promise.completeWith(watchForKilledInstances(instanceIds))
-    instances.foreach { instance =>
-      // TODO(PODS): do we make sure somewhere that an instance has _at_least_ one task?
-      val taskIds: IndexedSeq[Id] = instance.tasksMap.values.withFilter(!_.isTerminal).map(_.taskId)(collection.breakOut)
-      instancesToKill.update(
-        instance.instanceId,
-        ToKill(instance.instanceId, taskIds, maybeInstance = Some(instance), attempts = 0)
-      )
-    }
+    logger.debug(s"Adding instances $instanceIds to the queue")
+    maybePromise.map(p => p.completeWith(watchForKilledInstances(instanceIds)))
+    instances
+      .filterNot(instance => inFlight.keySet.contains(instance.instanceId)) // Don't trigger a kill request for instances that are already being killed
+      .foreach { instance =>
+        // TODO(PODS): do we make sure somewhere that an instance has _at_least_ one task?
+        logger.info(s"Process kill for ${instance.instanceId}:{${instance.state}, with tasks ${instance.tasksMap.values.map(_.taskId).toSeq}")
+        val taskIds: IndexedSeq[Id] = instance.tasksMap.values.withFilter(!_.isTerminal).map(_.taskId)(collection.breakOut)
+        instancesToKill.update(
+          instance.instanceId,
+          ToKill(instance.instanceId, taskIds, maybeInstance = Some(instance), attempts = 0)
+        )
+      }
     processKills()
   }
 
@@ -188,6 +196,7 @@ private[termination] object KillServiceActor {
   sealed trait Request extends InternalRequest
   case class KillInstances(instances: Seq[Instance], promise: Promise[Done]) extends Request
   case class KillUnknownTaskById(taskId: Task.Id) extends Request
+  case class KillInstancesAndForget(instances: Seq[Instance]) extends Request
 
   sealed trait InternalRequest
   case object Retry extends InternalRequest

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
@@ -16,8 +16,8 @@ private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillS
 
   override def killInstances(instances: Seq[Instance], reason: KillReason): Future[Done] = {
     logger.info(
-      s"Killing ${instances.size} tasks for reason: $reason (ids: {} ...)",
-      instances.take(3).map(_.instanceId).mkString(","))
+      s"Killing ${instances.size} instances for reason: $reason (ids: {} ...)",
+      instances.map(_.instanceId).mkString(","))
 
     val promise = Promise[Done]
     actorRef ! KillInstances(instances, promise)
@@ -32,5 +32,10 @@ private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillS
   override def killUnknownTask(taskId: Task.Id, reason: KillReason): Unit = {
     logger.info(s"Killing unknown task for reason: $reason (id: {})", taskId)
     actorRef ! KillUnknownTaskById(taskId)
+  }
+
+  override def killInstancesAndForget(instances: Seq[Instance], reason: KillReason): Unit = {
+    logger.info(s"Kill and forget following instances for reason $reason: ${instances.map(_.instanceId).mkString(",")}")
+    actorRef ! KillInstancesAndForget(instances)
   }
 }

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -95,7 +95,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
 
       f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)
 
-      verify(f.killService, times(1)).killInstance(orphanedInstance, KillReason.Orphaned)
+      verify(f.killService, times(1)).killInstancesAndForget(Seq(orphanedInstance), KillReason.Orphaned)
     }
 
     "Scale up correctly in case of lost tasks (active queue)" in {

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -114,7 +114,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
       val actor = f.actor(MarathonHttpHealthCheck(maxConsecutiveFailures = 3, portIndex = Some(PortReference(0))))
 
       actor.underlyingActor.checkConsecutiveFailures(f.instance, Health(f.instance.instanceId, consecutiveFailures = 3))
-      verify(f.killService).killInstance(f.instance, KillReason.FailedHealthChecks)
+      verify(f.killService).killInstancesAndForget(Seq(f.instance), KillReason.FailedHealthChecks)
       verifyNoMoreInteractions(f.tracker, f.driver, f.scheduler)
     }
 

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -131,6 +131,7 @@ case class TestTaskBuilder(
     case Condition.Unknown => Some(MesosTaskStatusTestHelper.unknown(taskId))
     case Condition.Unreachable => Some(MesosTaskStatusTestHelper.unreachable(taskId))
     case Condition.UnreachableInactive => Some(MesosTaskStatusTestHelper.unreachable(taskId))
+    case _ => throw new UnsupportedOperationException(s"Unknown condition $condition")
   }
 
   def taskError(since: Timestamp = now, containerName: Option[String] = None) = createTask(since, containerName, Condition.Error)

--- a/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
@@ -47,5 +47,11 @@ class KillServiceMock(system: ActorSystem) extends KillService with Mockito {
     instance.instanceId returns taskId.instanceId
     killInstance(instance, reason)
   }
+
+  override def killInstancesAndForget(instances: Seq[Instance], reason: KillReason): Unit = {
+    instances.foreach { instance =>
+      killInstance(instance, reason)
+    }
+  }
 }
 


### PR DESCRIPTION
Summary:
previously `TaskOverdueActor` would periodically check for overdue tasks and request killing them which would lead to too many kill requests being sent to Mesos due to a bug in the `KillService`. This is now fixed. In detail:
- `KillService` does not send kill requests to Mesos for tasks that are already "in flight"
- a new `KillService.killInstancesAndForget()` method was introduced for cases where the caller doesn't care about the
result. In this case, `KillStreamWatcher` will not be created potentially preventing a memory leak (should there be stuck
tasks for a long period of time in the cluster)
- `kill_retry_timeout` was increased to 30 seconds by default. This should further prevent overloading agents with kill
requests (actually, it's the docker daemon who is easily overloaded but anyway)

Fixes: MARATHON-8453
(cherry picked from commit 20c6eb24a6085bc25f7ddc8cd2c35a284eca175b)