### PR TITLE
Fixed a precision bug when sum-ing doubles

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -54,10 +54,10 @@ case class PodDefinition(
   override val diskForPersistentVolumes: Double = persistentVolumes.map(_.persistent.size).sum.toDouble
 
   def aggregateResources(filter: MesosContainer => Boolean = _ => true) = Resources(
-    cpus = executorResources.cpus + containers.withFilter(filter).map(_.resources.cpus).sum,
-    mem = executorResources.mem + containers.withFilter(filter).map(_.resources.mem).sum,
-    disk = executorResources.disk + containers.withFilter(filter).map(_.resources.disk).sum,
-    gpus = containers.withFilter(filter).map(_.resources.gpus).sum
+    cpus = (BigDecimal(executorResources.cpus) + containers.withFilter(filter).map(r => BigDecimal(r.resources.cpus)).sum).doubleValue(),
+    mem = (BigDecimal(executorResources.mem) + containers.withFilter(filter).map(r => BigDecimal(r.resources.mem)).sum).doubleValue(),
+    disk = (BigDecimal(executorResources.disk) + containers.withFilter(filter).map(r => BigDecimal(r.resources.disk)).sum).doubleValue(),
+    gpus = executorResources.gpus + containers.withFilter(filter).map(_.resources.gpus).sum
   )
 
   override def withInstances(instances: Int): RunSpec = copy(instances = instances)

--- a/src/test/scala/mesosphere/marathon/core/pod/PodDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/pod/PodDefinitionTest.scala
@@ -1,0 +1,20 @@
+package mesosphere.marathon
+package core.pod
+
+import mesosphere.UnitTest
+import mesosphere.marathon.raml.Resources
+import mesosphere.marathon.state.PathId
+
+class PodDefinitionTest extends UnitTest {
+  "PodDefinition" should {
+    "compute resources with a decimal point" in {
+      val pod = PodDefinition(PathId("/test"), executorResources = Resources(cpus = 0.1), containers = (1 to 7).map(n => MesosContainer(n.toString, resources = Resources(cpus = 0.1))))
+      pod.resources.cpus should be (0.8)
+    }
+
+    "compute GPU resources with both executor and container resources requested" in {
+      val pod = PodDefinition(PathId("/test"), executorResources = Resources(gpus = 1), containers = (1 to 2).map(n => MesosContainer(n.toString, resources = Resources(gpus = 1))))
+      pod.resources.cpus should be (3)
+    }
+  }
+}


### PR DESCRIPTION
Backport of cebb663 / #6646

We had a precision issue when computing resources needed. In TaskGroupBuilder we correctly use BigDecimal but not in PodDefinition. Additionally, we did not count in executor GPU resources when computing the resource consumption.

JIRA Issues: MARATHON-8493