### PR TITLE
Alter default backoff from 1 hour to 5 min

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -211,7 +211,7 @@ types:
         type: integer
         format: int32
         minimum: 0
-        default: 3600
+        default: 300
         description: |
           Configures exponential backoff behavior when launching potentially sick
           apps. This prevents sandboxes associated with consecutively failing tasks

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -54,7 +54,7 @@ types:
         type: number
         description: The maximum backoff (seconds) applied when subsequent failures are detected.
         minimum: 0
-        default: 3600
+        default: 300
   PodUpgradeStrategy:
     type: object
     description: |

--- a/src/main/scala/mesosphere/marathon/state/RunSpec.scala
+++ b/src/main/scala/mesosphere/marathon/state/RunSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration._
   */
 case class BackoffStrategy(
     backoff: FiniteDuration = 1.seconds,
-    maxLaunchDelay: FiniteDuration = 1.hour,
+    maxLaunchDelay: FiniteDuration = 5.minutes,
     factor: Double = 1.15)
 
 /**

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -595,7 +595,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
           portMappings = Seq(Container.PortMapping(name = Some("http"), containerPort = 80, protocol = "tcp")
           )
         )),
-        backoffStrategy = BackoffStrategy(maxLaunchDelay = 3600.seconds)
+        backoffStrategy = BackoffStrategy(maxLaunchDelay = 300.seconds)
       )
 
       val json =
@@ -616,7 +616,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
             ]
           }
         },
-        "maxLaunchDelaySeconds": 3600
+        "maxLaunchDelaySeconds": 300
       }
       """
 
@@ -637,7 +637,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
             "baz" -> "buzz"
 
           ))),
-        backoffStrategy = BackoffStrategy(maxLaunchDelay = 3600.seconds)
+        backoffStrategy = BackoffStrategy(maxLaunchDelay = 300.seconds)
       )
 
       val json =


### PR DESCRIPTION
Modify the default backoff delay

Summary:
Currently, the maximum backoff delay is 1 hour. This default is much larger than necessary to achieve the goals of the back off delay. After discussion, we have determined that the new backoff should be 5 minutes.

JIRA issues:
MARATHON-8505