### PR TITLE
Fix for a secrets validator error when we change env without changing…

### DIFF
--- a/src/main/scala/mesosphere/marathon/Normalization.scala
+++ b/src/main/scala/mesosphere/marathon/Normalization.scala
@@ -12,4 +12,5 @@ object Normalization {
   }
 
   def apply[T](f: (T => T)): Normalization[T] = (t: T) => f(t)
+
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.api.{Rejection, RejectionException}
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.appinfo.{AppSelector, Selector}
-import mesosphere.marathon.plugin.auth.{AuthorizedAction, Authorizer, CreateRunSpec, Identity, UpdateRunSpec, ViewRunSpec}
+import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.state.VersionInfo.OnlyVersion
 import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp, UnreachableStrategy}
 import mesosphere.marathon.raml.{AppConversion, AppExternalVolume, AppPersistentVolume, Raml}
@@ -22,11 +22,9 @@ object AppHelpers {
     AppNormalization(config).normalized(migrated)
   }
 
-  def appUpdateNormalization(
-    enabledFeatures: Set[String], config: AppNormalization.Config): Normalization[raml.AppUpdate] = Normalization { app =>
-    validateOrThrow(app)(AppValidation.validateOldAppUpdateAPI)
+  def appUpdateNormalization(config: AppNormalization.Config): Normalization[raml.AppUpdate] = Normalization { app =>
     val migrated = AppNormalization.forDeprecatedUpdates(config).normalized(app)
-    validateOrThrow(app)(AppValidation.validateCanonicalAppUpdateAPI(enabledFeatures, () => config.defaultNetworkName))
+    validateOrThrow(migrated)(AppValidation.validateAppUpdateVersion)
     AppNormalization.forUpdates(config).normalized(migrated)
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -274,72 +274,6 @@ trait AppValidation {
   }
 
   /**
-    * all validation that touches deprecated app-update API fields goes in here
-    */
-  def validateOldAppUpdateAPI: Validator[AppUpdate] = forAll(
-    validator[AppUpdate] { update =>
-      update.container is optional(validOldContainerAPI)
-      update.container.flatMap(_.docker.flatMap(_.portMappings)) is optional(portMappingsIndependentOfNetworks)
-      update.ipAddress is optional(isTrue(
-        "ipAddress/discovery is not allowed for Docker containers") { (ipAddress: IpAddress) =>
-          !(update.container.exists(c => c.`type` == EngineType.Docker) && ipAddress.discovery.nonEmpty)
-        })
-      update.uris is optional(every(api.v2.Validation.uriIsValid) and isTrue(
-        "may not be set in conjunction with fetch") { (uris: Seq[String]) =>
-          !(uris.nonEmpty && update.fetch.fold(false)(_.nonEmpty))
-        })
-    },
-    isTrue("ports must be unique") { update =>
-      val withoutRandom = update.ports.fold(Seq.empty[Int])(_.filterNot(_ == AppDefinition.RandomPortValue))
-      withoutRandom.distinct.size == withoutRandom.size
-    },
-    isTrue("cannot specify both an IP address and port") { update =>
-      val appWithoutPorts = update.ports.fold(true)(_.isEmpty) && update.portDefinitions.fold(true)(_.isEmpty)
-      appWithoutPorts || update.ipAddress.isEmpty
-    },
-    isTrue("cannot specify both ports and port definitions") { update =>
-      val portDefinitionsIsEquivalentToPorts = update.portDefinitions.map(_.map(_.port)) == update.ports
-      portDefinitionsIsEquivalentToPorts || update.ports.isEmpty || update.portDefinitions.isEmpty
-    },
-    isTrue("must not specify both networks and ipAddress") { update =>
-      !(update.ipAddress.nonEmpty && update.networks.fold(false)(_.nonEmpty))
-    },
-    isTrue("must not specify both container.docker.network and networks") { update =>
-      !(update.container.exists(_.docker.exists(_.network.nonEmpty)) && update.networks.nonEmpty)
-    }
-  )
-
-  def validateCanonicalAppUpdateAPI(enabledFeatures: Set[String], defaultNetworkName: () => Option[String]): Validator[AppUpdate] = forAll(
-    validator[AppUpdate] { update =>
-      update.id.map(PathId(_)) as "id" is optional(valid)
-      update.dependencies.map(_.map(PathId(_))) as "dependencies" is optional(every(valid))
-      update.env is optional(envValidator(strictNameValidation = false, update.secrets.getOrElse(Map.empty), enabledFeatures))
-      update.secrets is empty or featureEnabled(enabledFeatures, Features.SECRETS)
-      update.secrets is optional(featureEnabledImplies(enabledFeatures, Features.SECRETS)(secretValidator))
-      update.fetch is optional(every(valid))
-      update.portDefinitions is optional(portDefinitionsValidator)
-      update.container is optional(validContainer(enabledFeatures, update.networks.getOrElse(Nil), update.secrets.getOrElse(Map.empty)))
-      update.acceptedResourceRoles is optional(ResourceRole.validAcceptedResourceRoles("app", update.residency.isDefined) and notEmpty)
-      update.networks is optional(NetworkValidation.defaultNetworkNameValidator(defaultNetworkName))
-    },
-    isTrue("must not be root")(!_.id.fold(false)(PathId(_).isRoot)),
-    isTrue("must not be an empty string")(_.cmd.forall { s => s.length() > 1 }),
-    isTrue("portMappings are not allowed with host-networking") { update =>
-      !(update.networks.exists(_.exists(_.mode == NetworkMode.Host)) && update.container.exists(_.portMappings.exists(_.nonEmpty)))
-    },
-    isTrue("portDefinitions are only allowed with host-networking") { update =>
-      !(update.networks.exists(_.exists(_.mode != NetworkMode.Host)) && update.portDefinitions.exists(_.nonEmpty))
-    },
-    isTrue("The 'version' field may only be combined with the 'id' field.") { update =>
-      def onlyVersionOrIdSet: Boolean = update.productIterator.forall {
-        case x: Some[Any] => x == update.version || x == update.id // linter:ignore UnlikelyEquality
-        case _ => true
-      }
-      update.version.isEmpty || onlyVersionOrIdSet
-    }
-  )
-
-  /**
     * all validation that touches deprecated app API fields goes in here
     */
   val validateOldAppAPI: Validator[App] = forAll(
@@ -387,6 +321,16 @@ trait AppValidation {
     },
     isTrue("portDefinitions are only allowed with host-networking") { app =>
       !(app.networks.exists(_.mode != NetworkMode.Host) && app.portDefinitions.exists(_.nonEmpty))
+    }
+  )
+
+  def validateAppUpdateVersion: Validator[AppUpdate] = forAll(
+    isTrue("The 'version' field may only be combined with the 'id' field.") { update =>
+      def onlyVersionOrIdSet: Boolean = update.productIterator.forall {
+        case x: Some[Any] => x == update.version || x == update.id // linter:ignore UnlikelyEquality
+        case _ => true
+      }
+      update.version.isEmpty || onlyVersionOrIdSet
     }
   )
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2,12 +2,11 @@ package mesosphere.marathon
 package api.v2
 
 import java.util
-import javax.ws.rs.core.Response
 
+import javax.ws.rs.core.Response
 import akka.Done
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.api._
-import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.api.v2.validation.NetworkValidationMessages
 import mesosphere.marathon.core.appinfo.AppInfo.Embed
 import mesosphere.marathon.core.appinfo._
@@ -16,12 +15,11 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.ContainerNetwork
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer}
-import mesosphere.marathon.raml.{App, AppSecretVolume, AppUpdate, ContainerPortMapping, DockerContainer, DockerNetwork, DockerPullConfig, EngineType, EnvVarValueOrSecret, IpAddress, IpDiscovery, IpDiscoveryPort, Network, NetworkMode, Raml, SecretDef}
-import mesosphere.marathon.raml.{Container => RamlContainer}
+import mesosphere.marathon.raml.{App, AppSecretVolume, AppUpdate, ContainerPortMapping, DockerContainer, DockerNetwork, DockerPullConfig, EngineType, EnvVarSecret, EnvVarValueOrSecret, IpAddress, IpDiscovery, IpDiscoveryPort, Network, NetworkMode, Raml, SecretDef, Container => RamlContainer}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.GroupRepository
-import mesosphere.marathon.test.{GroupCreation, SettableClock, JerseyTest}
+import mesosphere.marathon.test.{GroupCreation, JerseyTest, SettableClock}
 import org.mockito.Matchers
 import play.api.libs.json._
 
@@ -59,13 +57,12 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
 
     val normalizationConfig = AppNormalization.Configuration(config.defaultNetworkName.toOption, config.mesosBridgeName())
     implicit lazy val appDefinitionValidator = AppDefinition.validAppDefinition(config.availableFeatures)(PluginManager.None)
-    implicit lazy val validateCanonicalAppUpdateAPI = AppValidation.validateCanonicalAppUpdateAPI(config.availableFeatures, () => config.defaultNetworkName.toOption)
 
     implicit val validateAndNormalizeApp: Normalization[raml.App] =
       AppHelpers.appNormalization(config.availableFeatures, normalizationConfig)(AppNormalization.withCanonizedIds())
 
-    implicit val validateAndNormalizeAppUpdate: Normalization[raml.AppUpdate] =
-      AppHelpers.appUpdateNormalization(config.availableFeatures, normalizationConfig)(AppNormalization.withCanonizedIds())
+    implicit val normalizeAppUpdate: Normalization[raml.AppUpdate] =
+      AppHelpers.appUpdateNormalization(normalizationConfig)(AppNormalization.withCanonizedIds())
 
     def normalize(app: App): App = {
       val migrated = AppNormalization.forDeprecated(normalizationConfig).normalized(app)
@@ -1359,7 +1356,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         app.id, Some(app), appUpdate, partialUpdate = false, allowCreation = true, now = clock.now(), service = service)
 
       And("also works when the update operation uses partial-update semantics, dropping portDefinitions")
-      val partUpdate = appsResource.canonicalAppUpdateFromJson(app.id, body, PartialUpdate)
+      val partUpdate = appsResource.canonicalAppUpdateFromJson(app.id, body, PartialUpdate(app))
       val app2 = AppHelpers.updateOrCreate(
         app.id, Some(app), partUpdate, partialUpdate = true, allowCreation = false, now = clock.now(), service = service)
 
@@ -1699,6 +1696,46 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
 
       Then("It is successful")
       assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[String]}")
+    }
+
+    "Allow editing a env configuration without sending secrets" in new Fixture(configArgs = Seq("--enable_features", "secrets")) {
+      Given("An app with a secret")
+      val app = App(id = "/app", cmd = Some("cmd"), env = Map("DATABASE_PW" -> EnvVarSecret("database")), secrets = Map("database" -> SecretDef("dbpassword")))
+      val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
+
+      When("The create request is made")
+      clock += 5.seconds
+
+      val response = asyncRequest { r =>
+        appsResource.create(body, force = false, auth.request, r)
+      }
+
+      Then("It is successful")
+      response.getStatus should be(201)
+      response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
+
+      When("Env is updated with a PUT request")
+      clock += 5.seconds
+
+      val update =
+        """
+          |{
+          |  "env": {
+          |    "DATABASE_PW": {
+          |      "secret": "database"
+          |    },
+          |    "foo":"bar"
+          |  }
+          |}
+        """.stripMargin.getBytes("UTF-8")
+      val updateResponse = asyncRequest { r =>
+        appsResource.replace(app.id, update, force = false, partialUpdate = true, auth.request, r)
+      }
+
+      Then("It is successful")
+      updateResponse.getStatus should be(200)
+      updateResponse.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
+
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -613,5 +613,30 @@ class AppDefinitionFormatsTest extends UnitTest
       val validator = AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName)
       validator(ramlApp) should haveViolations("/container/docker" -> "not defined")
     }
+
+    "FromJSON should throw a validation exception if ports and portDefinitions are both specified and not equal" in {
+      // port mappings is currently not supported
+      val app = Json.parse(
+        """{
+          |  "id": "/test",
+          |  "container": {
+          |    "type": "MESOS",
+          |    "docker": {
+          |      "image": "busybox"
+          |    }
+          |  },
+          |  "portDefinitions": [
+          |    {
+          |      "port": 8080
+          |    }
+          |  ],
+          |  "ports": [
+          |    8081
+          |  ]
+          |}""".stripMargin).as[raml.App]
+
+      AppValidation.validateOldAppAPI(app) should haveViolations("/" -> "cannot specify both ports and port definitions")
+
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
@@ -11,20 +11,12 @@ class AppUpdateFormatTest extends UnitTest {
 
   def normalizedAndValidated(appUpdate: AppUpdate): AppUpdate =
     AppHelpers.appUpdateNormalization(
-      Set.empty,
       AppNormalization.Configuration(None, "mesos-bridge-name")).normalized(appUpdate)
 
   def fromJson(json: String): AppUpdate =
     normalizedAndValidated(Json.parse(json).as[AppUpdate])
 
   "AppUpdateFormats" should {
-    // regression test for #1176
-    "should fail if id is /" in {
-      val json = """{"id": "/"}"""
-      a[ValidationFailedException] shouldBe thrownBy {
-        fromJson(json)
-      }
-    }
 
     "FromJSON should not fail when 'cpus' is greater than 0" in {
       val json = """ { "id": "test", "cpus": 0.0001 }"""
@@ -43,13 +35,6 @@ class AppUpdateFormatTest extends UnitTest {
       val json = """ { "id": "test", "acceptedResourceRoles": ["*"] }"""
       val appUpdate = fromJson(json)
       appUpdate.acceptedResourceRoles should equal(Some(Set(ResourceRole.Unreserved)))
-    }
-
-    "FromJSON should fail when 'acceptedResourceRoles' is defined but empty" in {
-      val json = """ { "id": "test", "acceptedResourceRoles": [] }"""
-      a[ValidationFailedException] shouldBe thrownBy {
-        fromJson(json)
-      }
     }
 
     "FromJSON should parse kill selection" in {

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -265,6 +265,26 @@ class AppValidationTest extends UnitTest with ValidationTestLike with TableDrive
         "/container/portMappings" -> "Port names must be unique.")
     }
 
+    "port definitions must have unique ports" in {
+      val app = App(id = "/app", cmd = Some("cmd"),
+        container = Option(raml.Container(`type` = EngineType.Mesos)),
+        portDefinitions = Some(PortDefinitions(9000, 8080, 9000))
+      )
+      basicValidator(app) should haveViolations("/portDefinitions" -> "Ports must be unique.")
+    }
+
+    "port definitions must have unique names" in {
+      val app = App(id = "/app", cmd = Some("cmd"),
+        container = Option(raml.Container(`type` = EngineType.Mesos)),
+        portDefinitions = Some(Seq(
+          PortDefinition(9000, name = Some("foo")),
+          PortDefinition(9001, name = Some("foo"))))
+      )
+      basicValidator(app) should haveViolations("/portDefinitions" -> "Port names must be unique.")
+    }
+
+
+
     "missing hostPort is allowed for bridge networking (so we can normalize it)" in {
       // This isn't _actually_ allowed; we expect that normalization will replace the None to a Some(0) before
       // converting to an AppDefinition, in order to support legacy API

--- a/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
@@ -4,34 +4,15 @@ package api.validation
 import com.wix.accord.validate
 import mesosphere.UnitTest
 import mesosphere.marathon.api.v2.AppNormalization
-import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.raml.{App, AppCContainer, AppUpdate, ContainerPortMapping, EngineType, Raml}
+import mesosphere.marathon.raml.{App, AppUpdate, Raml}
 import mesosphere.marathon.state.AppDefinition
 import org.scalatest.Matchers
 import play.api.libs.json.Json
 
 class AppUpdateValidatorTest extends UnitTest with Matchers {
-  implicit val appUpdateValidator = AppValidation.validateCanonicalAppUpdateAPI(Set.empty, () => AppNormalization.Configuration(None, "mesos-bridge-name").defaultNetworkName)
+
   implicit val validAppDefinition = AppDefinition.validAppDefinition(Set.empty)(PluginManager.None)
-
-  "validation that considers container types" should {
-    "test that Docker container is validated" in {
-      val f = new Fixture
-      val update = AppUpdate(
-        id = Some("/test"),
-        container = Some(f.invalidDockerContainer))
-      assert(validate(update).isFailure)
-    }
-
-    "test that AppC container is validated" in {
-      val f = new Fixture
-      val update = AppUpdate(
-        id = Some("/test"),
-        container = Some(f.invalidAppCContainer))
-      assert(validate(update).isFailure)
-    }
-  }
 
   "validation for network type changes" should {
     // regression test for DCOS-10641
@@ -79,55 +60,39 @@ class AppUpdateValidatorTest extends UnitTest with Matchers {
       val appUpdate = AppNormalization.forUpdates(config).normalized(
         AppNormalization.forDeprecatedUpdates(config).normalized(Json.parse(
           """
-          |{
-          |  "id": "/sleepy-moby",
-          |  "cmd": "sleep 1000",
-          |  "instances": 1,
-          |  "cpus": 1,
-          |  "mem": 128,
-          |  "disk": 0,
-          |  "gpus": 0,
-          |  "backoffSeconds": 1,
-          |  "backoffFactor": 1.15,
-          |  "maxLaunchDelaySeconds": 3600,
-          |  "container": {
-          |    "docker": {
-          |      "image": "alpine",
-          |      "forcePullImage": false,
-          |      "privileged": false,
-          |      "network": "USER"
-          |    }
-          |  },
-          |  "upgradeStrategy": {
-          |    "minimumHealthCapacity": 0.5,
-          |    "maximumOverCapacity": 0
-          |  },
-          |  "portDefinitions": [],
-          |  "ipAddress": {
-          |    "networkName": "dcos"
-          |  },
-          |  "requirePorts": false
-          |}
-        """.stripMargin).as[AppUpdate]))
+            |{
+            |  "id": "/sleepy-moby",
+            |  "cmd": "sleep 1000",
+            |  "instances": 1,
+            |  "cpus": 1,
+            |  "mem": 128,
+            |  "disk": 0,
+            |  "gpus": 0,
+            |  "backoffSeconds": 1,
+            |  "backoffFactor": 1.15,
+            |  "maxLaunchDelaySeconds": 3600,
+            |  "container": {
+            |    "docker": {
+            |      "image": "alpine",
+            |      "forcePullImage": false,
+            |      "privileged": false,
+            |      "network": "USER"
+            |    }
+            |  },
+            |  "upgradeStrategy": {
+            |    "minimumHealthCapacity": 0.5,
+            |    "maximumOverCapacity": 0
+            |  },
+            |  "portDefinitions": [],
+            |  "ipAddress": {
+            |    "networkName": "dcos"
+            |  },
+            |  "requirePorts": false
+            |}
+          """.stripMargin).as[AppUpdate]))
 
       assert(validate(Raml.fromRaml(Raml.fromRaml(appUpdate -> appDef))).isSuccess)
     }
-  }
-
-  class Fixture {
-    def invalidDockerContainer: raml.Container = raml.Container(
-      EngineType.Docker,
-      portMappings = Option(Seq(
-        ContainerPortMapping(
-          // Invalid (negative) port numbers
-          containerPort = -1, hostPort = Some(-1), servicePort = -1)
-      ))
-    )
-
-    def invalidAppCContainer: raml.Container = raml.Container(EngineType.Mesos, appc = Some(AppCContainer(
-      image = "anImage",
-      id = Some("invalidID")))
-    )
   }
 
 }


### PR DESCRIPTION
… secrets (#6651)

Summary: Secrets validator was only passing if we submit a secret environment variable update with a corresponding secret definition section. Because of this, the app update validation process is simplified now: instead of validating an app update and the resulting app definition, we merge the update first and validate the result. Note that app normalization stays there as before.

Jira issues: MARATHON-8498

(cherry picked from commit 80c70dbc3d3c37aa23fdb2b555ee418f8cf06362)

