### PR TITLE
Use ca certificate from DCOS_SSL_VERIFY.

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -12,7 +12,6 @@ import logging
 from datetime import timedelta
 from json.decoder import JSONDecodeError
 from functools import lru_cache
-from fixtures import get_ca_file
 from shakedown.clients import mesos, marathon, authentication, dcos_url_path
 from shakedown.clients.authentication import dcos_acs_token, DCOSAcsAuth
 from shakedown.clients.rpcclient import verify_ssl
@@ -843,13 +842,6 @@ def wait_for_service_endpoint(service_name, timeout_sec=120, path=""):
     if available it returns true,
     on expiration throws an exception
     """
-
-    def verify_ssl():
-        cafile = get_ca_file()
-        if cafile.is_file():
-            return str(cafile)
-        else:
-            return False
 
     def master_service_status_code(url):
         logger.info('Querying %s', url)

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -3,14 +3,12 @@ import common
 import json
 import os.path
 import pytest
-import ssl
 import logging
 
 from datetime import timedelta
-from pathlib import Path
-from shakedown.dcos import cluster
 from shakedown.clients import dcos_url_path
 from shakedown.clients.authentication import dcos_acs_token
+from shakedown.clients.rpcclient import get_ssl_context
 from shakedown.dcos.agent import get_agents, get_private_agents
 from shakedown.dcos.command import run_command_on_agent
 from shakedown.dcos.file import copy_file_from_agent
@@ -51,27 +49,6 @@ def parent_group(request):
     group = '/{}'.format(request.function.__name__).replace('_', '-')
     yield group
     common.clean_up_marathon(parent_group=group)
-
-
-def get_ca_file():
-    return Path(fixtures_dir(), 'dcos-ca.crt')
-
-
-def get_ssl_context():
-    """Looks for the DC/OS certificate in the fixtures folder.
-
-    Returns:
-        None if ca file does not exist.
-        SSLContext with file.
-
-    """
-    cafile = get_ca_file()
-    if cafile.is_file():
-        logger.info(f'Provide certificate {cafile}') # NOQA E999
-        ssl_context = ssl.create_default_context(cafile=cafile)
-        return ssl_context
-    else:
-        return None
 
 
 @pytest.fixture

--- a/tests/system/fixtures/__init__.py
+++ b/tests/system/fixtures/__init__.py
@@ -11,6 +11,7 @@ from shakedown.clients.authentication import dcos_acs_token
 from shakedown.clients.rpcclient import get_ssl_context
 from shakedown.dcos.agent import get_agents, get_private_agents
 from shakedown.dcos.command import run_command_on_agent
+from shakedown.dcos.cluster import ee_version
 from shakedown.dcos.file import copy_file_from_agent
 from shakedown.dcos.marathon import marathon_on_marathon
 from shakedown.dcos.security import add_user, set_user_permission, remove_user, remove_user_permission
@@ -97,7 +98,7 @@ def docker_ipv6_network_fixture():
 def install_enterprise_cli():
     """Install enterprise cli on an DC/OS EE cluster before all tests start.
     """
-    if cluster.ee_version() is not None:
+    if ee_version() is not None:
         common.install_enterprise_cli_package()
 
 


### PR DESCRIPTION
Summary:
Shakedown reads the path to the ca certificate for SSL connections from `DCOS_SSL_VERIFY`. This
changes enables SSL with the given certificate for all connections.

Depends on #6638.

JIRA issues: MARATHON-8423
