### PR TITLE
Define task id type in prefix of id string.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -406,9 +406,9 @@ object Task {
 
     /**
       * Create a taskId for a pod instance's task. This will create a taskId designating the instance and each
-      * task container's name. It may be used for reservations for persitent pods as well.
+      * task container's name. It may be used for reservations for persistent pods as well.
       *
-      * @param instanceId the ID of the instance that this task is contained in
+      * @param instanceId the ID of the instance that contains this task.
       * @param container the name of the task as per the pod container config.
       */
     def forInstanceId(instanceId: Instance.Id, container: Option[MesosContainer] = None): Id = EphemeralOrReservedTaskId(instanceId, container.map(_.name))

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -324,19 +324,19 @@ object Task {
     *
     * @param instanceId Identifies the instance the task belongs to.
     * @param containerName If set identifies the container in the pod. Defaults to [[Task.Id.Names.anonymousContainer]].
-    * @param attempt Counts how often a task has been launched on a specific reservation.
+    * @param incarnation Counts how often a task has been launched on a specific reservation.
     */
-  case class TaskIdWithIncarnation(val instanceId: Instance.Id, val containerName: Option[String], attempt: Long) extends Id {
+  case class TaskIdWithIncarnation(val instanceId: Instance.Id, val containerName: Option[String], incarnation: Long) extends Id {
 
     // A stringifed version of the id.
-    override val idString = TaskIdWithIncarnation.typePrefix + "." + instanceId.idString + "." + containerName.getOrElse(Id.Names.anonymousContainer) + "." + attempt
+    override val idString = TaskIdWithIncarnation.typePrefix + "." + instanceId.idString + "." + containerName.getOrElse(Id.Names.anonymousContainer) + "." + incarnation
 
     // Quick access to the underlying run spec identifier of the task.
     override lazy val runSpecId: PathId = instanceId.runSpecId
 
     override lazy val reservationId: String = instanceId.idString
 
-    def increaseAttempt(): TaskIdWithIncarnation = this.copy(attempt = attempt + 1L)
+    def increaseAttempt(): TaskIdWithIncarnation = this.copy(incarnation = incarnation + 1L)
   }
   object TaskIdWithIncarnation {
     val typePrefix = "$tiwi$"
@@ -364,17 +364,18 @@ object Task {
       *   * ResidentTaskIdRegex
       *   * TaskIdWithInstanceIdRegex
       *   * ResidentTaskIdWithInstanceIdRegex
+      *   * TaskIdWithIncarnation
       *
       * @param idString The raw id that should be parsed.
       * @return Task.Id
       */
     def apply(idString: String): Task.Id = {
       idString match {
-        case TaskIdWithIncarnation.regex(safeRunSpecId, prefix, uuid, container, attempt) =>
+        case TaskIdWithIncarnation.regex(safeRunSpecId, prefix, uuid, container, incarnation) =>
           val runSpec = PathId.fromSafePath(safeRunSpecId)
           val instanceId = Instance.Id(runSpec, Instance.Prefix.fromString(prefix), UUID.fromString(uuid))
           val containerName: Option[String] = if (container == Names.anonymousContainer) None else Some(container)
-          TaskIdWithIncarnation(instanceId, containerName, attempt.toLong)
+          TaskIdWithIncarnation(instanceId, containerName, incarnation.toLong)
         case ResidentTaskIdWithInstanceIdRegex(safeRunSpecId, prefix, uuid, container, attempt) =>
           val runSpec = PathId.fromSafePath(safeRunSpecId)
           val instanceId = Instance.Id(runSpec, Instance.Prefix.fromString(prefix), UUID.fromString(uuid))

--- a/src/test/scala/mesosphere/marathon/core/task/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskIdTest.scala
@@ -1,0 +1,28 @@
+package mesosphere.marathon
+package core.task
+
+import mesosphere.UnitTest
+import mesosphere.marathon.core.task.Task.TaskIdWithIncarnation
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class TaskIdTest extends UnitTest with TableDrivenPropertyChecks {
+
+  "TaskId.apply" should {
+
+    val ids = Table(
+      ("id string"),
+      ("$tiwi$.myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.$anon.1"),
+      ("$tiwi$.myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.$anon.3"),
+      ("$tiwi$.myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails.2"),
+      ("$tiwi$.myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails.42")
+    )
+    forAll(ids) { id =>
+      s"parse id $id to expected type" in {
+        val taskId = Task.Id(id)
+
+        taskId shouldBe a[TaskIdWithIncarnation]
+        taskId.idString should be(id)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
This introduces the `TaskIdWithIncarnation` id type. It is similar to
`ResidentTaskId` except that it prefixes the Mesos task id string with
`$tiwi$`. This makes parsing ids easier in the future, eg if we add the
version to the task id string with could introduce `TaskIdWithVersion`
with the type prefix `$tiv$`.

JIRA issues: MARATHON-8501