### PR TITLE
Fix for a secrets validator error when we change env without changing…

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
+++ b/src/main/scala/mesosphere/marathon/api/akkahttp/v2/AppsController.scala
@@ -43,7 +43,7 @@ class AppsController(
   import Directives._
 
   private implicit lazy val validateApp = AppDefinition.validAppDefinition(config.availableFeatures)(pluginManager)
-  private implicit lazy val updateValidator = AppValidation.validateCanonicalAppUpdateAPI(config.availableFeatures, () => normalizationConfig.defaultNetworkName)
+  private implicit lazy val updateValidator = AppValidation.validateAppUpdateVersion
 
   import AppsController._
   import EntityMarshallers._

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -694,5 +694,30 @@ class AppDefinitionFormatsTest extends UnitTest
         group("container", "is invalid", "docker" -> "not defined")
       )
     }
+
+    "FromJSON should throw a validation exception if ports and portDefinitions are both specified and not equal" in {
+      // port mappings is currently not supported
+      val app = Json.parse(
+        """{
+          |  "id": "/test",
+          |  "container": {
+          |    "type": "MESOS",
+          |    "docker": {
+          |      "image": "busybox"
+          |    }
+          |  },
+          |  "portDefinitions": [
+          |    {
+          |      "port": 8080
+          |    }
+          |  ],
+          |  "ports": [
+          |    8081
+          |  ]
+          |}""".stripMargin).as[raml.App]
+
+      val result = AppValidation.validateOldAppAPI(app)
+      result.isFailure shouldBe true
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
@@ -19,13 +19,6 @@ class AppUpdateFormatTest extends UnitTest {
     normalizedAndValidated(Json.parse(json).as[AppUpdate])
 
   "AppUpdateFormats" should {
-    // regression test for #1176
-    "should fail if id is /" in {
-      val json = """{"id": "/"}"""
-      a[ValidationFailedException] shouldBe thrownBy {
-        fromJson(json)
-      }
-    }
 
     "FromJSON should not fail when 'cpus' is greater than 0" in {
       val json = """ { "id": "test", "cpus": 0.0001 }"""
@@ -44,13 +37,6 @@ class AppUpdateFormatTest extends UnitTest {
       val json = """ { "id": "test", "acceptedResourceRoles": ["*"] }"""
       val appUpdate = fromJson(json)
       appUpdate.acceptedResourceRoles should equal(Some(Set(ResourceRole.Unreserved)))
-    }
-
-    "FromJSON should fail when 'acceptedResourceRoles' is defined but empty" in {
-      val json = """ { "id": "test", "acceptedResourceRoles": [] }"""
-      a[ValidationFailedException] shouldBe thrownBy {
-        fromJson(json)
-      }
     }
 
     "FromJSON should parse kill selection" in {

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -272,6 +272,24 @@ class AppValidationTest extends UnitTest with ResultMatchers with ValidationTest
               hostPort = Some(123))))).isFailure shouldBe true
     }
 
+    "port definitions must have unique ports" in {
+      val app = App(id = "/app", cmd = Some("cmd"),
+        container = Option(raml.Container(`type` = EngineType.Mesos)),
+        portDefinitions = Some(PortDefinitions(9000, 8080, 9000))
+      )
+      basicValidator(app) shouldBe (aFailure)
+    }
+
+    "port definitions must have unique names" in {
+      val app = App(id = "/app", cmd = Some("cmd"),
+        container = Option(raml.Container(`type` = EngineType.Mesos)),
+        portDefinitions = Some(Seq(
+          PortDefinition(9000, name = Some("foo")),
+          PortDefinition(9001, name = Some("foo"))))
+      )
+      basicValidator(app) shouldBe (aFailure)
+    }
+
     "missing hostPort is allowed for bridge networking (so we can normalize it)" in {
       // This isn't _actually_ allowed; we expect that normalization will replace the None to a Some(0) before
       // converting to an AppDefinition, in order to support legacy API


### PR DESCRIPTION
… secrets (#6651)

Summary: Secrets validator was only passing if we submit a secret environment variable update with a corresponding secret definition section. Because of this, the app update validation process is simplified now: instead of validating an app update and the resulting app definition, we merge the update first and validate the result. Note that app normalization stays there as before.

Jira issues: MARATHON-8498

(cherry picked from commit 80c70dbc3d3c37aa23fdb2b555ee418f8cf06362)
