### PR TITLE
Remove redundant log lines to ease debugging

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
@@ -35,7 +35,9 @@ private[termination] class KillServiceDelegate(actorRef: ActorRef) extends KillS
   }
 
   override def killInstancesAndForget(instances: Seq[Instance], reason: KillReason): Unit = {
-    logger.info(s"Kill and forget following instances for reason $reason: ${instances.map(_.instanceId).mkString(",")}")
-    actorRef ! KillInstancesAndForget(instances)
+    if (instances.nonEmpty) {
+      logger.info(s"Kill and forget following instances for reason $reason: ${instances.map(_.instanceId).mkString(",")}")
+      actorRef ! KillInstancesAndForget(instances)
+    }
   }
 }


### PR DESCRIPTION
I am debugging an issue and this is what I am seeing:

```
[39mDEBUG[0;39m[16:02:22 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:22 KillServiceDelegate] Kill and forget following instances for reason Overdue: 
[39mDEBUG[0;39m[16:02:22 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:22 KillServiceActor] processing 0 kills for Set()
[39mDEBUG[0;39m[16:02:27 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:27 OverdueInstancesActor$Support] Killing overdue instances: 
[39mDEBUG[0;39m[16:02:27 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:27 KillServiceDelegate] Kill and forget following instances for reason Overdue: 
[39mDEBUG[0;39m[16:02:27 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:27 KillServiceActor] processing 0 kills for Set()
[39mDEBUG[0;39m[16:02:32 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:32 OverdueInstancesActor$Support] Killing overdue instances: 
[39mDEBUG[0;39m[16:02:32 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:32 KillServiceDelegate] Kill and forget following instances for reason Overdue: 
[39mDEBUG[0;39m[16:02:32 AppDeployIntegrationTest-LocalMarathon-32857] [34mINFO [0;39m[16:02:32 KillServiceActor] processing 0 kills for Set()
```

This prevents that from happening