### PR TITLE
Fix for a secrets validator error when we change env without changing secrets

### DIFF
--- a/src/main/scala/mesosphere/marathon/Normalization.scala
+++ b/src/main/scala/mesosphere/marathon/Normalization.scala
@@ -5,37 +5,12 @@ trait Normalization[T] extends AnyRef {
   def apply(n: Normalization[T]): Normalization[T] = Normalization { t => n.normalized(normalized(t)) }
 }
 
-/**
-  * Normalization which takes context together with a parameter.
-  * @tparam T
-  * @tparam C
-  */
-trait NormalizationWithContext[T, C] extends Normalization[T] {
-  def normalizedWithContext(t: T, context: C): T
-  def applyNormalization(n: Normalization[T]): NormalizationWithContext[T, C] = Normalization.withContext { (t, maybeContext) =>
-
-    maybeContext.map { c =>
-      n.normalized(normalizedWithContext(t, c))
-    }.getOrElse {
-      n.normalized(normalized(t))
-    }
-  }
-}
-
 object Normalization {
 
   implicit class Normalized[T](val a: T) extends AnyVal {
     def normalize(implicit f: Normalization[T]): T = f.normalized(a)
-    def normalizeWithContext[C](c: C)(implicit f: NormalizationWithContext[T, C]): T = f.normalizedWithContext(a, c)
   }
 
   def apply[T](f: (T => T)): Normalization[T] = (t: T) => f(t)
-
-  def withContext[T, C](f: (T, Option[C]) => T): NormalizationWithContext[T, C] = new NormalizationWithContext[T, C] {
-
-    override def normalizedWithContext(t: T, context: C): T = f(t, Some(context))
-
-    override def normalized(t: T): T = f(t, None)
-  }
 
 }

--- a/src/main/scala/mesosphere/marathon/Normalization.scala
+++ b/src/main/scala/mesosphere/marathon/Normalization.scala
@@ -20,13 +20,6 @@ trait NormalizationWithContext[T, C] extends Normalization[T] {
       n.normalized(normalized(t))
     }
   }
-  def apply(n: NormalizationWithContext[T, C]): NormalizationWithContext[T, C] = Normalization.withContext { (t, maybeContext) =>
-    maybeContext.map { c =>
-      n.normalizedWithContext(t, c)
-    }.getOrElse {
-      n.normalized(t)
-    }
-  }
 }
 
 object Normalization {

--- a/src/main/scala/mesosphere/marathon/Normalization.scala
+++ b/src/main/scala/mesosphere/marathon/Normalization.scala
@@ -5,11 +5,44 @@ trait Normalization[T] extends AnyRef {
   def apply(n: Normalization[T]): Normalization[T] = Normalization { t => n.normalized(normalized(t)) }
 }
 
+/**
+  * Normalization which takes context together with a parameter.
+  * @tparam T
+  * @tparam C
+  */
+trait NormalizationWithContext[T, C] extends Normalization[T] {
+  def normalizedWithContext(t: T, context: C): T
+  def applyNormalization(n: Normalization[T]): NormalizationWithContext[T, C] = Normalization.withContext { (t, maybeContext) =>
+
+    maybeContext.map { c =>
+      n.normalized(normalizedWithContext(t, c))
+    }.getOrElse {
+      n.normalized(normalized(t))
+    }
+  }
+  def apply(n: NormalizationWithContext[T, C]): NormalizationWithContext[T, C] = Normalization.withContext { (t, maybeContext) =>
+    maybeContext.map { c =>
+      n.normalizedWithContext(t, c)
+    }.getOrElse {
+      n.normalized(t)
+    }
+  }
+}
+
 object Normalization {
 
   implicit class Normalized[T](val a: T) extends AnyVal {
     def normalize(implicit f: Normalization[T]): T = f.normalized(a)
+    def normalizeWithContext[C](c: C)(implicit f: NormalizationWithContext[T, C]): T = f.normalizedWithContext(a, c)
   }
 
   def apply[T](f: (T => T)): Normalization[T] = (t: T) => f(t)
+
+  def withContext[T, C](f: (T, Option[C]) => T): NormalizationWithContext[T, C] = new NormalizationWithContext[T, C] {
+
+    override def normalizedWithContext(t: T, context: C): T = f(t, Some(context))
+
+    override def normalized(t: T): T = f(t, None)
+  }
+
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -274,72 +274,6 @@ trait AppValidation {
   }
 
   /**
-    * all validation that touches deprecated app-update API fields goes in here
-    */
-  def validateOldAppUpdateAPI: Validator[AppUpdate] = forAll(
-    validator[AppUpdate] { update =>
-      update.container is optional(validOldContainerAPI)
-      update.container.flatMap(_.docker.flatMap(_.portMappings)) is optional(portMappingsIndependentOfNetworks)
-      update.ipAddress is optional(isTrue(
-        "ipAddress/discovery is not allowed for Docker containers") { (ipAddress: IpAddress) =>
-          !(update.container.exists(c => c.`type` == EngineType.Docker) && ipAddress.discovery.nonEmpty)
-        })
-      update.uris is optional(every(api.v2.Validation.uriIsValid) and isTrue(
-        "may not be set in conjunction with fetch") { (uris: Seq[String]) =>
-          !(uris.nonEmpty && update.fetch.fold(false)(_.nonEmpty))
-        })
-    },
-    isTrue("ports must be unique") { update =>
-      val withoutRandom = update.ports.fold(Seq.empty[Int])(_.filterNot(_ == AppDefinition.RandomPortValue))
-      withoutRandom.distinct.size == withoutRandom.size
-    },
-    isTrue("cannot specify both an IP address and port") { update =>
-      val appWithoutPorts = update.ports.fold(true)(_.isEmpty) && update.portDefinitions.fold(true)(_.isEmpty)
-      appWithoutPorts || update.ipAddress.isEmpty
-    },
-    isTrue("cannot specify both ports and port definitions") { update =>
-      val portDefinitionsIsEquivalentToPorts = update.portDefinitions.map(_.map(_.port)) == update.ports
-      portDefinitionsIsEquivalentToPorts || update.ports.isEmpty || update.portDefinitions.isEmpty
-    },
-    isTrue("must not specify both networks and ipAddress") { update =>
-      !(update.ipAddress.nonEmpty && update.networks.fold(false)(_.nonEmpty))
-    },
-    isTrue("must not specify both container.docker.network and networks") { update =>
-      !(update.container.exists(_.docker.exists(_.network.nonEmpty)) && update.networks.nonEmpty)
-    }
-  )
-
-  def validateCanonicalAppUpdateAPI(enabledFeatures: Set[String], defaultNetworkName: () => Option[String], existingSecretDefs: Map[String, SecretDef]): Validator[AppUpdate] = forAll(
-    validator[AppUpdate] { update =>
-      update.id.map(PathId(_)) as "id" is optional(valid)
-      update.dependencies.map(_.map(PathId(_))) as "dependencies" is optional(every(valid))
-      update.env is optional(envValidator(strictNameValidation = false, update.secrets.map(upgradeSecrets => existingSecretDefs ++ upgradeSecrets).getOrElse(existingSecretDefs), enabledFeatures))
-      update.secrets is empty or featureEnabled(enabledFeatures, Features.SECRETS)
-      update.secrets is optional(featureEnabledImplies(enabledFeatures, Features.SECRETS)(secretValidator))
-      update.fetch is optional(every(valid))
-      update.portDefinitions is optional(portDefinitionsValidator)
-      update.container is optional(validContainer(enabledFeatures, update.networks.getOrElse(Nil), update.secrets.getOrElse(Map.empty)))
-      update.acceptedResourceRoles is optional(ResourceRole.validAcceptedResourceRoles("app", update.residency.isDefined) and notEmpty)
-      update.networks is optional(NetworkValidation.defaultNetworkNameValidator(defaultNetworkName))
-    },
-    isTrue("must not be root")(!_.id.fold(false)(PathId(_).isRoot)),
-    isTrue("must not be an empty string")(_.cmd.forall { s => s.length() > 1 }),
-    isTrue("portMappings are not allowed with host-networking") { update =>
-      !(update.networks.exists(_.exists(_.mode == NetworkMode.Host)) && update.container.exists(_.portMappings.exists(_.nonEmpty)))
-    },
-    isTrue("portDefinitions are only allowed with host-networking") { update =>
-      !(update.networks.exists(_.exists(_.mode != NetworkMode.Host)) && update.portDefinitions.exists(_.nonEmpty))
-    },
-    isTrue("The 'version' field may only be combined with the 'id' field.") { update =>
-      def onlyVersionOrIdSet: Boolean = update.productIterator.forall {
-        case x: Some[Any] => x == update.version || x == update.id // linter:ignore UnlikelyEquality
-        case _ => true
-      }
-      update.version.isEmpty || onlyVersionOrIdSet
-    }
-  )
-
-  /**
     * all validation that touches deprecated app API fields goes in here
     */
   val validateOldAppAPI: Validator[App] = forAll(
@@ -387,6 +321,16 @@ trait AppValidation {
     },
     isTrue("portDefinitions are only allowed with host-networking") { app =>
       !(app.networks.exists(_.mode != NetworkMode.Host) && app.portDefinitions.exists(_.nonEmpty))
+    }
+  )
+
+  def validateAppUpdateVersion: Validator[AppUpdate] = forAll(
+    isTrue("The 'version' field may only be combined with the 'id' field.") { update =>
+      def onlyVersionOrIdSet: Boolean = update.productIterator.forall {
+        case x: Some[Any] => x == update.version || x == update.id // linter:ignore UnlikelyEquality
+        case _ => true
+      }
+      update.version.isEmpty || onlyVersionOrIdSet
     }
   )
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -7,7 +7,6 @@ import javax.ws.rs.core.Response
 import akka.Done
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.api._
-import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.api.v2.validation.NetworkValidationMessages
 import mesosphere.marathon.core.appinfo.AppInfo.Embed
 import mesosphere.marathon.core.appinfo._
@@ -58,13 +57,12 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
 
     val normalizationConfig = AppNormalization.Configuration(config.defaultNetworkName.toOption, config.mesosBridgeName())
     implicit lazy val appDefinitionValidator = AppDefinition.validAppDefinition(config.availableFeatures)(PluginManager.None)
-    implicit lazy val validateCanonicalAppUpdateAPI = AppValidation.validateCanonicalAppUpdateAPI(config.availableFeatures, () => config.defaultNetworkName.toOption, Map.empty)
 
     implicit val validateAndNormalizeApp: Normalization[raml.App] =
       AppHelpers.appNormalization(config.availableFeatures, normalizationConfig)(AppNormalization.withCanonizedIds())
 
-    implicit val validateAndNormalizeAppUpdate: Normalization[raml.AppUpdate] =
-      AppHelpers.appUpdateNormalization(config.availableFeatures, normalizationConfig).applyNormalization(AppNormalization.withCanonizedIds())
+    implicit val normalizeAppUpdate: Normalization[raml.AppUpdate] =
+      AppHelpers.appUpdateNormalization(normalizationConfig)(AppNormalization.withCanonizedIds())
 
     def normalize(app: App): App = {
       val migrated = AppNormalization.forDeprecated(normalizationConfig).normalized(app)
@@ -1358,7 +1356,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         app.id, Some(app), appUpdate, partialUpdate = false, allowCreation = true, now = clock.now(), service = service)
 
       And("also works when the update operation uses partial-update semantics, dropping portDefinitions")
-      val partUpdate = appsResource.canonicalAppUpdateFromJson(app.id, body, PartialUpdate)
+      val partUpdate = appsResource.canonicalAppUpdateFromJson(app.id, body, PartialUpdate(app))
       val app2 = AppHelpers.updateOrCreate(
         app.id, Some(app), partUpdate, partialUpdate = true, allowCreation = false, now = clock.now(), service = service)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -613,5 +613,30 @@ class AppDefinitionFormatsTest extends UnitTest
       val validator = AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName)
       validator(ramlApp) should haveViolations("/container/docker" -> "not defined")
     }
+
+    "FromJSON should throw a validation exception if ports and portDefinitions are both specified and not equal" in {
+      // port mappings is currently not supported
+      val app = Json.parse(
+        """{
+          |  "id": "/test",
+          |  "container": {
+          |    "type": "MESOS",
+          |    "docker": {
+          |      "image": "busybox"
+          |    }
+          |  },
+          |  "portDefinitions": [
+          |    {
+          |      "port": 8080
+          |    }
+          |  ],
+          |  "ports": [
+          |    8081
+          |  ]
+          |}""".stripMargin).as[raml.App]
+
+      AppValidation.validateOldAppAPI(app) should haveViolations("/" -> "cannot specify both ports and port definitions")
+
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
@@ -11,20 +11,12 @@ class AppUpdateFormatTest extends UnitTest {
 
   def normalizedAndValidated(appUpdate: AppUpdate): AppUpdate =
     AppHelpers.appUpdateNormalization(
-      Set.empty,
       AppNormalization.Configuration(None, "mesos-bridge-name")).normalized(appUpdate)
 
   def fromJson(json: String): AppUpdate =
     normalizedAndValidated(Json.parse(json).as[AppUpdate])
 
   "AppUpdateFormats" should {
-    // regression test for #1176
-    "should fail if id is /" in {
-      val json = """{"id": "/"}"""
-      a[ValidationFailedException] shouldBe thrownBy {
-        fromJson(json)
-      }
-    }
 
     "FromJSON should not fail when 'cpus' is greater than 0" in {
       val json = """ { "id": "test", "cpus": 0.0001 }"""
@@ -43,13 +35,6 @@ class AppUpdateFormatTest extends UnitTest {
       val json = """ { "id": "test", "acceptedResourceRoles": ["*"] }"""
       val appUpdate = fromJson(json)
       appUpdate.acceptedResourceRoles should equal(Some(Set(ResourceRole.Unreserved)))
-    }
-
-    "FromJSON should fail when 'acceptedResourceRoles' is defined but empty" in {
-      val json = """ { "id": "test", "acceptedResourceRoles": [] }"""
-      a[ValidationFailedException] shouldBe thrownBy {
-        fromJson(json)
-      }
     }
 
     "FromJSON should parse kill selection" in {

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -1,13 +1,13 @@
 package mesosphere.marathon
 package api.v2.json
 
-import com.wix.accord._
+import com.wix.accord.Validator
 import mesosphere.{UnitTest, ValidationTestLike}
 import mesosphere.marathon.api.JsonTestHelper
-import mesosphere.marathon.api.v2.validation.{AppValidation, NetworkValidationMessages}
-import mesosphere.marathon.api.v2.{AppNormalization, AppHelpers}
+import mesosphere.marathon.api.v2.validation.AppValidation
+import mesosphere.marathon.api.v2.{AppHelpers, AppNormalization}
 import mesosphere.marathon.core.readiness.ReadinessCheckTestHelper
-import mesosphere.marathon.raml.{AppCContainer, AppUpdate, Artifact, Container, ContainerPortMapping, DockerContainer, EngineType, Environment, Network, NetworkMode, PortDefinition, PortDefinitions, Raml, SecretDef, UpgradeStrategy}
+import mesosphere.marathon.raml.{AppCContainer, AppUpdate, Artifact, Container, ContainerPortMapping, DockerContainer, EngineType, Environment, Network, NetworkMode, Raml, UpgradeStrategy}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import play.api.libs.json.Json
@@ -16,12 +16,9 @@ import scala.collection.immutable.Seq
 
 class AppUpdateTest extends UnitTest with ValidationTestLike {
 
-  implicit val appUpdateValidator: Validator[AppUpdate] = AppValidation.validateCanonicalAppUpdateAPI(
-    Set("secrets"), () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName, Map.empty)
-
-  val appUpdateRoundTripValidator = roundTripValidator[AppUpdate](Some(appUpdateValidator))
-
   val runSpecId = PathId("/test")
+
+  implicit val appUpdateValidator: Validator[AppUpdate] = AppValidation.validateAppUpdateVersion
 
   /**
     * @return an [[AppUpdate]] that's been normalized to canonical form
@@ -29,45 +26,10 @@ class AppUpdateTest extends UnitTest with ValidationTestLike {
   private[this] def fromJsonString(json: String): AppUpdate = {
     val update: AppUpdate = Json.fromJson[AppUpdate](Json.parse(json)).get
     AppNormalization.forDeprecatedUpdates(AppNormalization.Configuration(None, "bridge-name"))
-      .normalized(validateOrThrow(update)(AppValidation.validateOldAppUpdateAPI))
+      .normalized(update)
   }
 
   "AppUpdate" should {
-    "Validation" in {
-      val update = AppUpdate()
-
-      appUpdateValidator(update.copy(portDefinitions = Some(PortDefinitions(9000, 8080, 9000)))) should haveViolations(
-        "/portDefinitions" -> "Ports must be unique.")
-
-      appUpdateValidator(
-        update.copy(portDefinitions = Some(Seq(
-          PortDefinition(9000, name = Some("foo")),
-          PortDefinition(9001, name = Some("foo"))))
-        )) should haveViolations("/portDefinitions" -> "Port names must be unique.")
-
-      appUpdateValidator(
-        update.copy(portDefinitions = Some(Seq(
-          PortDefinition(9000, name = Some("foo")),
-          PortDefinition(9001, name = Some("bar"))))
-        )) should be(aSuccess)
-
-      appUpdateRoundTripValidator(update.copy(mem = Some(-3.0))) should haveViolations("/mem" -> "error.min")
-      appUpdateRoundTripValidator(update.copy(cpus = Some(-3.0))) should haveViolations("/cpus" -> "error.min")
-      appUpdateRoundTripValidator(update.copy(disk = Some(-3.0))) should haveViolations("/disk" -> "error.min")
-      appUpdateRoundTripValidator(update.copy(instances = Some(-3))) should haveViolations("/instances" -> "error.min")
-      appUpdateValidator(update.copy(networks = Some(Seq(Network(mode = NetworkMode.Container))))) should haveViolations(
-        "/networks" -> NetworkValidationMessages.NetworkNameMustBeSpecified)
-    }
-
-    "Validate secrets" in {
-      val update = AppUpdate()
-
-      appUpdateRoundTripValidator(update.copy(secrets = Some(Map("a" -> SecretDef(""))))) should haveViolations(
-        "/secrets/a/source" -> "error.minLength")
-
-      appUpdateRoundTripValidator(update.copy(secrets = Some(Map("" -> SecretDef("a/b/c"))))) should haveViolations(
-        "/secrets/keys(0)" -> "must not be empty")
-    }
 
     "SerializationRoundtrip for empty definition" in {
       val update0 = AppUpdate(container = Some(Container(EngineType.Mesos)))
@@ -208,53 +170,6 @@ class AppUpdateTest extends UnitTest with ValidationTestLike {
 
       val changed = Raml.fromRaml(Raml.fromRaml((AppUpdate(acceptedResourceRoles = Some(Set("b"))), app))).copy(versionInfo = app.versionInfo)
       assert(changed == app.copy(acceptedResourceRoles = Set("b")))
-    }
-
-    "AppUpdate with a version and other changes are not allowed" in {
-      val vfe = intercept[ValidationFailedException](validateOrThrow(
-        AppUpdate(id = Some("/test"), cmd = Some("sleep 2"), version = Some(Timestamp(2).toOffsetDateTime))))
-      assert(vfe.failure.violations.toString.contains("The 'version' field may only be combined with the 'id' field."))
-    }
-
-    "update may not have both uris and fetch" in {
-      val json =
-        """
-      {
-        "id": "app-with-network-isolation",
-        "uris": ["http://example.com/file1.tar.gz"],
-        "fetch": [{"uri": "http://example.com/file1.tar.gz"}]
-      }
-      """
-
-      val vfe = intercept[ValidationFailedException](validateOrThrow(fromJsonString(json)))
-      assert(vfe.failure.violations.toString.contains("may not be set in conjunction with fetch"))
-    }
-
-    "update may not have both ports and portDefinitions" in {
-      val json =
-        """
-      {
-        "id": "app",
-        "ports": [1],
-        "portDefinitions": [{"port": 2}]
-      }
-      """
-
-      val vfe = intercept[ValidationFailedException](validateOrThrow(fromJsonString(json)))
-      assert(vfe.failure.violations.toString.contains("cannot specify both ports and port definitions"))
-    }
-
-    "update may not have duplicated ports" in {
-      val json =
-        """
-      {
-        "id": "app",
-        "ports": [1, 1]
-      }
-      """
-
-      val vfe = intercept[ValidationFailedException](validateOrThrow(fromJsonString(json)))
-      assert(vfe.failure.violations.toString.contains("ports must be unique"))
     }
 
     "update JSON serialization preserves readiness checks" in {
@@ -538,6 +453,12 @@ class AppUpdateTest extends UnitTest with ValidationTestLike {
       val update = AppUpdate(killSelection = Some(raml.KillSelection.OldestFirst))
       val result = Raml.fromRaml(update -> appDef)
       result.killSelection should be(raml.KillSelection.OldestFirst)
+    }
+
+    "not allow appUpdate with a version and other changes besides id" in {
+      val vfe = intercept[ValidationFailedException](validateOrThrow(
+        AppUpdate(id = Some("/test"), cmd = Some("sleep 2"), version = Some(Timestamp(2).toOffsetDateTime))))
+      assert(vfe.failure.violations.toString.contains("The 'version' field may only be combined with the 'id' field."))
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -17,7 +17,7 @@ import scala.collection.immutable.Seq
 class AppUpdateTest extends UnitTest with ValidationTestLike {
 
   implicit val appUpdateValidator: Validator[AppUpdate] = AppValidation.validateCanonicalAppUpdateAPI(
-    Set("secrets"), () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName)
+    Set("secrets"), () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName, Map.empty)
 
   val appUpdateRoundTripValidator = roundTripValidator[AppUpdate](Some(appUpdateValidator))
 

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -265,6 +265,26 @@ class AppValidationTest extends UnitTest with ValidationTestLike with TableDrive
         "/container/portMappings" -> "Port names must be unique.")
     }
 
+    "port definitions must have unique ports" in {
+      val app = App(id = "/app", cmd = Some("cmd"),
+        container = Option(raml.Container(`type` = EngineType.Mesos)),
+        portDefinitions = Some(PortDefinitions(9000, 8080, 9000))
+      )
+      basicValidator(app) should haveViolations("/portDefinitions" -> "Ports must be unique.")
+    }
+
+    "port definitions must have unique names" in {
+      val app = App(id = "/app", cmd = Some("cmd"),
+        container = Option(raml.Container(`type` = EngineType.Mesos)),
+        portDefinitions = Some(Seq(
+          PortDefinition(9000, name = Some("foo")),
+          PortDefinition(9001, name = Some("foo"))))
+      )
+      basicValidator(app) should haveViolations("/portDefinitions" -> "Port names must be unique.")
+    }
+
+
+
     "missing hostPort is allowed for bridge networking (so we can normalize it)" in {
       // This isn't _actually_ allowed; we expect that normalization will replace the None to a Some(0) before
       // converting to an AppDefinition, in order to support legacy API

--- a/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.Matchers
 import play.api.libs.json.Json
 
 class AppUpdateValidatorTest extends UnitTest with Matchers {
-  implicit val appUpdateValidator = AppValidation.validateCanonicalAppUpdateAPI(Set.empty, () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName)
+  implicit val appUpdateValidator = AppValidation.validateCanonicalAppUpdateAPI(Set.empty, () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName, Map.empty)
   implicit val validAppDefinition = AppDefinition.validAppDefinition(Set.empty)(PluginManager.None)
 
   "validation that considers container types" should {

--- a/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
@@ -4,34 +4,15 @@ package api.validation
 import com.wix.accord.validate
 import mesosphere.UnitTest
 import mesosphere.marathon.api.v2.AppNormalization
-import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.raml.{App, AppCContainer, AppUpdate, ContainerPortMapping, EngineType, Raml}
+import mesosphere.marathon.raml.{App, AppUpdate, Raml}
 import mesosphere.marathon.state.AppDefinition
 import org.scalatest.Matchers
 import play.api.libs.json.Json
 
 class AppUpdateValidatorTest extends UnitTest with Matchers {
-  implicit val appUpdateValidator = AppValidation.validateCanonicalAppUpdateAPI(Set.empty, () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName, Map.empty)
+
   implicit val validAppDefinition = AppDefinition.validAppDefinition(Set.empty)(PluginManager.None)
-
-  "validation that considers container types" should {
-    "test that Docker container is validated" in {
-      val f = new Fixture
-      val update = AppUpdate(
-        id = Some("/test"),
-        container = Some(f.invalidDockerContainer))
-      assert(validate(update).isFailure)
-    }
-
-    "test that AppC container is validated" in {
-      val f = new Fixture
-      val update = AppUpdate(
-        id = Some("/test"),
-        container = Some(f.invalidAppCContainer))
-      assert(validate(update).isFailure)
-    }
-  }
 
   "validation for network type changes" should {
     // regression test for DCOS-10641
@@ -79,55 +60,39 @@ class AppUpdateValidatorTest extends UnitTest with Matchers {
       val appUpdate = AppNormalization.forUpdates(config).normalized(
         AppNormalization.forDeprecatedUpdates(config).normalized(Json.parse(
           """
-          |{
-          |  "id": "/sleepy-moby",
-          |  "cmd": "sleep 1000",
-          |  "instances": 1,
-          |  "cpus": 1,
-          |  "mem": 128,
-          |  "disk": 0,
-          |  "gpus": 0,
-          |  "backoffSeconds": 1,
-          |  "backoffFactor": 1.15,
-          |  "maxLaunchDelaySeconds": 3600,
-          |  "container": {
-          |    "docker": {
-          |      "image": "alpine",
-          |      "forcePullImage": false,
-          |      "privileged": false,
-          |      "network": "USER"
-          |    }
-          |  },
-          |  "upgradeStrategy": {
-          |    "minimumHealthCapacity": 0.5,
-          |    "maximumOverCapacity": 0
-          |  },
-          |  "portDefinitions": [],
-          |  "ipAddress": {
-          |    "networkName": "dcos"
-          |  },
-          |  "requirePorts": false
-          |}
-        """.stripMargin).as[AppUpdate]))
+            |{
+            |  "id": "/sleepy-moby",
+            |  "cmd": "sleep 1000",
+            |  "instances": 1,
+            |  "cpus": 1,
+            |  "mem": 128,
+            |  "disk": 0,
+            |  "gpus": 0,
+            |  "backoffSeconds": 1,
+            |  "backoffFactor": 1.15,
+            |  "maxLaunchDelaySeconds": 3600,
+            |  "container": {
+            |    "docker": {
+            |      "image": "alpine",
+            |      "forcePullImage": false,
+            |      "privileged": false,
+            |      "network": "USER"
+            |    }
+            |  },
+            |  "upgradeStrategy": {
+            |    "minimumHealthCapacity": 0.5,
+            |    "maximumOverCapacity": 0
+            |  },
+            |  "portDefinitions": [],
+            |  "ipAddress": {
+            |    "networkName": "dcos"
+            |  },
+            |  "requirePorts": false
+            |}
+          """.stripMargin).as[AppUpdate]))
 
       assert(validate(Raml.fromRaml(Raml.fromRaml(appUpdate -> appDef))).isSuccess)
     }
-  }
-
-  class Fixture {
-    def invalidDockerContainer: raml.Container = raml.Container(
-      EngineType.Docker,
-      portMappings = Option(Seq(
-        ContainerPortMapping(
-          // Invalid (negative) port numbers
-          containerPort = -1, hostPort = Some(-1), servicePort = -1)
-      ))
-    )
-
-    def invalidAppCContainer: raml.Container = raml.Container(EngineType.Mesos, appc = Some(AppCContainer(
-      image = "anImage",
-      id = Some("invalidID")))
-    )
   }
 
 }


### PR DESCRIPTION
Summary: Secrets validator was only passing if we submit a secret environment variable update with a corresponding secret definition section. This change makes secret validator to preload existing definitions, so now we can update an environmental variable without specifying any secrets definitions as long as they're present in the app definition.

Jira issue: DCOS-41267