### PR TITLE
Bump `akka` to version 2.5.17

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -108,8 +108,8 @@ object Dependencies {
 object Dependency {
   object V {
     // runtime deps versions
-    val Akka = "2.5.7"
-    val AkkaHttp = "10.0.11"
+    val Akka = "2.5.17"
+    val AkkaHttp = "10.0.14"
     val Alpakka  = "0.14"
     val ApacheCommonsCompress = "1.13"
     val ApacheCommonsIO = "2.6"


### PR DESCRIPTION
and `akka-http` to 10.0.14. This fixes a severe memory leak which can lead to an `OutOfMemoryException` in the non-leader Marathon instances

Fixes JIRA: DCOS-42753