### PR TITLE
Drop connection for slow event consumers.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,13 @@
 ### Removed deprecated metrics
 We removed deprecated Kamon based metrics from the code base (see the 1.7.xxx changelog for details on new metrics). This led to removal of deprecated command line arguments e.g. old reporters like `--reporter_graphite`, `--reporter_datadog`, `--reporter_datadog` and `--metrics_averaging_window`.
 
+### Closing connection on slow event consumers
+
+Prior to 1.8 Marathon would drop events from the event stream for slow consumers. Starting with 1.8 Marathon will close
+the connection instead to raise awareness of problematic consumers. A consumer is considered slow when it fails to read
+`event_stream_max_outstanding_messages` events in time, ie Marathon buffered so many events. Consumers can and should
+reconnect when the connection was dropped by Marathon.
+
 ## Changes to 1.7.xxx
 
 ### New metrics names (breaking change)

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventStreamHandleActorTest.scala
@@ -34,7 +34,7 @@ class HttpEventStreamHandleActorTest extends AkkaUnitTest with ImplicitSender {
       verify(handle, times(1)).sendEvent(any[MarathonEvent])
     }
 
-    "If the consumer is slow and maxOutstanding limit is reached, messages get dropped" in new Fixture {
+    "If the consumer is slow and maxOutstanding limit is reached, connection is closed" in new Fixture {
       Given("A handler that will postpone the sending")
       val latch = new CountDownLatch(1)
       handle.sendEvent(any[MarathonEvent]) answers (_ => latch.await())
@@ -48,6 +48,7 @@ class HttpEventStreamHandleActorTest extends AkkaUnitTest with ImplicitSender {
       Then("Only one message is send to the handler")
       latch.countDown()
       filter.awaitDone(1.second)
+      verify(handle).close()
     }
 
     "If the handler throws an EOF exception, the actor stops acting" in new Fixture {


### PR DESCRIPTION
Summary:
We want to close the connection with slow event consumers instead of
dropping events. This follows our "fail loud and proud" pattern and
raises awareness of slow consumers.

JIRA issues: MARATHON-8133