### PR TITLE
Rename resident task id to TaskIdWithIncarnation

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -292,7 +292,7 @@ class InstanceOpFactoryImpl(
         }(collection.breakOut)
 
         val containerNameToTaskId: Map[String, Task.Id] = oldToNewTaskIds.values.map {
-          case taskId @ Task.ResidentTaskId(_, Some(containerName), _) => containerName -> taskId
+          case taskId @ Task.TaskIdWithIncarnation(_, Some(containerName), _) => containerName -> taskId
           case taskId => throw new IllegalStateException(s"failed to extract a container name from the task id $taskId")
         }(collection.breakOut)
         val podContainerTaskIds: Seq[Task.Id] = pod.containers.map { container =>

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition}
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.{EphemeralOrReservedTaskId, ResidentTaskId}
+import mesosphere.marathon.core.task.Task.{EphemeralOrReservedTaskId, TaskIdWithIncarnation}
 import mesosphere.marathon.raml.{Endpoint, Resources}
 import mesosphere.marathon.state.PathId
 
@@ -129,7 +129,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       case (EphemeralOrReservedTaskId(_, Some(ctName)), task) =>
         val ports: Seq[Int] = task.status.networkInfo.hostPorts
         ctName -> ports
-      case (ResidentTaskId(_, Some(ctName), _), task) =>
+      case (TaskIdWithIncarnation(_, Some(ctName), _), task) =>
         val ports: Seq[Int] = task.status.networkInfo.hostPorts
         ctName -> ports
       case (other, _) =>

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -85,7 +85,7 @@ class InstanceIdTest extends UnitTest with Inside {
       Instance.Id.fromReservationId(podTaskIdWithContainerName.reservationId) shouldEqual podTaskIdWithContainerName.instanceId
 
       val podTaskIdWithContainerNameAndAttempt = Task.Id("app.instance-4455cb85-0c16-490d-b84e-481f8321ff0a.ct.1")
-      podTaskIdWithContainerNameAndAttempt shouldBe a[Task.ResidentTaskId]
+      podTaskIdWithContainerNameAndAttempt shouldBe a[Task.TaskIdWithIncarnation]
       Instance.Id.fromReservationId(podTaskIdWithContainerNameAndAttempt.reservationId) shouldEqual podTaskIdWithContainerNameAndAttempt.instanceId
     }
   }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -136,7 +136,7 @@ class TaskIdTest extends UnitTest with Inside {
       podTaskIdWithContainerName.reservationId shouldEqual "app.instance-4455cb85-0c16-490d-b84e-481f8321ff0a"
 
       val podTaskIdWithContainerNameAndAttempt = Task.Id("app.instance-4455cb85-0c16-490d-b84e-481f8321ff0a.ct.1")
-      podTaskIdWithContainerNameAndAttempt shouldBe a[Task.ResidentTaskId]
+      podTaskIdWithContainerNameAndAttempt shouldBe a[Task.TaskIdWithIncarnation]
       podTaskIdWithContainerNameAndAttempt.reservationId shouldEqual "app.instance-4455cb85-0c16-490d-b84e-481f8321ff0a"
     }
   }


### PR DESCRIPTION
This will be used in more general sense while we come to stable instance ids.
