### PR TITLE
Decrease backoff delay when application are Running

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueue.scala
@@ -32,6 +32,9 @@ trait LaunchQueue {
   /** Advance the reference time point of the delay for the given RunSpec */
   def advanceDelay(spec: RunSpec): Unit
 
+  /** Decrease delay to the given RunnableSpec because of a running instance */
+  def decreaseDelay(spec: RunSpec): Unit
+
   /** Notify queue about InstanceUpdate */
   def notifyOfInstanceUpdate(update: InstanceChange): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueDelegate.scala
@@ -53,6 +53,9 @@ private[launchqueue] class LaunchQueueDelegate(
   override def resetDelay(spec: RunSpec): Unit = rateLimiterActor ! RateLimiterActor.ResetDelay(spec)
 
   override def advanceDelay(spec: RunSpec): Unit = rateLimiterActor ! RateLimiterActor.AdvanceDelay(spec)
+
+  override def decreaseDelay(spec: RunSpec): Unit = rateLimiterActor ! RateLimiterActor.DecreaseDelay(spec)
+
 }
 
 private[impl] object LaunchQueueDelegate {

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterActor.scala
@@ -78,7 +78,9 @@ private class RateLimiterActor private (rateLimiter: RateLimiter) extends Actor 
       rateLimiter.addDelay(runSpec)
       notify(RateLimiter.DelayUpdate(runSpec.configRef, rateLimiter.getDeadline(runSpec)))
 
-    case DecreaseDelay(_) => // ignore for now
+    case DecreaseDelay(runSpec) =>
+      rateLimiter.decreaseDelay(runSpec)
+      notify(RateLimiter.DelayUpdate(runSpec.configRef, rateLimiter.getDeadline(runSpec)))
 
     case AdvanceDelay(runSpec) =>
       rateLimiter.advanceDelay(runSpec)

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
@@ -36,6 +36,8 @@ class NotifyRateLimiterStepImpl @Inject() (
         notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime, launchQueue.addDelay)
       case condition if advanceWorthy(condition) && update.stateUpdated =>
         notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime, launchQueue.advanceDelay)
+      case condition if reduceWorthy(condition) && update.stateUpdated =>
+        notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime, launchQueue.decreaseDelay)
       case _ =>
         Future.successful(Done)
     }
@@ -61,5 +63,10 @@ private[steps] object NotifyRateLimiterStep {
   // A set of conditions that are worth advancing an existing delay of the corresponding runSpec
   val advanceWorthy: Set[Condition] = Set(
     Condition.Staging, Condition.Starting, Condition.Running, Condition.Provisioned
+  )
+
+  // When one runSpec is Running/Healthy, we should decrease delay
+  val reduceWorthy: Set[Condition] = Set(
+    Condition.Running
   )
 }

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterTest.scala
@@ -1,6 +1,8 @@
 package mesosphere.marathon
 package core.launchqueue.impl
 
+import java.util.concurrent.TimeUnit
+
 import mesosphere.UnitTest
 import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.state.PathId._
@@ -30,6 +32,21 @@ class RateLimiterTest extends UnitTest {
       limiter.addDelay(app)
 
       limiter.getDeadline(app) should be(Some(clock.now() + 20.seconds))
+    }
+
+    "reduceDelay for existing delay" in {
+      val limiter = new RateLimiter(clock)
+      val backoff = 100.seconds
+      val factor = 5L
+      val app = AppDefinition(id = "test".toPath, backoffStrategy = BackoffStrategy(backoff = backoff, factor = factor))
+      limiter.decreaseDelay(app) // linter:ignore:IdenticalStatements
+      // if no delay has been added at first, it should keep the delay as it is
+      limiter.getDeadline(app) should be(clock.now() + backoff)
+      limiter.addDelay(app)
+      limiter.getDeadline(app) should be(clock.now() + (backoff * factor))
+      limiter.decreaseDelay(app)
+      val time = FiniteDuration(((backoff * factor).toNanos * (1 - 1 / factor.toDouble)).toLong, TimeUnit.NANOSECONDS)
+      limiter.getDeadline(app) should be(clock.now() + time)
     }
 
     "cleanUpOverdueDelays" in {


### PR DESCRIPTION
Summary:
Whenever an application succeed to start and was considered
as healthy, Marathon had to wait for the overdue cleanup to
reduce delays.

Now, if application succeed to start and run again, delay will
decrease progressively ( applying the inverse of the backoff factor).

JIRA issues: MARATHON-8450
