### PR TITLE
Using one curator instance for leader election and data transfer

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
@@ -31,9 +31,9 @@ object ZkPersistenceStoreBenchmark {
     override def availableFeatures: Set[String] = Set.empty
   }
   Conf.verify()
-  val curatorFramework: Option[RichCuratorFramework] = StorageConfig.curatorFramework(Conf, JvmExitsCrashStrategy, LifecycleState.WatchingJVM)
+  val curatorFramework: RichCuratorFramework = StorageConfig.curatorFramework(Conf, JvmExitsCrashStrategy, LifecycleState.WatchingJVM)
   val lifecycleState = LifecycleState.WatchingJVM
-  val curator = CuratorZk(Conf, curatorFramework.get)
+  val curator = CuratorZk(Conf, curatorFramework)
   val metrics = DummyMetrics
   val zkStore = curator.leafStore(metrics)
 

--- a/src/main/scala/mesosphere/marathon/MetricsModule.scala
+++ b/src/main/scala/mesosphere/marathon/MetricsModule.scala
@@ -3,7 +3,6 @@ package mesosphere.marathon
 import akka.Done
 import akka.actor.ActorRefFactory
 import com.codahale.metrics.MetricRegistry
-import com.typesafe.config.Config
 import mesosphere.marathon.metrics.current.DropwizardMetricsModule
 import mesosphere.marathon.metrics.{Metrics, MetricsConf}
 import org.eclipse.jetty.server.Handler
@@ -21,7 +20,7 @@ trait MetricsModule {
 }
 
 object MetricsModule {
-  def apply(cliConf: MetricsConf with FeaturesConf, config: Config): MetricsModule = {
+  def apply(cliConf: MetricsConf with FeaturesConf): MetricsModule = {
     new DropwizardMetricsModule(cliConf)
   }
 }

--- a/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
+++ b/src/main/scala/mesosphere/marathon/ZookeeperConf.scala
@@ -79,6 +79,7 @@ trait ZookeeperConf extends ScallopConf {
 
   def zooKeeperStateUrl: ZkUrl = zooKeeperUrl() / "state"
   def zooKeeperLeaderUrl: ZkUrl = zooKeeperUrl() / "leader"
+  def zooKeeperLeaderCuratorUrl: ZkUrl = zooKeeperUrl() / "leader-curator"
 
   lazy val zkDefaultCreationACL = if (zooKeeperUrl().credentials.nonEmpty)
     ZooDefs.Ids.CREATOR_ALL_ACL

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -88,7 +88,7 @@ class CoreModuleImpl @Inject() (
     eventStream,
     hostPort,
     crashStrategy,
-    richCuratorFramework.client,
+    richCuratorFramework.client.usingNamespace(null), // using non-namespaced client for leader-election
     ExecutionContext.fromExecutor(electionExecutor)
   )
 

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -75,7 +75,11 @@ class CoreModuleImpl @Inject() (
 
   override lazy val config = ConfigFactory.load()
 
-  override lazy val metricsModule = MetricsModule(marathonConf, config)
+  // Initialize Apache Curator Framework (wrapped in [[RichCuratorFramework]] and connect/sync with the storage
+  // for an underlying Zookeeper storage.
+  lazy val richCuratorFramework: RichCuratorFramework = StorageConfig.curatorFramework(marathonConf, crashStrategy, lifecycleState)
+
+  override lazy val metricsModule = MetricsModule(marathonConf)
   override lazy val leadershipModule = LeadershipModule(actorsModule.actorRefFactory)
   override lazy val electionModule = new ElectionModule(
     metricsModule.metrics,
@@ -84,6 +88,7 @@ class CoreModuleImpl @Inject() (
     eventStream,
     hostPort,
     crashStrategy,
+    richCuratorFramework.client,
     ExecutionContext.fromExecutor(electionExecutor)
   )
 
@@ -94,14 +99,10 @@ class CoreModuleImpl @Inject() (
       storageModule.instanceRepository, instanceUpdateSteps)(actorsModule.materializer)
   override lazy val taskJobsModule = new TaskJobsModule(marathonConf, leadershipModule, clock)
 
-  // Initialize Apache Curator Framework (wrapped in [[RichCuratorFramework]] and connect/sync with the storage
-  // for an underlying Zookeeper storage. None is returned for [[InMem]] storage) since it's not needed.
-  lazy val curatorFramework: Option[RichCuratorFramework] = StorageConfig.curatorFramework(marathonConf, crashStrategy, lifecycleState)
-
   override lazy val storageModule = StorageModule(
     metricsModule.metrics,
     marathonConf,
-    curatorFramework)(
+    richCuratorFramework)(
       actorsModule.materializer,
       storageExecutionContext,
       actorSystem.scheduler,

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -29,3 +29,12 @@ case object JvmExitsCrashStrategy extends CrashStrategy {
     Runtime.getRuntime.asyncExit(reason.code)(ExecutionContext.Implicits.global)
   }
 }
+
+/**
+  * For testing purposes only: This crash strategy will *NOT* crash but throw an exception
+  */
+case object ThrowExceptionAndDontCrashStrategy extends CrashStrategy {
+  override def crash(reason: CrashStrategy.Reason): Future[Done] = {
+    throw new Exception(s"TESTING ONLY: Failed for reason ${reason}")
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -29,12 +29,3 @@ case object JvmExitsCrashStrategy extends CrashStrategy {
     Runtime.getRuntime.asyncExit(reason.code)(ExecutionContext.Implicits.global)
   }
 }
-
-/**
-  * For testing purposes only: This crash strategy will *NOT* crash but throw an exception
-  */
-case object ThrowExceptionAndDontCrashStrategy extends CrashStrategy {
-  override def crash(reason: CrashStrategy.Reason): Future[Done] = {
-    throw new Exception(s"TESTING ONLY: Failed for reason ${reason}")
-  }
-}

--- a/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/backup/Backup.scala
@@ -39,11 +39,11 @@ abstract class BackupRestoreAction extends StrictLogging {
     implicit val scheduler = system.scheduler
     import scala.concurrent.ExecutionContext.Implicits.global
 
-    val metricsModule = MetricsModule(conf, system.settings.config)
+    val metricsModule = MetricsModule(conf)
     metricsModule.start(system)
 
     try {
-      val curatorFramework: Option[RichCuratorFramework] = StorageConfig.curatorFramework(conf, JvmExitsCrashStrategy, LifecycleState.WatchingJVM)
+      val curatorFramework: RichCuratorFramework = StorageConfig.curatorFramework(conf, JvmExitsCrashStrategy, LifecycleState.WatchingJVM)
       val storageModule = StorageModule(metricsModule.metrics, conf, curatorFramework)
       storageModule.persistenceStore.markOpen()
       val backup = storageModule.persistentStoreBackup

--- a/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
+++ b/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/RichCuratorFramework.scala
@@ -8,7 +8,6 @@ import akka.Done
 import akka.util.ByteString
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.base.{LifecycleState, _}
-import mesosphere.marathon.storage.StorageConf
 import mesosphere.marathon.stream.Implicits._
 import org.apache.curator.framework.api.{ACLProvider, BackgroundPathable, Backgroundable, Pathable}
 import org.apache.curator.framework.imps.{CuratorFrameworkState, GzipCompressionProvider}
@@ -180,7 +179,7 @@ object RichCuratorFramework {
     new RichCuratorFramework(client)
   }
 
-  def apply(conf: StorageConf, crashStrategy: CrashStrategy): RichCuratorFramework = {
+  def apply(conf: ZookeeperConf, crashStrategy: CrashStrategy): RichCuratorFramework = {
     val builder = CuratorFrameworkFactory.builder()
     builder.connectString(conf.zooKeeperStateUrl.hostsString)
     builder.sessionTimeoutMs(conf.zkSessionTimeoutDuration.toMillis.toInt)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -83,7 +83,7 @@ private[tracker] class InstanceTrackerDelegate(
     * We use a [[akka.stream.scaladsl.SourceQueue]] to serialize all instance updates *per Instance.Id*. This is important
     * since the way [[InstanceTrackerActor]] is applying/persisting those update to existing Instance state, having two
     * such update operation in parallel will result in later operation overriding the former one.
-    * 
+    *
     * For this we group all [[InstanceUpdateOperation]]s in substreams hashed by [[Instance.Id.idString]] hash.
     * Number of parallel updates for *different Instance.Ids* is controlled via [[InstanceTrackerConfig.internalInstanceTrackerNumParallelUpdates]]
     * parameter.

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -88,6 +88,7 @@ private[tracker] class InstanceTrackerDelegate(
     * Number of parallel updates for *different Instance.Ids* is controlled via [[InstanceTrackerConfig.internalInstanceTrackerNumParallelUpdates]]
     * parameter.
     */
+  // format: off
   val queue = Source
     .queue[QueuedUpdate](config.internalInstanceTrackerUpdateQueueSize(), OverflowStrategy.dropNew)
     .groupBy(config.internalInstanceTrackerNumParallelUpdates(), queued => Math.abs(queued.update.instanceId.idString.hashCode) % config.internalInstanceTrackerNumParallelUpdates())
@@ -123,6 +124,7 @@ private[tracker] class InstanceTrackerDelegate(
     }
     promise.future
   }
+  // format: on
 
   override def schedule(instance: Instance): Future[Done] = {
     require(

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -31,7 +31,7 @@ trait StorageModule {
 }
 
 object StorageModule {
-  def apply(metrics: Metrics, conf: StorageConf with NetworkConf, curatorFramework: Option[RichCuratorFramework])(
+  def apply(metrics: Metrics, conf: StorageConf with NetworkConf, curatorFramework: RichCuratorFramework)(
     implicit
     mat: Materializer, ctx: ExecutionContext,
     scheduler: Scheduler, actorSystem: ActorSystem): StorageModule = {

--- a/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
@@ -15,7 +15,7 @@ class SystemResourceTest extends AkkaUnitTest with JerseyTest {
   class Fixture(conf: AllConf = AllConf.withTestConfig()) {
     val auth = new TestAuthFixture
     val actorSystem = mock[ActorSystem]
-    val metricsModule = MetricsModule(conf, system.settings.config)
+    val metricsModule = MetricsModule(conf)
     val resource = new SystemResource(conf, metricsModule, system.settings.config)(auth.auth, auth.auth, actorSystem, ctx)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -31,7 +31,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
 
   val metricsModules = Table(
     ("name", "module"),
-    ("dropwizard", MetricsModule(AllConf.withTestConfig(), ConfigFactory.load()))
+    ("dropwizard", MetricsModule(AllConf.withTestConfig()))
   )
 
   forAll (metricsModules) { (name: String, metricsModule: MetricsModule) =>

--- a/src/test/scala/mesosphere/marathon/test/ThrowExceptionAndDontCrashStrategy.scala
+++ b/src/test/scala/mesosphere/marathon/test/ThrowExceptionAndDontCrashStrategy.scala
@@ -1,0 +1,16 @@
+package mesosphere.marathon
+package test
+
+import akka.Done
+import mesosphere.marathon.core.base.CrashStrategy
+
+import scala.concurrent.Future
+
+/**
+  * For testing purposes only: This crash strategy will *NOT* crash but throw an exception
+  */
+case object ThrowExceptionAndDontCrashStrategy extends CrashStrategy {
+  override def crash(reason: CrashStrategy.Reason): Future[Done] = {
+    throw new Exception(s"TESTING ONLY: Failed for reason ${reason}")
+  }
+}

--- a/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
@@ -6,11 +6,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.Executors
 
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.base.{LifecycleState, ThrowExceptionAndDontCrashStrategy}
+import mesosphere.marathon.core.base.LifecycleState
 import mesosphere.marathon.core.storage.store.impl.zk.NoRetryPolicy
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.storage.StorageConfig
 import mesosphere.marathon.stream.EnrichedFlow
+import mesosphere.marathon.test.ThrowExceptionAndDontCrashStrategy
 import mesosphere.marathon.util.{LifeCycledCloseable, ZookeeperServerTest}
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.framework.recipes.leader.LeaderLatch

--- a/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/core/election/CuratorElectionStreamTest.scala
@@ -6,13 +6,15 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.Executors
 
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.base.{LifecycleState, ThrowExceptionAndDontCrashStrategy}
 import mesosphere.marathon.core.storage.store.impl.zk.NoRetryPolicy
 import mesosphere.marathon.metrics.dummy.DummyMetrics
+import mesosphere.marathon.storage.StorageConfig
 import mesosphere.marathon.stream.EnrichedFlow
 import mesosphere.marathon.util.{LifeCycledCloseable, ZookeeperServerTest}
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.framework.recipes.leader.LeaderLatch
-import org.apache.zookeeper.ZooDefs
+import org.rogach.scallop.ScallopConf
 import org.scalatest.Inside
 import org.scalatest.concurrent.Eventually
 
@@ -59,15 +61,11 @@ class CuratorElectionStreamTest extends AkkaUnitTest with Inside with ZookeeperS
 
   "CuratorElectionStream.newCuratorConnection" should {
     "throw an exception when given an unresolvable hostname" in {
-      val zkUrl = ZookeeperConf.ZkUrl.parse("zk://unresolvable:8080/marathon/leader").right.get
+      val conf = new ScallopConf(args = List("--zk", "zk://unresolvable:8080/marathon/leader")) with ZookeeperConf
+      conf.verify()
 
       a[Throwable] shouldBe thrownBy {
-        new LifeCycledCloseable(CuratorElectionStream.newCuratorConnection(
-          zkUrl = zkUrl,
-          sessionTimeoutMs = 1000,
-          connectionTimeoutMs = 1000,
-          timeoutDurationMs = 250,
-          defaultCreationACL = ZooDefs.Ids.OPEN_ACL_UNSAFE))
+        StorageConfig.curatorFramework(conf, ThrowExceptionAndDontCrashStrategy, LifecycleState.Ignore).client
       }
     }
   }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/EventsIntegrationTest.scala
@@ -49,7 +49,9 @@ class EventsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTes
         .runWith(Sink.seq)
 
       And("a new event source is connected")
-      val allEvents = marathon.events().futureValue
+      marathon
+        .events()
+        .futureValue
         .takeWhile(_.eventType != "deployment_success", inclusive = true)
         .runWith(Sink.seq)
 


### PR DESCRIPTION
Previously Marathon used two separate apache curator instances and hence two zookeeper connections - one for leader election and one for data transfer. This could have potential implications should leader client disconnect and the data client continues working and additionally wastes memory and threads. This commit merges both clients to one.

Fixes: MARATHON-8509