### PR TITLE
Do not expose use and password when attaching cli.

### DIFF
--- a/tests/shakedown/shakedown/dcos/command.py
+++ b/tests/shakedown/shakedown/dcos/command.py
@@ -14,7 +14,6 @@ from . import master_ip, master_leader_ip, marathon_leader_ip
 from .helpers import validate_key, try_close, get_transport, start_transport
 from ..clients import dcos_url
 from ..errors import DCOSException
-from ..clients.authentication import dcos_username, dcos_password
 
 
 logger = logging.getLogger(__name__)
@@ -211,7 +210,7 @@ def attached_cli():
 
     The CLI setup command should be idempotent. So it is save to call this method multiple times.
     """
-    cmd = 'cluster setup {} --no-check --username={} --password={}'.format(dcos_url(), dcos_username(), dcos_password())
+    cmd = 'cluster setup {} --no-check '.format(dcos_url())
     run_dcos_command(cmd)
     yield
 


### PR DESCRIPTION
Summary:
This fixes the circular dependency that broke system tests on master.

The newest DC/OS CLI pulls the crednetials from environment varaibles `DCOS_USERNAME` and
`DCOS_PASSWORD`. These are set by the Jenkins job. Developers have to call tests with these
variables set.