### PR TITLE
Update 1.4.x Docker image to Debian Stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,32 @@
-#
-# This is the official docker image that is used for production deployments of docker.
-#
-# It has the marathon startup script as entrypoint.
-#
-# It will reresolve all dependencies on every change (as opposed to Dockerfile.development)
-# but it ultimately results in a smaller docker image.
-#
-FROM buildpack-deps:jessie-curl
+FROM debian:stretch-slim
+LABEL MAINTAINER="Mesosphere Package Builder <support@mesosphere.io>"
 
 COPY . /marathon
 WORKDIR /marathon
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E56151BF && \
-    echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
-    echo "deb http://repos.mesosphere.com/debian jessie-unstable main" | tee /etc/apt/sources.list.d/mesosphere.list && \
-    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-    echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-    MESOS_VERSION=$(sed -n 's/^.*MesosDebian = "\(.*\)"/\1/p' </marathon/project/Dependencies.scala) && \
-    apt-get update && \
-    apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20161107~bpo8+1 && \
-    apt-get install --no-install-recommends -y --force-yes mesos=$MESOS_VERSION && \
-    apt-get clean && \
-    eval $(sed s/sbt.version/SBT_VERSION/ </marathon/project/build.properties) && \
-    mkdir -p /usr/local/bin && \
-    wget -P /usr/local/bin/ http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar && \
-    cp /marathon/project/sbt /usr/local/bin && chmod +x /usr/local/bin/sbt && \
-    sbt -Dsbt.log.format=false assembly && \
-    mv $(find target -name 'marathon-assembly-*.jar' | sort | tail -1) ./ && \
-    rm -rf project/target project/project/target plugin-interface/target target/* ~/.sbt ~/.ivy2 && \
-    mv marathon-assembly-*.jar target && \
+RUN cat /marathon/project/Dependencies.scala  | grep MesosDebian | cut -f 2 -d '"' > /marathon/MESOS_VERSION && \
+  cat /marathon/version.sbt | cut -f 2 -d '"' > /marathon/MARATHON_VERSION
 
+RUN apt-get update && apt-get install -my wget gnupg && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF && \
+    echo "deb http://ftp.debian.org/debian stretch-backports main" | tee -a /etc/apt/sources.list && \
+    echo "deb http://repos.mesosphere.com/debian stretch-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian stretch main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    apt-get update && \
+    apt-get upgrade -y && \
     # jdk setup
+    mkdir -p /usr/share/man/man1 && \
+    apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20170531+nmu1 && \
     /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
     ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home && \
+    # mesos setup
+    echo exit 0 > /usr/bin/systemctl && chmod +x /usr/bin/systemctl && \
+    apt-get install --no-install-recommends -y mesos=$(cat /marathon/MESOS_VERSION) && \
+    rm /usr/bin/systemctl && \
+    # marathon setup
+    apt-get install -y curl && \
+    mkdir -p /tmp/marathon && curl https://downloads.mesosphere.com/marathon/v$(cat MARATHON_VERSION)/marathon-$(cat MARATHON_VERSION).tgz | tar zx -C /tmp/marathon && \
+    mv /tmp/marathon/*/target /marathon/target && \
 
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Debian Jessie was EOL'd a several months ago and is no longer receiving
security updates.

We also change the Dockerfile to download a pre-built artifact, instead of rebuilding it from scratch inside of the docker container (and downloading all of the dependencies etc.). This was for my own sanity as I was developing the change.

JIRA Issues: MARATHON-8487