### PR TITLE
Install `enterprise-cli-package` before all SI tests

### DIFF
--- a/tests/shakedown/shakedown/dcos/command.py
+++ b/tests/shakedown/shakedown/dcos/command.py
@@ -14,6 +14,7 @@ from . import master_ip, master_leader_ip, marathon_leader_ip
 from .helpers import validate_key, try_close, get_transport, start_transport
 from ..clients import dcos_url
 from ..errors import DCOSException
+from ..clients.authentication import dcos_username, dcos_password
 
 
 logger = logging.getLogger(__name__)
@@ -210,7 +211,7 @@ def attached_cli():
 
     The CLI setup command should be idempotent. So it is save to call this method multiple times.
     """
-    cmd = 'cluster setup {} --no-check'.format(dcos_url())
+    cmd = 'cluster setup {} --no-check --username={} --password={}'.format(dcos_url(), dcos_username(), dcos_password())
     run_dcos_command(cmd)
     yield
 

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -8,6 +8,7 @@ import logging
 
 from datetime import timedelta
 from pathlib import Path
+from shakedown.dcos import cluster
 from shakedown.clients import dcos_url_path
 from shakedown.clients.authentication import dcos_acs_token
 from shakedown.dcos.agent import get_agents, get_private_agents
@@ -113,6 +114,14 @@ def docker_ipv6_network_fixture():
     yield
     for agent in agents:
         run_command_on_agent(agent, f"sudo docker network rm mesos-docker-ipv6-test")
+
+
+@pytest.fixture(autouse=True, scope='session')
+def install_enterprise_cli():
+    """Install enterprise cli on an DC/OS EE cluster before all tests start.
+    """
+    if cluster.ee_version() is not None:
+        common.install_enterprise_cli_package()
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -81,7 +81,10 @@ def test_create_pod():
 @pytest.mark.skipif("shakedown.dcos.cluster.ee_version() is None")
 @pytest.mark.skipif("common.docker_env_not_set()")
 def test_create_pod_with_private_image():
-    """Deploys a pod with a private Docker image, using Mesos containerizer."""
+    """Deploys a pod with a private Docker image, using Mesos containerizer.
+        This method relies on the global `install_enterprise_cli` fixture to install the
+        enterprise-cli-package.
+    """
 
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']

--- a/tests/system/marathon_pods_tests.py
+++ b/tests/system/marathon_pods_tests.py
@@ -83,9 +83,6 @@ def test_create_pod():
 def test_create_pod_with_private_image():
     """Deploys a pod with a private Docker image, using Mesos containerizer."""
 
-    if not common.is_enterprise_cli_package_installed():
-        common.install_enterprise_cli_package()
-
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']
 

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -154,6 +154,9 @@ def simple_sleep_app(name):
 
 
 def ensure_service_account():
+    """Method creates a MoM-EE service account. It relies on the global `install_enterprise_cli`
+       fixture to install the enterprise-cli-package.
+    """
     if common.has_service_account(MOM_EE_SERVICE_ACCOUNT):
         common.delete_service_account(MOM_EE_SERVICE_ACCOUNT)
     common.create_service_account(MOM_EE_SERVICE_ACCOUNT, PRIVATE_KEY_FILE, PUBLIC_KEY_FILE)
@@ -170,6 +173,9 @@ def ensure_permissions():
 
 
 def ensure_sa_secret(strict=False):
+    """Method creates a secret with MoM-EE service account private key. It relies on the global
+       `install_enterprise_cli` fixture to install the enterprise-cli-package.
+    """
     if common.has_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME):
         common.delete_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME)
     common.create_sa_secret(MOM_EE_SERVICE_ACCOUNT_SECRET_NAME, MOM_EE_SERVICE_ACCOUNT, strict)
@@ -177,6 +183,10 @@ def ensure_sa_secret(strict=False):
 
 
 def ensure_docker_config_secret():
+    """Method creates a secret with the docker credentials that is later used to pull
+       the image from our private docker repository. It relies on the global
+       `install_enterprise_cli` fixture to install the enterprise-cli-package.
+    """
     # Docker username and password should be passed  as environment variables `DOCKER_HUB_USERNAME`
     # and `DOCKER_HUB_PASSWORD` (usually by jenkins)
     assert 'DOCKER_HUB_USERNAME' in os.environ, "Couldn't find docker hub username. $DOCKER_HUB_USERNAME is not set"

--- a/tests/system/test_marathon_on_marathon_ee.py
+++ b/tests/system/test_marathon_on_marathon_ee.py
@@ -16,6 +16,7 @@ from shakedown import http
 from shakedown.clients import marathon
 from urllib.parse import urljoin
 from utils import get_resource
+from fixtures import install_enterprise_cli # NOQA F401
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,6 @@ def mom_ee_endpoint(version, security_mode):
 
 
 def assert_mom_ee(version, security_mode='permissive'):
-    ensure_prerequisites_installed()
     ensure_service_account()
     ensure_permissions()
     ensure_sa_secret(strict=True if security_mode == 'strict' else False)
@@ -151,12 +151,6 @@ def simple_sleep_app(name):
         tasks = shakedown.dcos.service.get_service_task(name, app_id.lstrip("/"))
         logger.info('MoM-EE tasks: {}'.format(tasks))
         return tasks is not None
-
-
-def ensure_prerequisites_installed():
-    if not common.is_enterprise_cli_package_installed():
-        common.install_enterprise_cli_package()
-    assert common.is_enterprise_cli_package_installed()
 
 
 def ensure_service_account():

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -422,9 +422,6 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
 def test_private_repository_mesos_app():
     """Deploys an app with a private Docker image, using Mesos containerizer."""
 
-    if not common.is_enterprise_cli_package_installed():
-        common.install_enterprise_cli_package()
-
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']
 
@@ -797,9 +794,6 @@ def test_pod_file_based_secret(secret_fixture):
 
 @pytest.fixture(scope="function")
 def secret_fixture():
-    if not common.is_enterprise_cli_package_installed():
-        common.install_enterprise_cli_package()
-
     secret_name = '/mysecret'
     secret_value = 'super_secret_password'
     common.create_secret(secret_name, secret_value)

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -420,7 +420,10 @@ def test_marathon_backup_and_check_apps(marathon_service_name):
 @pytest.mark.skipif("ee_version() is None")
 @pytest.mark.skipif("common.docker_env_not_set()")
 def test_private_repository_mesos_app():
-    """Deploys an app with a private Docker image, using Mesos containerizer."""
+    """Deploys an app with a private Docker image, using Mesos containerizer.
+        It relies on the global `install_enterprise_cli` fixture to install the
+        enterprise-cli-package.
+    """
 
     username = os.environ['DOCKER_HUB_USERNAME']
     password = os.environ['DOCKER_HUB_PASSWORD']

--- a/tests/system/test_marathon_root.py
+++ b/tests/system/test_marathon_root.py
@@ -28,7 +28,8 @@ from shakedown.dcos.cluster import dcos_1_9, dcos_version_less_than, ee_version,
 from shakedown.dcos.command import run_command, run_command_on_agent, run_command_on_master
 from shakedown.dcos.marathon import marathon_version_less_than # NOQA F401
 from shakedown.dcos.master import get_all_master_ips, masters, is_multi_master, required_masters # NOQA F401
-from fixtures import sse_events, wait_for_marathon_and_cleanup, user_billy, docker_ipv6_network_fixture, archive_sandboxes # NOQA F401
+from fixtures import sse_events, wait_for_marathon_and_cleanup, user_billy, docker_ipv6_network_fixture, archive_sandboxes, install_enterprise_cli # NOQA F401
+
 
 # the following lines essentially do:
 #     from dcos_service_marathon_tests import test_*


### PR DESCRIPTION
this should resolve current flakiness around the `dcos-enterprise-cli` package installation in our SI tests

Related: #6508 