### PR TITLE
Clean up instance update op resolver.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -8,7 +8,6 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation._
-import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.state.Timestamp
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -25,23 +25,23 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
     * violated the future will fail with an [[IllegalStateException]], otherwise the operation
     * will be applied and result in an [[InstanceUpdateEffect]].
     */
-  def resolve(instancesBySpec: InstancesBySpec, op: InstanceUpdateOperation): InstanceUpdateEffect = {
+  def resolve(maybeInstance: Option[Instance], op: InstanceUpdateOperation): InstanceUpdateEffect = {
     op match {
       case op: Schedule =>
         // TODO(karsten): Create events
-        createInstance(instancesBySpec, op.instanceId){
+        createInstance(maybeInstance){
           InstanceUpdateEffect.Update(op.instance, oldState = None, Seq.empty)
         }
 
       case op: Provision =>
-        updateExistingInstance(instancesBySpec, op.instanceId) { oldInstance =>
+        updateExistingInstance(maybeInstance, op.instanceId) { oldInstance =>
           // TODO(karsten): Create events
           InstanceUpdateEffect.Update(op.instance, oldState = Some(oldInstance), Seq.empty)
         }
 
       case RescheduleReserved(instance, runSpecVersion) =>
         // TODO(alena): Create events
-        updateExistingInstance(instancesBySpec, op.instanceId) { i =>
+        updateExistingInstance(maybeInstance, op.instanceId) { i =>
           InstanceUpdateEffect.Update(
             i.copy(
               state = InstanceState(Condition.Scheduled, Timestamp.now(), None, None, Goal.Running),
@@ -51,13 +51,13 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
         }
 
       case op: MesosUpdate =>
-        updateExistingInstance(instancesBySpec, op.instanceId)(updater.mesosUpdate(_, op))
+        updateExistingInstance(maybeInstance, op.instanceId)(updater.mesosUpdate(_, op))
 
       case op: ReservationTimeout =>
-        updateExistingInstance(instancesBySpec, op.instanceId)(updater.reservationTimeout(_, clock.now()))
+        updateExistingInstance(maybeInstance, op.instanceId)(updater.reservationTimeout(_, clock.now()))
 
       case op: GoalChange =>
-        updateExistingInstance(instancesBySpec, op.instanceId)(i => {
+        updateExistingInstance(maybeInstance, op.instanceId)(i => {
           val updatedInstance = i.copy(state = i.state.copy(goal = op.goal))
           val events = InstanceChangedEventsGenerator.events(updatedInstance, task = None, clock.now(), previousCondition = Some(i.state.condition))
 
@@ -66,12 +66,12 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
         })
 
       case op: Reserve =>
-        updateExistingInstance(instancesBySpec, op.instanceId) { _ =>
+        updateExistingInstance(maybeInstance, op.instanceId) { _ =>
           updater.reserve(op, clock.now())
         }
 
       case op: ForceExpunge =>
-        instancesBySpec.instance(op.instanceId) match {
+        maybeInstance match {
           case Some(existingInstance) =>
             updater.forceExpunge(existingInstance, clock.now())
 
@@ -87,12 +87,13 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
   /**
     * Helper method that verifies that an instance already exists. If it does, it will apply the given function and
     * return the resulting effect; otherwise this will result in a. [[InstanceUpdateEffect.Failure]].
-    * @param id ID of the instance that is expected to exist.
+    *
+    * @param maybeInstance The instance for the update if one exists. None otherwise.
     * @param applyOperation the operation that shall be applied to the instance
     * @return The [[InstanceUpdateEffect]] that results from applying the given operation.
     */
-  private[this] def updateExistingInstance(instancesBySpec: InstancesBySpec, id: Instance.Id)(applyOperation: Instance => InstanceUpdateEffect): InstanceUpdateEffect = {
-    instancesBySpec.instance(id) match {
+  private[this] def updateExistingInstance(maybeInstance: Option[Instance], id: Instance.Id)(applyOperation: Instance => InstanceUpdateEffect): InstanceUpdateEffect = {
+    maybeInstance match {
       case Some(existingInstance) =>
         applyOperation(existingInstance)
 
@@ -105,15 +106,16 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
   /**
     * Helper method that verifies that no instance with the given ID exists, and applies the given operation if that is
     * true. If an instance with this ID already exists, this will result in an [[InstanceUpdateEffect.Failure]].
-    * @param id ID of the instance that shall be created.
+    *
+    * @param maybeInstance The instance for the update if one exists. None otherwise.
     * @param applyOperation the operation that will create the instance.
     * @return The [[InstanceUpdateEffect]] that results from applying the given operation.
     */
-  private[this] def createInstance(instancesBySpec: InstancesBySpec, id: Instance.Id)(applyOperation: => InstanceUpdateEffect): InstanceUpdateEffect = {
-    instancesBySpec.instance(id) match {
-      case Some(_) =>
+  private[this] def createInstance(maybeInstance: Option[Instance])(applyOperation: => InstanceUpdateEffect): InstanceUpdateEffect = {
+    maybeInstance match {
+      case Some(instance) =>
         InstanceUpdateEffect.Failure(
-          new IllegalStateException(s"$id of app [${id.runSpecId}] already exists"))
+          new IllegalStateException(s"${instance.instanceId} of app [${instance.runSpecId}] already exists"))
 
       case None =>
         applyOperation

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -221,7 +221,7 @@ private[impl] class LaunchQueueActor(
 
   @SuppressWarnings(Array("all")) // async/await
   private[this] def receiveHandleNormalCommands: Receive = {
-    case add@ Add(spec, count) =>
+    case add @ Add(spec, count) =>
       logger.debug(s"Adding $count instances for the ${spec.configRef}")
       // we cannot process more Add requests for one runSpec in parallel because it leads to race condition.
       // See MARATHON-8320 for details. The queue handling is helping us ensure we add an instance at a time.

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -219,7 +219,8 @@ private[impl] class InstanceTrackerActor(
     if (update.deadline <= clock.now()) {
       InstanceUpdateEffect.Failure(new TimeoutException(s"Timeout: ${update.operation} for app [${update.appId}] and ${update.instanceId}."))
     } else {
-      updateOperationResolver.resolve(instancesBySpec, update.operation)
+      val maybeInstance = instancesBySpec.instance(update.operation.instanceId)
+      updateOperationResolver.resolve(maybeInstance, update.operation)
     }
   }
   /**

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -83,7 +83,7 @@ private[tracker] class InstanceTrackerDelegate(
     * We use a [[akka.stream.scaladsl.SourceQueue]] to serialize all instance updates *per Instance.Id*. This is important
     * since the way [[InstanceTrackerActor]] is applying/persisting those update to existing Instance state, having two
     * such update operation in parallel will result in later operation overriding the former one.
-    *
+    * 
     * For this we group all [[InstanceUpdateOperation]]s in substreams hashed by [[Instance.Id.idString]] hash.
     * Number of parallel updates for *different Instance.Ids* is controlled via [[InstanceTrackerConfig.internalInstanceTrackerNumParallelUpdates]]
     * parameter.
@@ -97,16 +97,14 @@ private[tracker] class InstanceTrackerDelegate(
         val effectF = (instanceTrackerRef ? update)
           .mapTo[InstanceUpdateEffect]
           .transform {
-            case s @ Success(_) =>
-              logger.info(s"Completed processing instance update ${update.operation.shortString}"); s
-            case f @ Failure(e: AskTimeoutException) =>
-              logger.error(s"Timed out waiting for response for update $update", e); f
-            case f @ Failure(t: Throwable) => logger.error(s"An unexpected error occurred during update processing of: $update", t); f
+            case s@Success(_) => logger.info(s"Completed processing instance update ${update.operation.shortString}"); s
+            case f@Failure(e: AskTimeoutException) => logger.error(s"Timed out waiting for response for update $update", e); f
+            case f@Failure(t: Throwable) => logger.error(s"An unexpected error occurred during update processing of: $update", t); f
           }
         promise.completeWith(effectF)
 
-        effectF // We already completed the sender promise with the future result (failed or not)
-          .transform(_ => Success(Done)) // so here we map the future to a successful one to preserve the stream
+        effectF                             // We already completed the sender promise with the future result (failed or not)
+          .transform(_ => Success(Done))    // so here we map the future to a successful one to preserve the stream
     }
     .mergeSubstreams
     .toMat(Sink.ignore)(Keep.left)

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -10,7 +10,6 @@ import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.Reschedu
 import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.task.bus.{MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper}
 import mesosphere.marathon.core.task.state.TaskConditionMapping
-import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.core.task.{Task, TaskCondition}
 import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp}
 import mesosphere.marathon.test.SettableClock
@@ -28,8 +27,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
 
   "InstanceUpdateOpResolver" should {
     "ForceExpunge for an unknown task" in new Fixture {
-      val instancesBySpec = InstancesBySpec.empty
-      val stateChange = updateOpResolver.resolve(instancesBySpec, InstanceUpdateOperation.ForceExpunge(notExistingInstanceId))
+      val stateChange = updateOpResolver.resolve(None, InstanceUpdateOperation.ForceExpunge(notExistingInstanceId))
 
       Then("result in a Noop")
       stateChange shouldBe a[InstanceUpdateEffect.Noop]
@@ -38,10 +36,10 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     // this case is actually a little constructed, as the task will be loaded before and will fail if it doesn't exist
     "MesosUpdate for an unknown task" in new Fixture {
       Given("The instance is unknown")
-      val instancesBySpec = InstancesBySpec.empty
+      val instance = Option.empty[Instance]
 
       When("call taskTracker.task")
-      val stateChange = updateOpResolver.resolve(instancesBySpec, InstanceUpdateOperation.MesosUpdate(
+      val stateChange = updateOpResolver.resolve(instance, InstanceUpdateOperation.MesosUpdate(
         instance = existingInstance,
         mesosStatus = MesosTaskStatusTestHelper.running(),
         now = Timestamp(0)))
@@ -54,11 +52,11 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       reason <- TaskConditionMapping.Unreachable
     ) {
       s"TASK_LOST update with $reason indicating a TemporarilyUnreachable" in new Fixture {
-        val instancesBySpec = InstancesBySpec.forInstances(existingInstance)
+        val instance = Some(existingInstance)
 
         When("we resolve the update")
         val operation = TaskStatusUpdateTestHelper.lost(reason, existingInstance).operation
-        val effect = updateOpResolver.resolve(instancesBySpec, operation)
+        val effect = updateOpResolver.resolve(instance, operation)
 
         Then("result in an Update with the correct status")
         inside(effect) {
@@ -72,12 +70,12 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       reason <- TaskConditionMapping.Gone
     ) {
       s"TASK_LOST update with $reason indicating a task won't come" in new Fixture {
-        val instancesBySpec = InstancesBySpec.forInstances(existingInstance)
+        val instance = Some(existingInstance)
 
         When("we resolve the update")
         val stateOp: InstanceUpdateOperation.MesosUpdate = TaskStatusUpdateTestHelper.lost(
           reason, existingInstance).operation.asInstanceOf[InstanceUpdateOperation.MesosUpdate]
-        val stateChange = updateOpResolver.resolve(instancesBySpec, stateOp)
+        val stateChange = updateOpResolver.resolve(instance, stateOp)
 
         Then("result in an Expunge with the correct status")
         stateChange shouldBe a[InstanceUpdateEffect.Expunge]
@@ -109,13 +107,13 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       reason <- TaskConditionMapping.Unreachable
     ) {
       s"a TASK_LOST update with an unreachable $reason but a message saying that the task is unknown to the slave " in new Fixture {
-        val instancesBySpec = InstancesBySpec.forInstances(existingInstance)
+        val instance = Some(existingInstance)
 
         When("we resolve the update")
         val message = "Reconciliation: Task is unknown to the slave"
         val stateOp: InstanceUpdateOperation.MesosUpdate = TaskStatusUpdateTestHelper.lost(
           reason, existingInstance, Some(message)).operation.asInstanceOf[InstanceUpdateOperation.MesosUpdate]
-        val stateChange = updateOpResolver.resolve(instancesBySpec, stateOp)
+        val stateChange = updateOpResolver.resolve(instance, stateOp)
 
         Then("result in an expunge")
         stateChange shouldBe a[InstanceUpdateEffect.Expunge]
@@ -124,7 +122,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
 
     "a subsequent TASK_LOST update with another reason" in new Fixture {
       val lostInstance = TestInstanceBuilder.newBuilder(appId).addTaskLost().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(lostInstance)
+      val instance = Some(lostInstance)
       val reason = mesos.Protos.TaskStatus.Reason.REASON_SLAVE_DISCONNECTED
       val taskId = Task.Id.forInstanceId(lostInstance.instanceId)
       val mesosStatus = MesosTaskStatusTestHelper.mesosStatus(
@@ -136,58 +134,54 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       When("we resolve the update")
       val marathonTaskCondition = TaskCondition(mesosStatus)
       val stateOp = InstanceUpdateOperation.MesosUpdate(lostInstance, marathonTaskCondition, mesosStatus, clock.now())
-      val stateChange = updateOpResolver.resolve(instancesBySpec, stateOp)
+      val stateChange = updateOpResolver.resolve(instance, stateOp)
 
       Then("result in an noop and not update the timestamp")
       stateChange shouldBe a[InstanceUpdateEffect.Noop]
     }
 
     "a subsequent TASK_LOST update with a message saying that the task is unknown to the slave" in new Fixture {
-      val instancesBySpec = InstancesBySpec.forInstances(unreachableInstance)
+      val instance = Some(unreachableInstance)
 
       When("we resolve the update")
       val reason = mesos.Protos.TaskStatus.Reason.REASON_RECONCILIATION
       val maybeMessage = Some("Reconciliation: Task is unknown to the slave")
       val stateOp: InstanceUpdateOperation.MesosUpdate = TaskStatusUpdateTestHelper.lost(
         reason, unreachableInstance, maybeMessage).operation.asInstanceOf[InstanceUpdateOperation.MesosUpdate]
-      val stateChange = updateOpResolver.resolve(instancesBySpec, stateOp)
+      val stateChange = updateOpResolver.resolve(instance, stateOp)
 
       Then("result in an expunge")
       stateChange shouldBe a[InstanceUpdateEffect.Expunge]
     }
 
     "ReservationTimeout for an unknown instance" in new Fixture {
-      val instancesBySpec = InstancesBySpec.empty
 
       When("we resolve the update")
-      val stateChange = updateOpResolver.resolve(instancesBySpec, InstanceUpdateOperation.ReservationTimeout(notExistingInstanceId))
+      val stateChange = updateOpResolver.resolve(None, InstanceUpdateOperation.ReservationTimeout(notExistingInstanceId))
 
       Then("result in a Failure")
       stateChange shouldBe a[InstanceUpdateEffect.Failure]
     }
 
     "Processing a Schedule for an existing instanceId" in new Fixture {
-      val instancesBySpec = InstancesBySpec.forInstances(existingInstance)
 
       When("call taskTracker.task")
-      val stateChange = updateOpResolver.resolve(instancesBySpec, InstanceUpdateOperation.Schedule(existingInstance))
+      val stateChange = updateOpResolver.resolve(Some(existingInstance), InstanceUpdateOperation.Schedule(existingInstance))
 
       Then("result in a Failure")
       stateChange shouldBe a[InstanceUpdateEffect.Failure]
     }
 
     "Processing a Reserve for an existing instanceId" in new Fixture {
-      val instancesBySpec = InstancesBySpec.forInstances(reservedInstance)
 
-      val stateChange = updateOpResolver.resolve(instancesBySpec, InstanceUpdateOperation.Reserve(reservedInstance))
+      val stateChange = updateOpResolver.resolve(Some(reservedInstance), InstanceUpdateOperation.Reserve(reservedInstance))
 
       Then("result in an Update")
       stateChange shouldBe an[InstanceUpdateEffect.Update]
     }
 
     "Revert" in new Fixture {
-      val instancesBySpec = InstancesBySpec.forInstances(reservedInstance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, InstanceUpdateOperation.Revert(reservedInstance))
+      val stateChange = updateOpResolver.resolve(Some(reservedInstance), InstanceUpdateOperation.Revert(reservedInstance))
 
       Then("result in an Update")
       stateChange shouldEqual InstanceUpdateEffect.Update(reservedInstance, None, events = Nil)
@@ -198,9 +192,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_FAILED update for running task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskRunning().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.failed(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
       stateChange shouldBe a[InstanceUpdateEffect.Expunge]
@@ -209,9 +202,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_GONE update for a running task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskRunning().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.gone(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
       stateChange shouldBe a[InstanceUpdateEffect.Expunge]
@@ -220,9 +212,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_DROPPED update for a staging task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskStaged().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.dropped(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
       stateChange shouldBe a[InstanceUpdateEffect.Expunge]
@@ -231,9 +222,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_DROPPED update for a starting task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskStarting().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.dropped(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
       stateChange shouldBe a[InstanceUpdateEffect.Expunge]
@@ -242,9 +232,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_UNREACHABLE update for a staging task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskStaged().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.unreachable(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an update")
       inside(stateChange) {
@@ -256,9 +245,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_UNREACHABLE update for a starting task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskStarting().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.unreachable(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an update")
       stateChange shouldBe a[InstanceUpdateEffect.Update]
@@ -271,9 +259,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_UNREACHABLE update for a running task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskRunning().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.unreachable(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an update")
       inside(stateChange) {
@@ -285,9 +272,8 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "Processing a TASK_UNKNOWN update for an unreachable task" in new Fixture {
       val builder = TestInstanceBuilder.newBuilder(appId)
       val instance = builder.addTaskUnreachable().getInstance()
-      val instancesBySpec = InstancesBySpec.forInstances(instance)
       val update = TaskStatusUpdateTestHelper.unknown(instance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, update.operation)
+      val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
       stateChange shouldBe a[InstanceUpdateEffect.Expunge]
@@ -295,8 +281,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
 
     "move instance to scheduled state when previously reserved" in new Fixture {
       val version = Timestamp(clock.instant())
-      val instancesBySpec = InstancesBySpec.forInstances(reservedInstance)
-      val stateChange = updateOpResolver.resolve(instancesBySpec, RescheduleReserved(reservedInstance, version))
+      val stateChange = updateOpResolver.resolve(Some(reservedInstance), RescheduleReserved(reservedInstance, version))
 
       inside(stateChange) {
         case update: Update =>


### PR DESCRIPTION
Summary:
This simplifies the logic a little bit. Instead of receiving
`instancesBySpec` the resolve method just takes an optional instance
that should be updated or created.