### PR TITLE
Enable Marathon to start on Java 9+

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,6 +1,5 @@
 -mem 8192
 -J-XX:MaxMetaspaceSize=512m
--J-XX:+UseConcMarkSweepGC
 -J-XX:+CMSClassUnloadingEnabled
 -J-server
 -J-XX:+CMSParallelRemarkEnabled

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,6 +70,7 @@ object Dependencies {
     jettySecurity % "compile",
     jerseyCore % "compile",
     jerseyServer % "compile",
+    javaXAnnotationApi % "compile",
     jerseyServlet % "compile",
     jacksonScala % "compile",
     jacksonJaxrs % "compile",
@@ -117,6 +118,7 @@ object Dependency {
     val Jackson = "2.9.5"
     val Java8Compat = "0.9.0"
     val Jersey = "2.27"
+    val JavaXAnnotation = "1.3.2"
     val Jetty = "9.4.8.v20171121"
     val JettyServlets = "9.4.8.v20171121"
     val JsonSchemaValidator = "2.2.6"
@@ -174,6 +176,8 @@ object Dependency {
   val jerseyMultiPart =  "org.glassfish.jersey.media" % "jersey-media-multipart" % V.Jersey
   val jerseyServer = "org.glassfish.jersey.core" % "jersey-server" % V.Jersey
   val jerseyServlet =  "org.glassfish.jersey.containers" % "jersey-container-servlet" % V.Jersey
+
+  val javaXAnnotationApi = "javax.annotation" % "javax.annotation-api" % V.JavaXAnnotation
 
   // Jersey 2 still relies on hk2. See https://jersey.github.io/release-notes/2.26.html
   val jerseyHk2 =  "org.glassfish.jersey.inject" % "jersey-hk2" % V.Jersey

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -120,7 +120,6 @@ object Dependency {
     val Jackson = "2.9.5"
     val Java8Compat = "0.9.0"
     val Jersey = "2.27"
-    val JavaXAnnotation = "1.3.2"
     val Jetty = "9.4.8.v20171121"
     val JettyServlets = "9.4.8.v20171121"
     val JsonSchemaValidator = "2.2.6"
@@ -205,7 +204,7 @@ object Dependency {
 
   object Java9Compatibility {
 
-    val javaXAnnotationApi = "javax.annotation" % "javax.annotation-api" % V.JavaXAnnotation % "compile"
+    val javaXAnnotationApi = "javax.annotation" % "javax.annotation-api" % "1.3.2" % "compile"
 
     val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1" % "compile"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,6 @@ object Dependencies {
     jettySecurity % "compile",
     jerseyCore % "compile",
     jerseyServer % "compile",
-    javaXAnnotationApi % "compile",
     jerseyServlet % "compile",
     jacksonScala % "compile",
     jacksonJaxrs % "compile",
@@ -89,7 +88,10 @@ object Dependencies {
     Test.akkaHttpTestKit % "test",
     Test.junit % "test",
     Test.scalacheck % "test"
-  ) ++ Curator.all ++ DropwizardMetrics.all).map(
+  ) ++ Curator.all
+    ++ DropwizardMetrics.all
+    ++ Java9Compatibility.all
+    ).map(
     _.excludeAll(excludeSlf4jLog4j12)
      .excludeAll(excludeLog4j)
      .excludeAll(excludeJCL)
@@ -177,7 +179,6 @@ object Dependency {
   val jerseyServer = "org.glassfish.jersey.core" % "jersey-server" % V.Jersey
   val jerseyServlet =  "org.glassfish.jersey.containers" % "jersey-container-servlet" % V.Jersey
 
-  val javaXAnnotationApi = "javax.annotation" % "javax.annotation-api" % V.JavaXAnnotation
 
   // Jersey 2 still relies on hk2. See https://jersey.github.io/release-notes/2.26.html
   val jerseyHk2 =  "org.glassfish.jersey.inject" % "jersey-hk2" % V.Jersey
@@ -201,6 +202,18 @@ object Dependency {
   val servletApi = "javax.servlet" % "servlet-api" % V.ServletApi
   val uuidGenerator = "com.fasterxml.uuid" % "java-uuid-generator" % V.UUIDGenerator
   val wixAccord = "com.wix" %% "accord-core" % V.WixAccord
+
+  object Java9Compatibility {
+
+    val javaXAnnotationApi = "javax.annotation" % "javax.annotation-api" % V.JavaXAnnotation % "compile"
+
+    val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1" % "compile"
+
+    val all: Seq[ModuleID] = Seq(
+      javaXAnnotationApi,
+      jaxbApi
+    )
+  }
 
   object Curator {
     /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -178,7 +178,6 @@ object Dependency {
   val jerseyServer = "org.glassfish.jersey.core" % "jersey-server" % V.Jersey
   val jerseyServlet =  "org.glassfish.jersey.containers" % "jersey-container-servlet" % V.Jersey
 
-
   // Jersey 2 still relies on hk2. See https://jersey.github.io/release-notes/2.26.html
   val jerseyHk2 =  "org.glassfish.jersey.inject" % "jersey-hk2" % V.Jersey
 


### PR DESCRIPTION
Summary: Due to recent introduction of modules system in Java 9, javaEE dependencies aren't provided by default anymore, what results in a `java.lang.NoClassDefFoundError`. This fix explicitly adds the missing dependencies, so Marathon can start on Java 9+.

Jira issues: MARATHON-8503
