### PR TITLE
Remove LaunchEphemeral

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -40,9 +40,6 @@ private[marathon] class InstanceUpdateOpResolver(
           InstanceUpdateEffect.Update(op.instance, oldState = None, Seq.empty)
         }
 
-      case op: LaunchEphemeral =>
-        createInstance(op.instanceId)(updater.launchEphemeral(op, clock.now()))
-
       case op: Provision =>
         updateExistingInstance(op.instanceId) { oldInstance =>
           // TODO(karsten): Create events

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -13,11 +13,6 @@ sealed trait InstanceUpdateOperation {
 }
 
 object InstanceUpdateOperation {
-  /** Launch (aka create) an ephemeral task*/
-  case class LaunchEphemeral(instance: Instance) extends InstanceUpdateOperation {
-    override def instanceId: Instance.Id = instance.instanceId
-  }
-
   /** Revert a task to the given state. Used in case TaskOps are rejected. */
   case class Revert(instance: Instance) extends InstanceUpdateOperation {
     override def instanceId: Instance.Id = instance.instanceId
@@ -37,8 +32,7 @@ object InstanceUpdateOperation {
   }
 
   /**
-    * Creates a new instance. This is similar to [[LaunchEphemeral]] except that a scheduled instance has no information
-    * where it might run.
+    * Creates a new instance. Scheduled instance has no information where it might run.
     *
     * @param instance The new instance.
     */

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -4,7 +4,7 @@ package core.instance.update
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.{Goal, Instance, Reservation}
-import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.{LaunchEphemeral, MesosUpdate, Reserve}
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.{MesosUpdate, Reserve}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.update.TaskUpdateEffect
 import mesosphere.marathon.state.{Timestamp, UnreachableEnabled}
@@ -36,11 +36,6 @@ object InstanceUpdater extends StrictLogging {
       tasksMap = updatedTasks,
       state = Instance.InstanceState(Some(instance.state), updatedTasks, now, instance.unreachableStrategy, goal),
       reservation = updatedReservation)
-  }
-
-  private[marathon] def launchEphemeral(op: LaunchEphemeral, now: Timestamp): InstanceUpdateEffect = {
-    val events = eventsGenerator.events(op.instance, task = None, now, previousCondition = None)
-    InstanceUpdateEffect.Update(op.instance, oldState = None, events)
   }
 
   private[marathon] def reserve(op: Reserve, now: Timestamp): InstanceUpdateEffect = {

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -16,20 +16,6 @@ class InstanceOpFactoryHelper(
 
   private[this] val offerOperationFactory = new OfferOperationFactory(metrics, principalOpt, roleOpt)
 
-  // TODO(karsten): Remove as it is only used in tests.
-  def launchEphemeral(
-    taskInfo: Mesos.TaskInfo,
-    newTask: Task,
-    instance: Instance): InstanceOp.LaunchTask = {
-
-    assume(newTask.taskId.mesosTaskId == taskInfo.getTaskId, "marathon task id and mesos task id must be equal")
-
-    def createOperations = Seq(offerOperationFactory.launch(taskInfo))
-
-    val stateOp = InstanceUpdateOperation.LaunchEphemeral(instance)
-    InstanceOp.LaunchTask(taskInfo, stateOp, oldInstance = None, createOperations)
-  }
-
   def provision(
     taskInfo: Mesos.TaskInfo,
     newTask: Task,

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -65,8 +65,6 @@ trait InstanceTracker extends StrictLogging {
   /** Process an InstanceUpdateOperation and propagate its result. */
   def process(stateOp: InstanceUpdateOperation): Future[InstanceUpdateEffect]
 
-  def launchEphemeral(instance: Instance): Future[Done]
-
   def schedule(instance: Instance): Future[Done]
 
   def schedule(instances: Instance*)(implicit ec: ExecutionContext): Future[Done] = {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -89,12 +89,6 @@ private[tracker] class InstanceTrackerDelegate(
     }
   }
 
-  override def launchEphemeral(instance: Instance): Future[Done] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
-
-    process(InstanceUpdateOperation.LaunchEphemeral(instance)).map(_ => Done)
-  }
-
   override def schedule(instance: Instance): Future[Done] = {
     require(
       instance.isScheduled,

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -1,16 +1,14 @@
 package mesosphere.marathon
 
-import akka.stream.scaladsl.Source
 import java.time.Clock
 
 import akka.Done
+import akka.stream.scaladsl.Source
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.{AkkaUnitTest, WaitTestSupport}
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launcher.InstanceOp.LaunchTask
-import mesosphere.marathon.core.launcher.impl.InstanceOpFactoryHelper
 import mesosphere.marathon.core.launcher.{InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
@@ -19,9 +17,9 @@ import mesosphere.marathon.core.matcher.base.util.OfferMatcherSpec
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.{AkkaUnitTest, WaitTestSupport}
 import org.mockito.Matchers
 
 import scala.concurrent.Future

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -9,6 +9,7 @@ import mesosphere.{AkkaUnitTest, WaitTestSupport}
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
+import mesosphere.marathon.core.launcher.InstanceOp.LaunchTask
 import mesosphere.marathon.core.launcher.impl.InstanceOpFactoryHelper
 import mesosphere.marathon.core.launcher.{InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule
@@ -98,7 +99,6 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     "an offer gets successfully matched against an item in the queue" in fixture { f =>
       import f._
       Given("An app in the queue")
-      val scheduledInstance = Instance.scheduled(app)
       instanceTracker.specInstances(any[PathId])(any) returns Future.successful(Seq.empty)
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduledInstance)
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
@@ -130,15 +130,15 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val task: Task = instance.appTask
 
     val mesosTask = MarathonTestHelper.makeOneCPUTask(task.taskId).build()
-    val launch = new InstanceOpFactoryHelper(DummyMetrics, Some("principal"), Some("role")).
-      launchEphemeral(mesosTask, task, instance)
+    val scheduledInstance = Instance.scheduled(app)
+    val launchTaskInstanceOp = LaunchTask(mesosTask, InstanceUpdateOperation.Provision(scheduledInstance), Some(scheduledInstance), Seq.empty)
     val instanceChange = TaskStatusUpdateTestHelper(
-      operation = InstanceUpdateOperation.LaunchEphemeral(instance),
+      operation = InstanceUpdateOperation.Provision(instance),
       effect = InstanceUpdateEffect.Update(instance = instance, oldState = None, events = Nil)).wrapped
 
     lazy val clock: Clock = Clock.systemUTC()
     val noMatchResult = OfferMatchResult.NoMatch(app, offer, Seq.empty, clock.now())
-    val launchResult = OfferMatchResult.Match(app, offer, launch, clock.now())
+    val launchResult = OfferMatchResult.Match(app, offer, launchTaskInstanceOp, clock.now())
 
     lazy val offerMatcherManager: DummyOfferMatcherManager = new DummyOfferMatcherManager()
     lazy val instanceTracker: InstanceTracker = mock[InstanceTracker]

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.{Health, HealthCheck, MesosCommandHealthCheck}
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.Provision
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder, TestTaskBuilder}
 import mesosphere.marathon.core.leadership.{AlwaysElectedLeadershipModule, LeadershipModule}
 import mesosphere.marathon.core.task.Task
@@ -18,6 +19,7 @@ import org.apache.mesos.{Protos => mesos}
 import org.scalatest.concurrent.Eventually
 
 import scala.collection.immutable.Set
+import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -47,11 +49,11 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
   }
 
   def makeRunningTask(appId: PathId, version: Timestamp)(implicit instanceTracker: InstanceTracker): (Instance.Id, Task.Id) = {
-    val instance = TestInstanceBuilder.newBuilder(appId, version = version).addTaskStaged().getInstance()
+    val instance = Instance.scheduled(AppDefinition(appId, versionInfo = VersionInfo.forNewConfig(version)))
     val (taskId, _) = instance.tasksMap.head
     val taskStatus = TestTaskBuilder.Helper.runningTask(instance.instanceId).status.mesosStatus.get
 
-    instanceTracker.launchEphemeral(instance).futureValue
+    instanceTracker.process(Provision(instance)).futureValue
     instanceTracker.updateStatus(instance, taskStatus, clock.now()).futureValue
 
     (instance.instanceId, taskId)
@@ -87,14 +89,12 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
     "update" in new Fixture {
       val app: AppDefinition = AppDefinition(id = appId, versionInfo = VersionInfo.NoVersion)
 
-      val instance = TestInstanceBuilder.newBuilder(appId).addTaskStaged().getInstance()
-      val instanceId = instance.instanceId
-      val (taskId, _) = instance.tasksMap.head
-      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(instanceId).status.mesosStatus.get
-
       val healthCheck = MesosCommandHealthCheck(gracePeriod = 0.seconds, command = Command("true"))
 
-      instanceTracker.launchEphemeral(instance).futureValue
+      val instance = TestInstanceBuilder.runningInstance(appId, Timestamp.zero, instanceTracker).futureValue
+      val (instanceId, taskId) = (instance.instanceId, instance.tasksMap.head._2)
+      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(instanceId).status.mesosStatus.get
+
       instanceTracker.updateStatus(instance, taskStatus, clock.now()).futureValue
 
       hcManager.add(app, healthCheck, Seq.empty)
@@ -129,9 +129,12 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
       val healthCheck = MesosCommandHealthCheck(gracePeriod = 0.seconds, command = Command("true"))
       hcManager.add(app, healthCheck, Seq.empty)
 
-      val (instanceId1, taskId1) = makeRunningTask(appId, version)
-      val (instanceId2, taskId2) = makeRunningTask(appId, version)
-      val (instanceId3, taskId3) = makeRunningTask(appId, version)
+      val instance1 = TestInstanceBuilder.runningInstance(appId, version, instanceTracker).futureValue
+      val (instanceId1, taskId1) = (instance1.instanceId, instance1.tasksMap.head._2.taskId)
+      val instance2 = TestInstanceBuilder.runningInstance(appId, version, instanceTracker).futureValue
+      val (instanceId2, taskId2) = (instance2.instanceId, instance2.tasksMap.head._2.taskId)
+      val instance3 = TestInstanceBuilder.runningInstance(appId, version, instanceTracker).futureValue
+      val (instanceId3, taskId3) = (instance3.instanceId, instance3.tasksMap.head._2.taskId)
 
       def statuses = hcManager.statuses(appId).futureValue
 
@@ -204,66 +207,69 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
       val versions = List(0L, 1L, 2L).map {
         Timestamp(_)
       }.toArray
-      val instances = List(0, 1, 2).map { i =>
-        TestInstanceBuilder.newBuilder(appId, version = versions(i)).addTaskStaged(version = Some(versions(i))).getInstance()
-      }
+      var instances = new ListBuffer[Instance]()
+      var currentApp: AppDefinition = _
 
-      def startTask(appId: PathId, instance: Instance, version: Timestamp, healthChecks: Set[HealthCheck]): AppDefinition = {
+      def startInstance(appId: PathId, version: Timestamp, healthChecks: Set[HealthCheck]): (Instance, AppDefinition) = {
         val app = AppDefinition(
           id = appId,
           versionInfo = VersionInfo.forNewConfig(version),
           healthChecks = healthChecks
         )
-        instanceTracker.launchEphemeral(instance).futureValue
-        instanceTracker.updateStatus(instance, taskStatus(instance), clock.now()).futureValue
-        app
+        val instance = TestInstanceBuilder.runningInstance(appId, version, instanceTracker).futureValue
+        (instance, app)
       }
 
-      def startTask_i(i: Int): AppDefinition = startTask(appId, instances(i), versions(i), healthChecks(i))
+      def startInstance_i(i: Int): (Instance, AppDefinition) = startInstance(appId, versions(i), healthChecks(i))
 
       def stopTask(instance: Instance) =
         instanceTracker.forceExpunge(instance.instanceId).futureValue
 
       // one other task of another app
       val otherAppId = "other".toRootPath
-      val otherInstance = TestInstanceBuilder.newBuilder(appId).addTaskStaged(version = Some(Timestamp.zero)).getInstance()
       val otherHealthChecks = Set[HealthCheck](MesosCommandHealthCheck(gracePeriod = 0.seconds, command = Command("true")))
-      val otherApp = startTask(otherAppId, otherInstance, Timestamp(42), otherHealthChecks)
+      val (otherInstance, otherApp) = startInstance(otherAppId, Timestamp(42), otherHealthChecks)
 
       hcManager.addAllFor(otherApp, Seq.empty)
       assert(hcManager.list(otherAppId) == otherHealthChecks) // linter:ignore:UnlikelyEquality
 
       // start task 0 without running health check
-      var currentAppVersion = startTask_i(0)
+      val (instance0, app0) = startInstance_i(0)
+      instances += instance0
+      currentApp = app0
       assert(hcManager.list(appId) == Set.empty[HealthCheck])
-      groupManager.appVersion(currentAppVersion.id, currentAppVersion.version.toOffsetDateTime) returns Future.successful(Some(currentAppVersion))
+      groupManager.appVersion(app0.id, app0.version.toOffsetDateTime) returns Future.successful(Some(app0))
 
       // reconcile doesn't do anything b/c task 0 has no health checks
-      hcManager.reconcile(Seq(currentAppVersion))
+      hcManager.reconcile(Seq(app0))
       assert(hcManager.list(appId) == Set.empty[HealthCheck])
 
       // reconcile starts health checks of task 1
       val captured1 = captureEvents.forBlock {
-        currentAppVersion = startTask_i(1)
+        val (instance1, app1) = startInstance_i(1)
+        currentApp = app1
+        instances += instance1
         assert(hcManager.list(appId) == Set.empty[HealthCheck])
-        groupManager.appVersion(currentAppVersion.id, currentAppVersion.version.toOffsetDateTime) returns Future.successful(Some(currentAppVersion))
-        hcManager.reconcile(Seq(currentAppVersion)).futureValue
+        groupManager.appVersion(app1.id, app1.version.toOffsetDateTime) returns Future.successful(Some(app1))
+        hcManager.reconcile(Seq(app1)).futureValue
       }
       assert(captured1.map(_.eventType).count(_ == "add_health_check_event") == 1)
       assert(hcManager.list(appId) == healthChecks(1)) // linter:ignore:UnlikelyEquality
 
       // reconcile leaves health check running
       val captured2 = captureEvents.forBlock {
-        hcManager.reconcile(Seq(currentAppVersion)).futureValue
+        hcManager.reconcile(Seq(currentApp)).futureValue
       }
       assert(captured2.isEmpty)
       assert(hcManager.list(appId) == healthChecks(1)) // linter:ignore:UnlikelyEquality
 
       // reconcile starts health checks of task 2 and leaves those of task 1 running
       val captured3 = captureEvents.forBlock {
-        currentAppVersion = startTask_i(2)
-        groupManager.appVersion(currentAppVersion.id, currentAppVersion.version.toOffsetDateTime) returns Future.successful(Some(currentAppVersion))
-        hcManager.reconcile(Seq(currentAppVersion)).futureValue
+        val (instance2, app2) = startInstance_i(2)
+        currentApp = app2
+        instances += instance2
+        groupManager.appVersion(app2.id, app2.version.toOffsetDateTime) returns Future.successful(Some(app2))
+        hcManager.reconcile(Seq(app2)).futureValue
       }
       assert(captured3.map(_.eventType).count(_ == "add_health_check_event") == 2)
       assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2)) // linter:ignore:UnlikelyEquality
@@ -272,7 +278,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
       val captured4 = captureEvents.forBlock {
         stopTask(instances(1))
         assert(hcManager.list(appId) == healthChecks(1) ++ healthChecks(2)) // linter:ignore:UnlikelyEquality
-        hcManager.reconcile(Seq(currentAppVersion)).futureValue //wrong
+        hcManager.reconcile(Seq(currentApp)).futureValue //wrong
       }
       assert(captured4.map(_.eventType) == Vector("remove_health_check_event"))
       assert(hcManager.list(appId) == healthChecks(2)) // linter:ignore:UnlikelyEquality
@@ -281,7 +287,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
       val captured5 = captureEvents.forBlock {
         stopTask(instances(2))
         assert(hcManager.list(appId) == healthChecks(2)) // linter:ignore:UnlikelyEquality
-        hcManager.reconcile(Seq(currentAppVersion)).futureValue //wrong
+        hcManager.reconcile(Seq(currentApp)).futureValue //wrong
       }
       assert(captured5.map(_.eventType) == Vector.empty)
       assert(hcManager.list(appId) == healthChecks(2)) // linter:ignore:UnlikelyEquality
@@ -294,22 +300,17 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
       val healthCheck = MesosCommandHealthCheck(command = Command("true"))
       val app: AppDefinition = AppDefinition(id = appId, healthChecks = Set(healthCheck))
 
-      // Create a task
-      val instance: Instance = TestInstanceBuilder.newBuilder(appId, version = app.version).addTaskStaged().getInstance()
-      val instanceId = instance.instanceId
-      val (taskId, _) = instance.tasksMap.head
-      instanceTracker.launchEphemeral(instance).futureValue
-
       // Send an unhealthy update
-      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(instanceId).status.mesosStatus.get
+      val instance = TestInstanceBuilder.runningInstance(appId, app.version, instanceTracker).futureValue
+      val taskStatus = TestTaskBuilder.Helper.unhealthyTask(instance.instanceId).status.mesosStatus.get
       instanceTracker.updateStatus(instance, taskStatus, clock.now()).futureValue
 
-      assert(hcManager.status(app.id, instanceId).futureValue.isEmpty)
+      assert(hcManager.status(app.id, instance.instanceId).futureValue.isEmpty)
 
       groupManager.appVersion(app.id, app.version.toOffsetDateTime) returns Future.successful(Some(app))
       // Reconcile health checks
       hcManager.reconcile(Seq(app)).futureValue
-      val health = hcManager.status(app.id, instanceId).futureValue.head
+      val health = hcManager.status(app.id, instance.instanceId).futureValue.head
 
       health.lastFailure.isDefined should be (true) withClue (s"Expecting health lastFailure to be defined, but it was None: $health")
       health.lastSuccess.isEmpty should be (true) withClue (s"Expecting health lastSuccess to be empty, but it was '${health.lastSuccess}': $health")

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.{Health, HealthCheck, MesosCommandHealthCheck}
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.Provision
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder, TestTaskBuilder}
+import mesosphere.marathon.core.instance.{Instance, TestTaskBuilder}
 import mesosphere.marathon.core.leadership.{AlwaysElectedLeadershipModule, LeadershipModule}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -17,7 +17,6 @@ import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerMo
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.{CaptureEvents, MarathonTestHelper, SettableClock}
-import org.apache.mesos
 import org.apache.mesos.Protos.TaskStatus
 import org.apache.mesos.{Protos => mesos}
 import org.scalatest.concurrent.Eventually
@@ -82,7 +81,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
     // update to running
     val taskStatus = TaskStatus.newBuilder
       .setTaskId(taskId.mesosTaskId)
-      .setState(mesos.Protos.TaskState.TASK_RUNNING)
+      .setState(mesos.TaskState.TASK_RUNNING)
       .setHealthy(true)
       .build
     await(instanceTracker.updateStatus(instance, taskStatus, Timestamp.now()))

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -6,13 +6,11 @@ import mesosphere.marathon.core.instance.Instance.{AgentInfo, InstanceState, Leg
 import mesosphere.marathon.core.instance.update.{InstanceUpdateOperation, InstanceUpdater}
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, AgentTestDefaults, NetworkInfoPlaceholder}
-import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.{AppDefinition, PathId, RunSpec, Timestamp, UnreachableEnabled, UnreachableStrategy, VersionInfo}
+import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, AgentTestDefaults}
+import mesosphere.marathon.state.{PathId, RunSpec, Timestamp, UnreachableEnabled, UnreachableStrategy}
 import org.apache.mesos
 
 import scala.collection.immutable.Seq
-import scala.concurrent.Future
 import scala.concurrent.duration._
 
 case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.now()) {
@@ -143,10 +141,6 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
 }
 
 object TestInstanceBuilder {
-
-  import scala.async.Async.{async, await}
-  import org.apache.mesos.Protos.TaskStatus
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   def emptyInstance(now: Timestamp = Timestamp.now(), version: Timestamp = Timestamp.zero,
     instanceId: Instance.Id): Instance = Instance(

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -192,9 +192,9 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       verifyNoMoreInteractions()
     }
 
-    "Processing a Launch for an existing instanceId" in new Fixture {
+    "Processing a Schedule for an existing instanceId" in new Fixture {
       instanceTracker.instance(existingInstance.instanceId) returns Future.successful(Some(existingInstance))
-      val stateChange = updateOpResolver.resolve(InstanceUpdateOperation.LaunchEphemeral(existingInstance)).futureValue
+      val stateChange = updateOpResolver.resolve(InstanceUpdateOperation.Schedule(existingInstance)).futureValue
       When("call taskTracker.task")
       verify(instanceTracker).instance(existingInstance.instanceId)
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -52,8 +52,8 @@ class OfferProcessorImplTest extends UnitTest {
   object f {
     import org.apache.mesos.{Protos => Mesos}
     val metrics = DummyMetrics
-    val launch = new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role"))
-      .launchEphemeral(_: Mesos.TaskInfo, _: Task, _: Instance)
+    val provision = new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role"))
+      .provision(_: Mesos.TaskInfo, _: Task, _: Instance)
     val launchWithNewTask = new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role"))
       .launchOnReservation(_: Mesos.TaskInfo, _: InstanceUpdateOperation.Provision, _: Instance)
   }
@@ -70,12 +70,12 @@ class OfferProcessorImplTest extends UnitTest {
     "match successful, launch tasks successful" in new Fixture {
       Given("an offer")
       val dummySource = new DummySource
-      val tasksWithSource = tasks.map(task => InstanceOpWithSource(dummySource, f.launch(task._1, task._2, task._3)))
+      val tasksWithSource = tasks.map(task => InstanceOpWithSource(dummySource, f.provision(task._1, task._2, task._3)))
 
       And("a cooperative offerMatcher and taskTracker")
       offerMatcher.matchOffer(offer) returns Future.successful(MatchedInstanceOps(offerId, tasksWithSource))
       for (task <- tasks) {
-        val stateOp = InstanceUpdateOperation.LaunchEphemeral(task._3)
+        val stateOp = InstanceUpdateOperation.Provision(task._3)
         instanceTracker.process(stateOp) returns Future.successful(arbitraryInstanceUpdateEffect)
       }
 
@@ -104,7 +104,7 @@ class OfferProcessorImplTest extends UnitTest {
     "match successful, launch tasks unsuccessful" in new Fixture {
       Given("an offer")
       val dummySource = new DummySource
-      val tasksWithSource = tasks.map(task => InstanceOpWithSource(dummySource, f.launch(task._1, task._2, task._3)))
+      val tasksWithSource = tasks.map(task => InstanceOpWithSource(dummySource, f.provision(task._1, task._2, task._3)))
 
       And("a cooperative offerMatcher and taskTracker")
       offerMatcher.matchOffer(offer) returns Future.successful(MatchedInstanceOps(offerId, tasksWithSource))

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
@@ -29,7 +29,7 @@ class TaskLauncherImplTest extends UnitTest {
     val taskInfo = taskInfoBuilder.build()
     val instance = TestInstanceBuilder.newBuilderWithInstanceId(instanceId).addTaskWithBuilder().taskFromTaskInfo(taskInfo).build().getInstance()
     val task: Task = instance.appTask
-    new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role")).launchEphemeral(taskInfo, task, instance)
+    new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role")).provision(taskInfo, task, instance)
   }
   private[this] val appId = PathId("/test")
   private[this] val instanceId = Instance.Id.forRunSpec(appId)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -8,8 +8,9 @@ import mesosphere.AkkaUnitTest
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
-import mesosphere.marathon.core.instance.update.InstanceUpdated
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdateOperation, InstanceUpdated}
 import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.launcher.InstanceOp.LaunchTask
 import mesosphere.marathon.core.launcher.impl.InstanceOpFactoryHelper
 import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
@@ -18,7 +19,7 @@ import mesosphere.marathon.core.matcher.base.util.{ActorOfferMatcher, InstanceOp
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
-import mesosphere.marathon.core.task.state.{NetworkInfoPlaceholder, TaskConditionMapping}
+import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder, TaskConditionMapping}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.metrics.dummy.DummyMetrics
@@ -55,15 +56,14 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
   object f {
     import org.apache.mesos.{Protos => Mesos}
     val app = AppDefinition(id = PathId("/testapp"))
-    val runningMarathonInstance = TestInstanceBuilder.newBuilder(app.id, version = app.version, now = Timestamp.now()).addTaskRunning().getInstance()
-    val provisionedMarathonInstance = TestInstanceBuilder.newBuilder(app.id, version = app.version, now = Timestamp.now()).addTaskProvisioned().getInstance()
-    val marathonTask: Task = runningMarathonInstance.appTask
-    val instanceId = runningMarathonInstance.instanceId
-    val task = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId)).build()
-    val metrics: Metrics = DummyMetrics
-    val opFactory = new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role")).launchEphemeral(
-      _: Mesos.TaskInfo, _: Task, _: Instance)
-    val launch = opFactory(task, marathonTask, runningMarathonInstance)
+    val scheduledInstance = Instance.scheduled(app)
+    val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)
+    val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), NetworkInfoPlaceholder(), app, Timestamp.now(), taskId)
+    val runningInstance = TestInstanceBuilder.newBuilder(app.id, version = app.version, now = Timestamp.now()).addTaskRunning().getInstance()
+    val marathonTask: Task = provisionedInstance.appTask
+    val provisionedInstanceId = provisionedInstance.instanceId
+    val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(provisionedInstanceId, None)).build()
+    val launch = LaunchTask(taskInfo, InstanceUpdateOperation.Provision(scheduledInstance), Some(scheduledInstance), Seq.empty)
     val offer = MarathonTestHelper.makeBasicOffer().build()
     val noMatchResult = OfferMatchResult.NoMatch(app, offer, Seq.empty, Timestamp.now())
     val launchResult = OfferMatchResult.Match(app, offer, launch, Timestamp.now())
@@ -101,8 +101,8 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
   }
 
   "TaskLauncherActor" should {
-    "Initial population of task list from instanceTracker with one task" in new Fixture {
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
+    "show correct count statistics for one running instance in the state" in new Fixture {
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningInstance))
 
       val launcherRef = createLauncherRef()
       launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
@@ -117,17 +117,16 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
     // This test does not apply to the new task launcher. The number of scheduled instances should not be defined in the
     // task launcher but outside.
-    "upgrade an app updates app definition in actor and requeries backoff" ignore new Fixture {
+    "upgrade an app updates app definition in actor and requires backoff" in new Fixture {
       Given("an entry for an app")
       val instances = Seq(
-        f.runningMarathonInstance,
+        f.provisionedInstance,
         Instance.scheduled(f.app, Instance.Id.forRunSpec(f.app.id)),
         Instance.scheduled(f.app, Instance.Id.forRunSpec(f.app.id)),
         Instance.scheduled(f.app, Instance.Id.forRunSpec(f.app.id))
       )
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(instances))
       val launcherRef = createLauncherRef()
-      // TODO(karsten): Schedule 3 instances
       rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(f.app))
       rateLimiterActor.reply(RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now())))
 
@@ -137,7 +136,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
       When("upgrading the app")
       val upgradedApp = f.app.copy(cmd = Some("new command"))
-      launcherRef ! TaskLauncherActor.Sync(upgradedApp) //TaskLauncherActor.AddInstances(upgradedApp, 1)
+      launcherRef ! TaskLauncherActor.Sync(upgradedApp)
 
       Then("the actor requeries the backoff delay")
       rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(upgradedApp))
@@ -148,27 +147,15 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
       And("the actor knows the new app definition")
       assert(launcherRef.underlyingActor.runSpec == upgradedApp)
-
-      And("resets the task to launch according to the new add command")
-      assert(launcherRef.underlyingActor.instancesToLaunch == 1)
-
-      And("removes its offer subscription because of the backoff delay")
-      Mockito.verify(offerMatcherManager).removeSubscription(mockito.Matchers.any())(mockito.Matchers.any())
-
-      // We don't care about these:
-      Mockito.reset(instanceTracker)
-      verifyClean()
     }
 
-    "Upgrading an app updates reregisters the offerMatcher at the manager" in new Fixture {
+    "re-register the offerMatcher when upgrading an app" in new Fixture {
       Given("an entry for an app")
-      val instances = Seq(f.runningMarathonInstance, Instance.scheduled(f.app))
+      val instances = Seq(f.provisionedInstance, Instance.scheduled(f.app))
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(instances))
       val launcherRef = createLauncherRef()
       rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(f.app))
       rateLimiterActor.reply(RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now())))
-
-      launcherRef.underlyingActor.instancesToLaunch shouldBe 1
 
       // We don't care about interactions until this point
       Mockito.reset(offerMatcherManager)
@@ -179,21 +166,15 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       rateLimiterActor.expectMsg(RateLimiterActor.GetDelay(upgradedApp))
       rateLimiterActor.reply(RateLimiter.DelayUpdate(upgradedApp.configRef, Some(clock.now())))
 
-      Then("the actor reregisters itself for at the offerMatcher")
+      Then("the actor re-registers itself for at the offerMatcher")
       val inOrder = Mockito.inOrder(offerMatcherManager)
       inOrder.verify(offerMatcherManager).removeSubscription(mockito.Matchers.any())(mockito.Matchers.any())
       inOrder.verify(offerMatcherManager).addSubscription(mockito.Matchers.any())(mockito.Matchers.any())
-
-      // We don't care about these:
-      Mockito.reset(instanceTracker)
-      verifyClean()
     }
 
-    "Process task launch" in new Fixture {
-
+    "match offer when in progress and offer received" in new Fixture {
       Given("a scheduled and a running instance")
-      val scheduledInstance = Instance.scheduled(f.app)
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance, scheduledInstance))
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningInstance, f.scheduledInstance))
       val offer = MarathonTestHelper.makeBasicOffer().build()
       Mockito.when(instanceOpFactory.matchOfferRequest(m.any())).thenReturn(f.launchResult)
 
@@ -207,12 +188,23 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
       Then("it is matched")
       promise.future.futureValue
+    }
+
+    // task launcher actor for every update just polls the state from instance tracker
+    // this test verifies that this poll happened
+    "update the internal when instance update is received" in new Fixture {
+      Given("a scheduled and a running instance")
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningInstance, f.scheduledInstance))
+      val launcherRef = createLauncherRef()
+      val now = clock.now()
+      launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(now))
 
       When("the launcher receives the update for the provisioned instance")
-      val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)
-      val provisionedInstance = scheduledInstance.provisioned(TestInstanceBuilder.defaultAgentInfo, NetworkInfoPlaceholder(), f.app, clock.now(), taskId)
-      val update = InstanceUpdated(provisionedInstance, Some(scheduledInstance.state), Seq.empty)
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance, provisionedInstance))
+      val taskId = Task.Id.forInstanceId(f.scheduledInstance.instanceId)
+      val provisionedInstance = f.scheduledInstance.provisioned(TestInstanceBuilder.defaultAgentInfo, NetworkInfoPlaceholder(), f.app, clock.now(), taskId)
+      val update = InstanceUpdated(provisionedInstance, Some(f.scheduledInstance.state), Seq.empty)
+      // setting new state in instancetracker here
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningInstance, provisionedInstance))
       launcherRef ! update
 
       Then("there are not instances left to launch")
@@ -221,7 +213,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       launcherRef.underlyingActor.instancesToLaunch shouldBe 0
     }
 
-    "Don't pass the task factory lost tasks when asking for new tasks" in new Fixture {
+    "not use unreachable instance when matching an offer if unreachable but not inactive" in new Fixture {
       import mesosphere.marathon.Protos.Constraint.Operator
 
       val uniqueConstraint = Protos.Constraint.newBuilder
@@ -253,7 +245,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       verifyClean()
     }
 
-    "Restart a replacement task for an unreachable task with default unreachableStrategy instantly" in new Fixture {
+    "use unreachable inactive task when matching an offer" in new Fixture {
       import mesosphere.marathon.Protos.Constraint.Operator
 
       val uniqueConstraint = Protos.Constraint.newBuilder
@@ -285,9 +277,8 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       verifyClean()
     }
 
-    "Process task launch reject" in new Fixture {
-      val scheduledInstance = Instance.scheduled(f.app)
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(scheduledInstance))
+    "process task launch reject" in new Fixture {
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.scheduledInstance))
       val offer = MarathonTestHelper.makeBasicOffer().build()
       Mockito.when(instanceOpFactory.matchOfferRequest(m.any())).thenReturn(f.launchResult)
 
@@ -306,35 +297,11 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       assert(launcherRef.underlyingActor.instancesToLaunch == 1)
     }
 
-    "Process task launch accept" in new Fixture {
-      val scheduledInstance = Instance.scheduled(f.app)
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(scheduledInstance))
-      val offer = MarathonTestHelper.makeBasicOffer().build()
-      Mockito.when(instanceOpFactory.matchOfferRequest(m.any())).thenReturn(f.launchResult)
-
-      val launcherRef = createLauncherRef()
-      launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
-
-      val promise = Promise[MatchedInstanceOps]
-      launcherRef ! ActorOfferMatcher.MatchOffer(offer, promise)
-      val matchedTasks: MatchedInstanceOps = promise.future.futureValue
-      matchedTasks.opsWithSource.foreach(_.accept())
-
-      val runningInstance = f.runningMarathonInstance.copy(instanceId = scheduledInstance.instanceId)
-      val update = InstanceUpdated(runningInstance, Some(runningInstance.state), Seq.empty)
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(runningInstance))
-      launcherRef ! update
-
-      assert(activeCount(launcherRef) == 1)
-      assert(!inProgress(launcherRef))
-      assert(launcherRef.underlyingActor.instancesToLaunch == 0)
-    }
-
-    "Expunged task is removed from counts" in new Fixture {
-      val update = TaskStatusUpdateTestHelper.finished(f.runningMarathonInstance).wrapped
+    "decomissioned task is not counted in as active or to be launched" in new Fixture {
+      val update = TaskStatusUpdateTestHelper.finished(f.provisionedInstance).wrapped
       val updatedInstance = update.instance.copy(state = update.instance.state.copy(goal = Goal.Decommissioned))
 
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.provisionedInstance))
 
       val launcherRef = createLauncherRef()
       launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
@@ -347,72 +314,28 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       assert(activeCount(launcherRef) == 0)
     }
 
-    for (
-      update <- TaskConditionMapping.Gone.toSeq.map(reason => TaskStatusUpdateTestHelper.lost(reason, f.runningMarathonInstance))
-        .union(Seq(
-          TaskStatusUpdateTestHelper.finished(f.runningMarathonInstance),
-          TaskStatusUpdateTestHelper.killed(f.runningMarathonInstance),
-          TaskStatusUpdateTestHelper.error(f.runningMarathonInstance)))
-    ) {
-      s"Terminated task (${update.simpleName} with ${update.reason} is removed" in new Fixture {
-        Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
-
-        val launcherRef = createLauncherRef()
-        launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
-
-        // task status update
-        launcherRef ! update.wrapped
-
-        assert(!inProgress(launcherRef))
-        assert(launcherRef.underlyingActor.instancesToLaunch == 0)
-
-        verifyClean()
-      }
-    }
-
-    for (
-      reason <- TaskConditionMapping.Unreachable
-    ) {
-      s"TemporarilyUnreachable task ($reason) is NOT removed" in new Fixture {
-        val update = TaskStatusUpdateTestHelper.lost(reason, f.runningMarathonInstance, timestamp = clock.now())
-        Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
-
-        val launcherRef = createLauncherRef()
-        launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
-
-        // task status update
-        launcherRef ! update.wrapped
-        assert(!inProgress(launcherRef))
-        assert(activeCount(launcherRef) == 1)
-        assert(launcherRef.underlyingActor.instancesToLaunch == 0)
-
-        verifyClean()
-      }
-    }
-
-    "Updated task is reflected in counts" in new Fixture {
-      val update = TaskStatusUpdateTestHelper.runningHealthy(f.runningMarathonInstance)
-
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
+    s"unreachable task queue statistics return expected values" in new Fixture {
+      val lostInstance = TestInstanceBuilder.newBuilder(f.app.id, version = f.app.version, now = Timestamp.now()).addTaskWithBuilder().taskUnreachable().build().instance
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(lostInstance))
 
       val launcherRef = createLauncherRef()
       launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
 
-      // task status update
-      launcherRef ! update.wrapped
+      launcherRef.underlyingActor.instancesToLaunch shouldBe 0
+      activeCount(launcherRef) shouldBe 1
+      inProgress(launcherRef) shouldBe (false)
 
-      assert(launcherRef.underlyingActor.instancesToLaunch == 0)
-      assert(activeCount(launcherRef) == 1)
+      verifyClean()
     }
 
     for (
-      update <- TaskConditionMapping.Gone.toSeq.map(r => TaskStatusUpdateTestHelper.lost(r, f.runningMarathonInstance))
+      update <- TaskConditionMapping.Gone.toSeq.map(r => TaskStatusUpdateTestHelper.lost(r, f.provisionedInstance))
         .union(Seq(
-          TaskStatusUpdateTestHelper.finished(f.runningMarathonInstance),
-          TaskStatusUpdateTestHelper.killed(f.runningMarathonInstance),
-          TaskStatusUpdateTestHelper.error(f.runningMarathonInstance)))
+          TaskStatusUpdateTestHelper.finished(f.provisionedInstance),
+          TaskStatusUpdateTestHelper.killed(f.provisionedInstance),
+          TaskStatusUpdateTestHelper.error(f.provisionedInstance)))
     ) {
-      s"Revive offers if task with constraints terminates (${update.simpleName} with ${update.reason})" in new Fixture {
+      s"revive offers if task with constraints terminates (${update.simpleName} with ${update.reason})" in new Fixture {
         Given("an actor for an app with constraints and one task")
         val constraint = Protos.Constraint
           .newBuilder()
@@ -420,7 +343,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
           .setOperator(Protos.Constraint.Operator.CLUSTER)
           .build()
         val appWithConstraints = f.app.copy(constraints = Set(constraint))
-        Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
+        Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.provisionedInstance))
 
         val launcherRef = createLauncherRef(appWithConstraints)
         launcherRef ! RateLimiter.DelayUpdate(appWithConstraints.configRef, Some(clock.now()))
@@ -436,37 +359,13 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       }
     }
 
-    for (
-      update <- Seq(
-        TaskStatusUpdateTestHelper.staging(f.runningMarathonInstance),
-        TaskStatusUpdateTestHelper.running(f.provisionedMarathonInstance)
-      )
-    ) {
-      s"DO NOT REMOVE running task (${update.simpleName})" in new Fixture {
-        Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
-
-        val launcherRef = createLauncherRef()
-        launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
-
-        // task status update
-        launcherRef ! update.wrapped
-
-        assert(activeCount(launcherRef) == 1)
-        assert(!inProgress(launcherRef))
-        assert(launcherRef.underlyingActor.instancesToLaunch == 0)
-
-        verifyClean()
-      }
-    }
-
     "reschedule instance on provision timeout" in new Fixture {
       Given("a provisioned instance")
-      val scheduledInstance = Instance.scheduled(f.app)
 
       val scheduledInstanceB = Instance.scheduled(f.app)
       val taskId = Task.Id.forInstanceId(scheduledInstanceB.instanceId)
       val provisionedInstance = scheduledInstanceB.provisioned(TestInstanceBuilder.defaultAgentInfo, NetworkInfoPlaceholder(), f.app, clock.now(), taskId)
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(scheduledInstance, provisionedInstance))
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.scheduledInstance, provisionedInstance))
 
       val launcherRef = createLauncherRef()
       launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
@@ -484,14 +383,14 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
     "not reschedule instance on provision time out for a running instance" in new Fixture {
       Given("a running instance")
-      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningMarathonInstance))
+      Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningInstance))
 
       val launcherRef = createLauncherRef()
       launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(clock.now()))
 
       When("the provision times out")
       val op = mock[InstanceOp]
-      op.instanceId returns f.runningMarathonInstance.instanceId
+      op.instanceId returns f.provisionedInstance.instanceId
       launcherRef ! InstanceOpSourceDelegate.InstanceOpRejected(op, TaskLauncherActor.OfferOperationRejectedTimeoutReason)
 
       Then("the instance is not rescheduled")

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -5,13 +5,11 @@ import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.{TestActorRef, TestProbe}
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.flow.OfferReviver
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
-import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdateOperation, InstanceUpdated}
+import mesosphere.marathon.core.instance.update.{InstanceUpdateOperation, InstanceUpdated}
 import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launcher.InstanceOp.LaunchTask
-import mesosphere.marathon.core.launcher.impl.InstanceOpFactoryHelper
 import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedInstanceOps
@@ -21,10 +19,8 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder, TaskConditionMapping}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.metrics.Metrics
-import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.state._
-import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
 import org.mockito
 import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatest.concurrent.Eventually

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -50,7 +50,6 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       ref.underlyingActor.inFlightInstanceOperations.nonEmpty
 
   object f {
-    import org.apache.mesos.{Protos => Mesos}
     val app = AppDefinition(id = PathId("/testapp"))
     val scheduledInstance = Instance.scheduled(app)
     val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -43,7 +43,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val launch = new InstanceOpFactoryHelper(
       metrics,
       Some("principal"),
-      Some("role")).launchEphemeral(_: Mesos.TaskInfo, _: Task, _: Instance)
+      Some("role")).provision(_: Mesos.TaskInfo, _: Task, _: Instance)
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskStatusComparisonTest.scala
@@ -34,7 +34,6 @@ class TaskStatusComparisonTest extends UnitTest with TableDrivenPropertyChecks {
     )
     // format: ON
 
-
     forAll (conditions) { (condition: Condition, isError, isFailed, isFinished, isKilled, isKilling, isRunning, isStaging, isStarting, isUnreachable, isUnreachableInactive, isGone, isUnknown, isDropped, isActive, isTerminal) =>
       s"it's condition is $condition" should {
 

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -29,7 +29,7 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
     case _ => throw new scala.RuntimeException(s"The wrapped effect does not result in an update or expunge: $effect")
   }
   private[this] def instanceFromOperation: Instance = operation match {
-    case launch: InstanceUpdateOperation.LaunchEphemeral => launch.instance
+    case provision: InstanceUpdateOperation.Provision => provision.instance
     case update: InstanceUpdateOperation.MesosUpdate => update.instance
     case _ => throw new RuntimeException(s"Unable to fetch instance from ${operation.getClass.getSimpleName}")
   }
@@ -49,7 +49,7 @@ object TaskStatusUpdateTestHelper {
   lazy val defaultTimestamp = Timestamp(OffsetDateTime.of(2015, 2, 3, 12, 30, 0, 0, ZoneOffset.UTC))
 
   def taskLaunchFor(instance: Instance) = {
-    val operation = InstanceUpdateOperation.LaunchEphemeral(instance)
+    val operation = InstanceUpdateOperation.Provision(instance)
     val effect = InstanceUpdateEffect.Update(operation.instance, oldState = None, events = Nil)
     TaskStatusUpdateTestHelper(operation, effect)
   }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -28,11 +28,11 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
   }
 
   "InstanceTrackerDelegate" should {
-    "Launch succeeds" in {
+    "Provision succeeds" in {
       val f = new Fixture
       val appId: PathId = PathId("/test")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
-      val stateOp = InstanceUpdateOperation.LaunchEphemeral(instance)
+      val stateOp = InstanceUpdateOperation.Provision(instance)
       val expectedStateChange = InstanceUpdateEffect.Update(instance, None, events = Nil)
 
       When("process is called")
@@ -49,11 +49,11 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       create.futureValue shouldBe a[InstanceUpdateEffect.Update]
     }
 
-    "Launch fails" in {
+    "provisioning fails" in {
       val f = new Fixture
       val appId: PathId = PathId("/test")
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
-      val stateOp = InstanceUpdateOperation.LaunchEphemeral(instance)
+      val stateOp = InstanceUpdateOperation.Provision(instance)
 
       When("process is called")
       val create = f.delegate.process(stateOp)
@@ -70,7 +70,6 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       val createValue = create.failed.futureValue
       createValue.getMessage should include(appId.toString)
       createValue.getMessage should include(instance.instanceId.idString)
-      createValue.getMessage should include("Launch")
       createValue.getCause should be(cause)
     }
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
@@ -35,7 +35,7 @@ class InstanceOpFactoryHelperTest extends UnitTest {
 
       When("We create a launch operation")
       val error = intercept[AssertionError] {
-        f.helper.launchEphemeral(taskInfo, task, instance)
+        f.helper.provision(taskInfo, task, instance)
       }
 
       Then("An exception is thrown")
@@ -51,10 +51,10 @@ class InstanceOpFactoryHelperTest extends UnitTest {
       val taskInfo = MarathonTestHelper.makeOneCPUTask(task.taskId).build()
 
       When("We create a launch operation")
-      val launch = f.helper.launchEphemeral(taskInfo, task, instance)
+      val launch = f.helper.provision(taskInfo, task, instance)
 
       Then("The result is as expected")
-      launch.stateOp shouldEqual InstanceUpdateOperation.LaunchEphemeral(instance)
+      launch.stateOp shouldEqual InstanceUpdateOperation.Provision(instance)
       launch.taskInfo shouldEqual taskInfo
       launch.oldInstance shouldBe empty
       launch.offerOperations should have size 1

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -3,32 +3,25 @@ package tasks
 
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.{Provision, Schedule}
-import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
 import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerModule}
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp, VersionInfo}
 import mesosphere.marathon.state.PathId.StringPathId
+import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
 import mesosphere.marathon.storage.repository.InstanceRepository
 import mesosphere.marathon.stream.EnrichedSink
-import mesosphere.marathon.test.MarathonTestHelper
+import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.TextAttribute
-import org.apache.mesos
 import org.apache.mesos.Protos
 import org.apache.mesos.Protos.{TaskState, TaskStatus}
 import org.mockito.Mockito.spy
 import org.scalatest.matchers.{HavePropertyMatchResult, HavePropertyMatcher}
-
-import scala.async.Async.{async, await}
-import scala.concurrent.Future
 
 class InstanceTrackerImplTest extends AkkaUnitTest {
 

--- a/tools/elk/bin/target
+++ b/tools/elk/bin/target
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-cd $(dirname "$0")/../
-
-amm lib/main.sc "$@"

--- a/tools/elk/bin/target
+++ b/tools/elk/bin/target
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd $(dirname "$0")/../
+
+amm lib/main.sc "$@"


### PR DESCRIPTION
Summary:
This PR does not touch any production code, LaunchEphemeral was only used in tests.
LaunchEphemeral in production code was already replaced by Provision in the previous iterations.

JIRA issues: MARATHON-8221
