### PR TITLE
Do not put whole instance into provision update op

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -7,9 +7,7 @@ import com.fasterxml.uuid.{EthernetAddress, Generators}
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.UnreachableInactive
 import mesosphere.marathon.core.instance.Instance.InstanceState
-import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.{MarathonState, PathId, Timestamp, UnreachableDisabled, UnreachableEnabled, UnreachableStrategy, _}
 import mesosphere.marathon.stream.Implicits._

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -35,7 +35,7 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
       case op: Provision =>
         updateExistingInstance(maybeInstance, op.instanceId) { oldInstance =>
           // TODO(karsten): Create events
-          InstanceUpdateEffect.Update(op.instance, oldState = Some(oldInstance), Seq.empty)
+          InstanceUpdateEffect.Update(oldInstance.provisioned(op.agentInfo, op.runSpecVersion, op.tasks, op.now), oldState = Some(oldInstance), Seq.empty)
         }
 
       case RescheduleReserved(instance, runSpecVersion) =>

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -3,9 +3,8 @@ package core.instance.update
 
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.{Goal, Instance}
-import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.{Task, TaskCondition}
-import mesosphere.marathon.state.{AppDefinition, RunSpec, Timestamp}
+import mesosphere.marathon.state.Timestamp
 import org.apache.mesos
 
 import scala.collection.immutable.Seq

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -7,8 +7,6 @@ import mesosphere.marathon.core.task.{Task, TaskCondition}
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos
 
-import scala.collection.immutable.Seq
-
 sealed trait InstanceUpdateOperation {
   def instanceId: Instance.Id
 

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -4,9 +4,11 @@ package core.instance.update
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.task.TaskCondition
-import mesosphere.marathon.state.Timestamp
+import mesosphere.marathon.core.task.{Task, TaskCondition}
+import mesosphere.marathon.state.{AppDefinition, RunSpec, Timestamp}
 import org.apache.mesos
+
+import scala.collection.immutable.Seq
 
 sealed trait InstanceUpdateOperation {
   def instanceId: Instance.Id
@@ -48,11 +50,8 @@ object InstanceUpdateOperation {
     * Scheduled instance have no agent info. Provisioned instances have such info. They are created when offer is
     * matched.
     *
-    * @param instance An instance that has been created during an offer match.
     */
-  case class Provision(instance: Instance) extends InstanceUpdateOperation {
-    override def instanceId: Instance.Id = instance.instanceId
-  }
+  case class Provision(instanceId: Instance.Id, agentInfo: Instance.AgentInfo, runSpecVersion: Timestamp, tasks: Seq[Task], now: Timestamp) extends InstanceUpdateOperation
 
   /**
     * Describes an instance update.

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -7,7 +7,10 @@ import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory}
 import mesosphere.marathon.core.matcher.base.util.OfferOperationFactory
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.state.Timestamp
 import org.apache.mesos.{Protos => Mesos}
+
+import scala.collection.immutable.Seq
 
 class InstanceOpFactoryHelper(
     private val metrics: Metrics,
@@ -18,29 +21,36 @@ class InstanceOpFactoryHelper(
 
   def provision(
     taskInfo: Mesos.TaskInfo,
-    newTask: Task,
-    instance: Instance): InstanceOp.LaunchTask = {
+    instanceId: Instance.Id,
+    agentInfo: Instance.AgentInfo,
+    runSpecVersion: Timestamp,
+    task: Task,
+    now: Timestamp): InstanceOp.LaunchTask = {
 
-    assume(newTask.taskId.mesosTaskId == taskInfo.getTaskId, "marathon task id and mesos task id must be equal")
+    assume(task.taskId.mesosTaskId == taskInfo.getTaskId, "marathon task id and mesos task id must be equal")
 
     def createOperations = Seq(offerOperationFactory.launch(taskInfo))
 
-    val stateOp = InstanceUpdateOperation.Provision(instance)
+    val stateOp = InstanceUpdateOperation.Provision(instanceId, agentInfo, runSpecVersion, Seq(task), now)
     InstanceOp.LaunchTask(taskInfo, stateOp, oldInstance = None, createOperations)
   }
 
   def provision(
     executorInfo: Mesos.ExecutorInfo,
     groupInfo: Mesos.TaskGroupInfo,
-    launched: Instance.LaunchRequest): InstanceOp.LaunchTaskGroup = {
+    instanceId: Instance.Id,
+    agentInfo: Instance.AgentInfo,
+    runSpecVersion: Timestamp,
+    tasks: Seq[Task],
+    now: Timestamp): InstanceOp.LaunchTaskGroup = {
 
     assume(
-      executorInfo.getExecutorId.getValue == launched.instance.instanceId.executorIdString,
+      executorInfo.getExecutorId.getValue == instanceId.executorIdString,
       "marathon pod instance id and mesos executor id must be equal")
 
     def createOperations = Seq(offerOperationFactory.launch(executorInfo, groupInfo))
 
-    val stateOp = InstanceUpdateOperation.Provision(launched.instance)
+    val stateOp = InstanceUpdateOperation.Provision(instanceId, agentInfo, runSpecVersion, tasks, now)
     InstanceOp.LaunchTaskGroup(executorInfo, groupInfo, stateOp, oldInstance = None, createOperations)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -10,8 +10,6 @@ import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos.{Protos => Mesos}
 
-import scala.collection.immutable.Seq
-
 class InstanceOpFactoryHelper(
     private val metrics: Metrics,
     private val principalOpt: Option[String],

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -97,8 +97,14 @@ class InstanceOpFactoryImpl(
         val agentInfo = Instance.AgentInfo(offer)
         val taskIDs: Seq[Task.Id] = groupInfo.getTasksList.map { t => Task.Id(t.getTaskId) }(collection.breakOut)
         val now = clock.now()
-        val instanceOp = taskOperationFactory.provision(executorInfo, groupInfo, scheduledInstance.instanceId, agentInfo, pod.version, Tasks.provisioned(taskIDs, agentInfo, hostPorts, pod, now), now)
-        OfferMatchResult.Match(pod, offer, instanceOp, clock.now())
+        val instanceOp = taskOperationFactory.provision(
+          executorInfo,
+          groupInfo,
+          scheduledInstance.instanceId,
+          agentInfo,
+          pod.version,
+          Tasks.provisioned(taskIDs, agentInfo, hostPorts, pod, now), now)
+        OfferMatchResult.Match(pod, offer, instanceOp, now)
       case matchesNot: ResourceMatchResponse.NoMatch =>
         OfferMatchResult.NoMatch(pod, offer, matchesNot.reasons, clock.now())
     }
@@ -131,9 +137,15 @@ class InstanceOpFactoryImpl(
 
         val agentInfo = AgentInfo(offer)
 
-        val instanceOp = taskOperationFactory.provision(taskInfo, scheduledInstance.instanceId, agentInfo, app.version, Task.provisioned(taskId, networkInfo, app.version, clock.now()), clock.now())
+        val now = clock.now()
+        val instanceOp = taskOperationFactory.provision(
+          taskInfo,
+          scheduledInstance.instanceId,
+          agentInfo,
+          app.version,
+          Task.provisioned(taskId, networkInfo, app.version, now), now)
 
-        OfferMatchResult.Match(app, offer, instanceOp, clock.now())
+        OfferMatchResult.Match(app, offer, instanceOp, now)
       case matchesNot: ResourceMatchResponse.NoMatch => OfferMatchResult.NoMatch(app, offer, matchesNot.reasons, clock.now())
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.core.instance.{Instance, LocalVolume, LocalVolumeId, 
 import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.plugin.scheduler.SchedulerPlugin
@@ -96,8 +96,8 @@ class InstanceOpFactoryImpl(
 
         val agentInfo = Instance.AgentInfo(offer)
         val taskIDs: Seq[Task.Id] = groupInfo.getTasksList.map { t => Task.Id(t.getTaskId) }(collection.breakOut)
-        val instance = scheduledInstance.provisioned(agentInfo, hostPorts, pod, taskIDs, clock.now())
-        val instanceOp = taskOperationFactory.provision(executorInfo, groupInfo, Instance.LaunchRequest(instance))
+        val now = clock.now()
+        val instanceOp = taskOperationFactory.provision(executorInfo, groupInfo, scheduledInstance.instanceId, agentInfo, pod.version, Tasks.provisioned(taskIDs, agentInfo, hostPorts, pod, now), now)
         OfferMatchResult.Match(pod, offer, instanceOp, clock.now())
       case matchesNot: ResourceMatchResponse.NoMatch =>
         OfferMatchResult.NoMatch(pod, offer, matchesNot.reasons, clock.now())
@@ -131,8 +131,7 @@ class InstanceOpFactoryImpl(
 
         val agentInfo = AgentInfo(offer)
 
-        val provisionedInstance = scheduledInstance.provisioned(agentInfo, networkInfo, app, clock.now(), taskId)
-        val instanceOp = taskOperationFactory.provision(taskInfo, provisionedInstance.appTask, provisionedInstance)
+        val instanceOp = taskOperationFactory.provision(taskInfo, scheduledInstance.instanceId, agentInfo, app.version, Task.provisioned(taskId, networkInfo, app.version, clock.now()), clock.now())
 
         OfferMatchResult.Match(app, offer, instanceOp, clock.now())
       case matchesNot: ResourceMatchResponse.NoMatch => OfferMatchResult.NoMatch(app, offer, matchesNot.reasons, clock.now())
@@ -269,7 +268,7 @@ class InstanceOpFactoryImpl(
             .build(offer, resourceMatch, Some(volumeMatch))
 
         val now = clock.now()
-        val stateOp = InstanceUpdateOperation.Provision(reservedInstance.provisioned(agentInfo, networkInfo, app, now, newTaskId))
+        val stateOp = InstanceUpdateOperation.Provision(reservedInstance.instanceId, agentInfo, app.version, Seq(Task.provisioned(newTaskId, networkInfo, app.version, now)), now)
 
         taskOperationFactory.launchOnReservation(taskInfo, stateOp, reservedInstance)
 
@@ -303,7 +302,8 @@ class InstanceOpFactoryImpl(
         val (executorInfo, groupInfo, hostPorts) = TaskGroupBuilder.build(pod, offer,
           instanceId, podContainerTaskIds, builderConfig, runSpecTaskProc, resourceMatch, Some(volumeMatch))
 
-        val stateOp = InstanceUpdateOperation.Provision(reservedInstance.provisioned(agentInfo, hostPorts, pod, podContainerTaskIds, clock.now()))
+        val now = clock.now()
+        val stateOp = InstanceUpdateOperation.Provision(reservedInstance.instanceId, agentInfo, pod.version, Tasks.provisioned(podContainerTaskIds, agentInfo, hostPorts, pod, now), now)
 
         taskOperationFactory.launchOnReservation(executorInfo, groupInfo, stateOp, reservedInstance)
     }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -349,9 +349,10 @@ private class TaskLauncherActor(
 
     // Mark instance in internal map as provisioned
     instanceOp.stateOp match {
-      case InstanceUpdateOperation.Provision(instance) =>
-        assert(instanceMap.contains(instance.instanceId), s"Internal task launcher state did not include provisioned instance ${instance.instanceId}")
-        instanceMap += instance.instanceId -> instance
+      case InstanceUpdateOperation.Provision(instanceId, agentInfo, runSpecVersion, tasks, now) =>
+        assert(instanceMap.contains(instanceId), s"Internal task launcher state did not include newly provisioned instance $instanceId")
+        val existingInstance = instanceMap(instanceId)
+        instanceMap += instanceId -> existingInstance.provisioned(agentInfo, runSpecVersion, tasks, now)
         scheduleTaskOpTimeout(context, instanceOp)
         logger.info(s"Updated instance map to ${instanceMap.values.map(i => i.instanceId -> i.state.condition)}")
       case InstanceUpdateOperation.Reserve(instance) =>

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -21,8 +21,6 @@ import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.core.task.Task.Id
 import play.api.libs.json._
 
-import scala.collection.immutable.Seq
-
 /**
   * The state for launching a task. This might be a launched task or a reservation for launching a task or both.
   * Here a task is Reserved or LaunchedOnReservation only if the corresponding instance has a reservation.

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -470,6 +470,12 @@ object Task {
 
   implicit val taskFormat: Format[Task] = Json.format[Task]
 
+  /**
+    * Creates a new artificial task with the `Provisioned` condition that's used when provisioning an instance
+    * This method is used only for apps right now because of a different way we deal with NetworkInfo for apps and pods
+    *
+    * @return new task with condition Provisioned
+    */
   def provisioned(taskId: Id, networkInfo: NetworkInfo, appVersion: Timestamp, now: Timestamp): Task = {
     Task(
       taskId = taskId,
@@ -480,6 +486,12 @@ object Task {
 }
 
 object Tasks {
+  /**
+    * Creates a new artificial tasks with the `Provisioned` condition that are used when provisioning an instance
+    * This method is used only for pods right now because of a different way we deal with NetworkInfo for apps and pods
+    *
+    * @return new task with condition Provisioned
+    */
   def provisioned(taskIds: Seq[Id], agentInfo: Instance.AgentInfo, hostPorts: Seq[Option[Int]], pod: PodDefinition, now: Timestamp): Seq[Task] = {
     val taskNetworkInfos = podTaskNetworkInfos(pod, agentInfo, taskIds, hostPorts)
 

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.Terminal
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.pod.MesosContainer
+import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition}
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.update.TaskUpdateEffect
 import mesosphere.marathon.state._
@@ -18,7 +18,10 @@ import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.concurrent.duration.FiniteDuration
 import mesosphere.marathon.api.v2.json.Formats._
+import mesosphere.marathon.core.task.Task.Id
 import play.api.libs.json._
+
+import scala.collection.immutable.Seq
 
 /**
   * The state for launching a task. This might be a launched task or a reservation for launching a task or both.
@@ -468,4 +471,64 @@ object Task {
   }
 
   implicit val taskFormat: Format[Task] = Json.format[Task]
+
+  def provisioned(taskId: Id, networkInfo: NetworkInfo, appVersion: Timestamp, now: Timestamp): Task = {
+    Task(
+      taskId = taskId,
+      runSpecVersion = appVersion,
+      status = Task.Status(stagedAt = now, condition = Condition.Provisioned, networkInfo = networkInfo)
+    )
+  }
+}
+
+object Tasks {
+  def provisioned(taskIds: Seq[Id], agentInfo: Instance.AgentInfo, hostPorts: Seq[Option[Int]], pod: PodDefinition, now: Timestamp): Seq[Task] = {
+    val taskNetworkInfos = podTaskNetworkInfos(pod, agentInfo, taskIds, hostPorts)
+
+    taskIds.map { taskId =>
+      // the task level host ports are needed for fine-grained status/reporting later on
+      val networkInfo = taskNetworkInfos.getOrElse(
+        taskId,
+        throw new IllegalStateException("failed to retrieve a task network info"))
+      Task(
+        taskId = taskId,
+        runSpecVersion = pod.version,
+        status = Task.Status(stagedAt = now, condition = Condition.Provisioned, networkInfo = networkInfo)
+      )
+    }
+  }
+
+  private def podTaskNetworkInfos(
+    pod: PodDefinition,
+    agentInfo: Instance.AgentInfo,
+    taskIDs: Seq[Id],
+    hostPorts: Seq[Option[Int]]
+  ): Map[Id, NetworkInfo] = {
+
+    val reqPortsByCTName: Seq[(String, Option[Int])] = pod.containers.flatMap { ct =>
+      ct.endpoints.map { ep =>
+        ct.name -> ep.hostPort
+      }
+    }
+
+    val totalRequestedPorts = reqPortsByCTName.size
+    require(totalRequestedPorts == hostPorts.size, s"expected that number of allocated ports ${hostPorts.size}" +
+      s" would equal the number of requested host ports $totalRequestedPorts")
+
+    require(!hostPorts.flatten.contains(0), "expected that all dynamic host ports have been allocated")
+
+    val allocPortsByCTName: Seq[(String, Int)] = reqPortsByCTName.zip(hostPorts).collect {
+      case ((name, Some(_)), Some(allocatedPort)) => name -> allocatedPort
+    }(collection.breakOut)
+
+    taskIDs.map { taskId =>
+      // the task level host ports are needed for fine-grained status/reporting later on
+      val taskHostPorts: Seq[Int] = taskId.containerName.map { ctName =>
+        allocPortsByCTName.withFilter { case (name, port) => name == ctName }.map(_._2)
+      }.getOrElse(Seq.empty[Int])
+
+      val networkInfo = NetworkInfo(agentInfo.host, taskHostPorts, ipAddresses = Nil)
+      taskId -> networkInfo
+    }(collection.breakOut)
+  }
 }

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -16,8 +16,9 @@ import mesosphere.marathon.core.matcher.DummyOfferMatcherManager
 import mesosphere.marathon.core.matcher.base.util.OfferMatcherSpec
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
+import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-import mesosphere.marathon.state.PathId
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.{AkkaUnitTest, WaitTestSupport}
 import org.mockito.Matchers
@@ -121,18 +122,17 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
 
   class Fixture extends AutoCloseable {
     val app = MarathonTestHelper.makeBasicApp().copy(id = PathId("/app"))
+    val scheduledInstance = Instance.scheduled(app)
+    val task: Task = Task.provisioned(Task.Id.forInstanceId(scheduledInstance.instanceId), NetworkInfoPlaceholder(), app.version, Timestamp.now())
+    val mesosTask = MarathonTestHelper.makeOneCPUTask(task.taskId).build()
 
     val offer = MarathonTestHelper.makeBasicOffer().build()
-    val runspecId = PathId("/test")
-    val instance = TestInstanceBuilder.newBuilder(runspecId).addTaskWithBuilder().taskRunning().build().getInstance()
-    val task: Task = instance.appTask
 
-    val mesosTask = MarathonTestHelper.makeOneCPUTask(task.taskId).build()
-    val scheduledInstance = Instance.scheduled(app)
-    val launchTaskInstanceOp = LaunchTask(mesosTask, InstanceUpdateOperation.Provision(scheduledInstance), Some(scheduledInstance), Seq.empty)
+    val provisionOp = InstanceUpdateOperation.Provision(scheduledInstance.instanceId, AgentInfoPlaceholder(), app.version, Seq(Task.provisioned(Task.Id.forInstanceId(scheduledInstance.instanceId), NetworkInfoPlaceholder(), app.version, Timestamp.now())), Timestamp.now())
+    val launchTaskInstanceOp = LaunchTask(mesosTask, provisionOp, Some(scheduledInstance), Seq.empty)
     val instanceChange = TaskStatusUpdateTestHelper(
-      operation = InstanceUpdateOperation.Provision(instance),
-      effect = InstanceUpdateEffect.Update(instance = instance, oldState = None, events = Nil)).wrapped
+      operation = provisionOp,
+      effect = InstanceUpdateEffect.Update(instance = scheduledInstance.provisioned(AgentInfoPlaceholder(), app.version, Seq(Task.provisioned(Task.Id.forInstanceId(scheduledInstance.instanceId), NetworkInfoPlaceholder(), app.version, Timestamp.now())), Timestamp.now()), oldState = None, events = Nil)).wrapped
 
     lazy val clock: Clock = Clock.systemUTC()
     val noMatchResult = OfferMatchResult.NoMatch(app, offer, Seq.empty, clock.now())

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -5,9 +5,8 @@ import java.time.Clock
 import akka.Done
 import akka.stream.scaladsl.Source
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.core.instance.TestInstanceBuilder._
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launcher.InstanceOp.LaunchTask
 import mesosphere.marathon.core.launcher.{InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.launchqueue.LaunchQueueModule

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -127,7 +127,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
 
     val offer = MarathonTestHelper.makeBasicOffer().build()
 
-    val provisionOp = InstanceUpdateOperation.Provision(scheduledInstance.instanceId, AgentInfoPlaceholder(), app.version, Seq(Task.provisioned(Task.Id.forInstanceId(scheduledInstance.instanceId), NetworkInfoPlaceholder(), app.version, Timestamp.now())), Timestamp.now())
+    val provisionOp = InstanceUpdateOperation.Provision(scheduledInstance.instanceId, AgentInfoPlaceholder(), app.version, Seq(task), Timestamp.now())
     val launchTaskInstanceOp = LaunchTask(mesosTask, provisionOp, Some(scheduledInstance), Seq.empty)
     val instanceChange = TaskStatusUpdateTestHelper(
       operation = provisionOp,

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -7,7 +7,6 @@ import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.{Health, HealthCheck, MesosCommandHealthCheck}
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.Provision
 import mesosphere.marathon.core.instance.{Instance, TestTaskBuilder}
 import mesosphere.marathon.core.leadership.{AlwaysElectedLeadershipModule, LeadershipModule}
 import mesosphere.marathon.core.task.Task
@@ -52,27 +51,15 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
     )
   }
 
-  def makeRunningTask(appId: PathId, version: Timestamp)(implicit instanceTracker: InstanceTracker): (Instance.Id, Task.Id) = {
-    val instance = Instance.scheduled(AppDefinition(appId, versionInfo = VersionInfo.forNewConfig(version)))
-    val (taskId, _) = instance.tasksMap.head
-    val taskStatus = TestTaskBuilder.Helper.runningTask(instance.instanceId).status.mesosStatus.get
-
-    instanceTracker.process(Provision(instance)).futureValue
-    instanceTracker.updateStatus(instance, taskStatus, clock.now()).futureValue
-
-    (instance.instanceId, taskId)
-  }
-
   def setupTrackerWithProvisionedInstance(appId: PathId, version: Timestamp, instanceTracker: InstanceTracker): Future[Instance] = async {
     val app = AppDefinition(appId, versionInfo = VersionInfo.OnlyVersion(version))
     val scheduledInstance = Instance.scheduled(app)
     // schedule
     await(instanceTracker.schedule(scheduledInstance))
     // provision
-    val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), NetworkInfoPlaceholder(), app, Timestamp.now(), Task.Id.forInstanceId(scheduledInstance.instanceId))
-    await(instanceTracker.process(InstanceUpdateOperation.Provision(provisionedInstance)))
+    await(instanceTracker.process(InstanceUpdateOperation.Provision(scheduledInstance.instanceId, AgentInfoPlaceholder(), version, Seq(Task.provisioned(Task.Id.forInstanceId(scheduledInstance.instanceId), NetworkInfoPlaceholder(), version, Timestamp.now())), Timestamp.now())))
 
-    provisionedInstance
+    await(instanceTracker.get(scheduledInstance.instanceId)).get
   }
 
   def setupTrackerWithRunningInstance(appId: PathId, version: Timestamp, instanceTracker: InstanceTracker): Future[Instance] = async {

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -247,7 +247,7 @@ class InstanceUpdaterTest extends UnitTest {
     val app = new AppDefinition(PathId("/test"))
     val scheduledInstance = Instance.scheduled(app)
     val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)
-    val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), NetworkInfoPlaceholder(), app, Timestamp.now(f.clock), taskId)
+    val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), app.version, Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now(f.clock))), Timestamp.now(f.clock))
     val withStoppedGoal = provisionedInstance.copy(state = provisionedInstance.state.copy(goal = Goal.Stopped))
 
     val mesosTaskStatus = MesosTaskStatusTestHelper.killed(taskId)
@@ -326,7 +326,7 @@ class InstanceUpdaterTest extends UnitTest {
 
     val app = AppDefinition(PathId("/test"))
     val scheduledReserved = TestInstanceBuilder.scheduledWithReservation(app)
-    val provisionedInstance = scheduledReserved.provisioned(f.agentInfo, NetworkInfoPlaceholder(), app, Timestamp(f.clock.instant()), f.taskId)
+    val provisionedInstance = scheduledReserved.provisioned(f.agentInfo, app.version, Seq(Task.provisioned(f.taskId, NetworkInfoPlaceholder(), app.version, Timestamp(f.clock.instant()))), Timestamp(f.clock.instant()))
     val killedOperation = InstanceUpdateOperation.MesosUpdate(provisionedInstance, Condition.Killed, MesosTaskStatusTestHelper.killed(f.taskId), Timestamp(f.clock.instant()))
     val updated = InstanceUpdater.mesosUpdate(provisionedInstance, killedOperation).asInstanceOf[Update]
 

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition}
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.Task.{EphemeralOrReservedTaskId, ResidentTaskId}
 import mesosphere.marathon.raml.{Endpoint, Resources}
 import mesosphere.marathon.state.PathId
@@ -27,7 +27,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, tc.hostPortsAllocatedFromOffer, pod, tc.taskIDs, clock.now())
+        agentInfo, pod.version, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -38,7 +38,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, tc.hostPortsAllocatedFromOffer, pod, tc.taskIDs, clock.now())
+        agentInfo, pod.version, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -49,7 +49,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, tc.hostPortsAllocatedFromOffer, pod, tc.taskIDs, clock.now())
+        agentInfo, pod.version, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -65,7 +65,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, tc.hostPortsAllocatedFromOffer, pod, tc.taskIDs, clock.now())
+        agentInfo, pod.version, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -81,7 +81,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, tc.hostPortsAllocatedFromOffer, pod, tc.taskIDs, clock.now())
+        agentInfo, pod.version, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -97,7 +97,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(tc.pod, tc.instanceId).provisioned(
-        agentInfo, tc.hostPortsAllocatedFromOffer, tc.pod, tc.taskIDs, clock.now())
+        agentInfo, pod.version, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
       check(tc, instance)
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/OfferProcessorImplTest.scala
@@ -107,7 +107,9 @@ class OfferProcessorImplTest extends UnitTest {
       Given("an offer")
       val dummySource = new DummySource
       val tasksWithSource = tasks.map {
-        case (taskInfo, task, instance) => InstanceOpWithSource(dummySource, f.provision(taskInfo, instance.instanceId, instance.agentInfo.get, instance.runSpecVersion, task, clock.now()))
+        case (taskInfo, task, Instance(instanceId, Some(agentInfo), _, _, runSpecVersion, _, _)) =>
+          val op = f.provision(taskInfo, instanceId, agentInfo, runSpecVersion, task, clock.now())
+          InstanceOpWithSource(dummySource, op)
       }
 
       And("a cooperative offerMatcher and taskTracker")
@@ -148,9 +150,10 @@ class OfferProcessorImplTest extends UnitTest {
         case (taskInfo, _, _) =>
           val dummyInstance = TestInstanceBuilder.scheduledWithReservation(AppDefinition(appId))
           val taskId = Task.Id(taskInfo.getTaskId)
+          val app = AppDefinition(appId)
           val launch = f.launchWithNewTask(
             taskInfo,
-            InstanceUpdateOperation.Provision(dummyInstance.instanceId, AgentInfoPlaceholder(), AppDefinition(appId).version, Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), AppDefinition(appId).version, clock.now())), clock.now()),
+            InstanceUpdateOperation.Provision(dummyInstance.instanceId, AgentInfoPlaceholder(), app.version, Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), app.version, clock.now())), clock.now()),
             dummyInstance
           )
           InstanceOpWithSource(dummySource, launch)

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.core.launcher.{InstanceOp, TaskLauncher}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.state.PathId
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.mesos.protos.Implicits._
@@ -29,7 +29,7 @@ class TaskLauncherImplTest extends UnitTest {
     val taskInfo = taskInfoBuilder.build()
     val instance = TestInstanceBuilder.newBuilderWithInstanceId(instanceId).addTaskWithBuilder().taskFromTaskInfo(taskInfo).build().getInstance()
     val task: Task = instance.appTask
-    new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role")).provision(taskInfo, task, instance)
+    new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role")).provision(taskInfo, instance.instanceId, instance.agentInfo.get, instance.runSpecVersion, task, Timestamp.now())
   }
   private[this] val appId = PathId("/test")
   private[this] val instanceId = Instance.Id.forRunSpec(appId)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -53,12 +53,12 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
     val app = AppDefinition(id = PathId("/testapp"))
     val scheduledInstance = Instance.scheduled(app)
     val taskId = Task.Id.forInstanceId(scheduledInstance.instanceId)
-    val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), NetworkInfoPlaceholder(), app, Timestamp.now(), taskId)
+    val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), app.version, Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now())), Timestamp.now())
     val runningInstance = TestInstanceBuilder.newBuilder(app.id, version = app.version, now = Timestamp.now()).addTaskRunning().getInstance()
     val marathonTask: Task = provisionedInstance.appTask
     val provisionedInstanceId = provisionedInstance.instanceId
     val taskInfo = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(provisionedInstanceId, None)).build()
-    val launch = LaunchTask(taskInfo, InstanceUpdateOperation.Provision(scheduledInstance), Some(scheduledInstance), Seq.empty)
+    val launch = LaunchTask(taskInfo, InstanceUpdateOperation.Provision(scheduledInstance.instanceId, AgentInfoPlaceholder(), app.version, Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now())), Timestamp.now()), Some(scheduledInstance), Seq.empty)
     val offer = MarathonTestHelper.makeBasicOffer().build()
     val noMatchResult = OfferMatchResult.NoMatch(app, offer, Seq.empty, Timestamp.now())
     val launchResult = OfferMatchResult.Match(app, offer, launch, Timestamp.now())
@@ -196,7 +196,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
       When("the launcher receives the update for the provisioned instance")
       val taskId = Task.Id.forInstanceId(f.scheduledInstance.instanceId)
-      val provisionedInstance = f.scheduledInstance.provisioned(TestInstanceBuilder.defaultAgentInfo, NetworkInfoPlaceholder(), f.app, clock.now(), taskId)
+      val provisionedInstance = f.scheduledInstance.provisioned(TestInstanceBuilder.defaultAgentInfo, f.app.version, Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), f.app.version, clock.now())), clock.now())
       val update = InstanceUpdated(provisionedInstance, Some(f.scheduledInstance.state), Seq.empty)
       // setting new state in instancetracker here
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.runningInstance, provisionedInstance))
@@ -359,7 +359,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
       val scheduledInstanceB = Instance.scheduled(f.app)
       val taskId = Task.Id.forInstanceId(scheduledInstanceB.instanceId)
-      val provisionedInstance = scheduledInstanceB.provisioned(TestInstanceBuilder.defaultAgentInfo, NetworkInfoPlaceholder(), f.app, clock.now(), taskId)
+      val provisionedInstance = scheduledInstanceB.provisioned(TestInstanceBuilder.defaultAgentInfo, f.app.version, Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), f.app.version, clock.now())), clock.now())
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.scheduledInstance, provisionedInstance))
 
       val launcherRef = createLauncherRef()

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerModuleTest.scala
@@ -16,7 +16,7 @@ import mesosphere.marathon.core.matcher.base.util.OfferMatcherSpec
 import mesosphere.marathon.core.matcher.manager.{OfferMatcherManagerConfig, OfferMatcherManagerModule}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.state.PathId
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.ResourceUtil
 import mesosphere.marathon.test.MarathonTestHelper
@@ -43,7 +43,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     val launch = new InstanceOpFactoryHelper(
       metrics,
       Some("principal"),
-      Some("role")).provision(_: Mesos.TaskInfo, _: Task, _: Instance)
+      Some("role")).provision(_: Mesos.TaskInfo, _: Instance.Id, _: Instance.AgentInfo, _: Timestamp, _: Task, _: Timestamp)
   }
 
   class Fixture {
@@ -81,7 +81,7 @@ class OfferMatcherManagerModuleTest extends AkkaUnitTest with OfferMatcherSpec {
       val opsWithSources = matchTasks(offer).map { taskInfo =>
         val instance = TestInstanceBuilder.newBuilderWithInstanceId(F.instanceId).addTaskWithBuilder().taskFromTaskInfo(taskInfo, offer).build().getInstance()
         val task: Task = instance.appTask
-        val launch = F.launch(taskInfo, task.copy(taskId = Task.Id(taskInfo.getTaskId)), instance)
+        val launch = F.launch(taskInfo, instance.instanceId, instance.agentInfo.get, instance.runSpecVersion, task.copy(taskId = Task.Id(taskInfo.getTaskId)), Timestamp.now())
         InstanceOpWithSource(Source, launch)
       }(collection.breakOut)
 

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -23,12 +23,6 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
     case _ => throw new scala.RuntimeException("the wrapped stateOp os no MesosUpdate!")
   }
 
-  private[this] def instanceFromOperation: Instance = operation match {
-    // case provision: InstanceUpdateOperation.Provision => provision.instance
-    case update: InstanceUpdateOperation.MesosUpdate => update.instance
-    case _ => throw new RuntimeException(s"Unable to fetch instance from ${operation.getClass.getSimpleName}")
-  }
-
   def reason: String = if (status.hasReason) status.getReason.toString else "no reason"
   def wrapped: InstanceChange = effect match {
     case InstanceUpdateEffect.Update(instance, old, events) => InstanceUpdated(instance, old.map(_.state), events)
@@ -38,7 +32,12 @@ class TaskStatusUpdateTestHelper(val operation: InstanceUpdateOperation, val eff
   def updatedInstance: Instance = effect match {
     case InstanceUpdateEffect.Update(instance, old, events) => instance
     case InstanceUpdateEffect.Expunge(instance, events) => instance
-    case _ => instanceFromOperation
+    case update: InstanceUpdateOperation.MesosUpdate => update.instance
+    case _ =>
+      operation match {
+        case update: InstanceUpdateOperation.MesosUpdate => update.instance
+        case _ => throw new RuntimeException(s"Unable to fetch instance from ${operation.getClass.getSimpleName}")
+      }
   }
 
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -6,8 +6,8 @@ import akka.actor.{Status, Terminated}
 import akka.testkit.{TestActorRef, TestProbe}
 import com.typesafe.config.ConfigFactory
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.update.{InstanceUpdateOpResolver, InstanceUpdateOperation}
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.TaskCondition
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.UpdateContext

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -7,7 +7,7 @@ import akka.testkit.{TestActorRef, TestProbe}
 import com.typesafe.config.ConfigFactory
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.instance.update.{InstanceUpdateOpResolver, InstanceUpdateOperation}
+import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.TaskCondition
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.UpdateContext
@@ -194,7 +194,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
 
         When("a new staged task gets added")
         val probe = TestProbe()
-        val helper = TaskStatusUpdateTestHelper.taskLaunchFor(scheduled, f.clock.now())
+        val helper = TaskStatusUpdateTestHelper.provision(scheduled, f.clock.now())
         val update = helper.operation
 
         probe.send(f.taskTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
@@ -222,7 +222,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         f.taskLoader.load() returns Future.successful(appDataMap)
 
         val probe = TestProbe()
-        val helper = TaskStatusUpdateTestHelper.taskLaunchFor(scheduled, f.clock.now())
+        val helper = TaskStatusUpdateTestHelper.provision(scheduled, f.clock.now())
         val update = UpdateContext(f.clock.now() + 3.days, helper.operation)
 
         When("Instance update is received")
@@ -241,25 +241,21 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val f = new Fixture
         Given("an task loader with one staged and two running instances")
         val appId: PathId = PathId("/app")
-        val staged = TestInstanceBuilder.newBuilder(appId).addTaskStaged().getInstance()
-        val runningOne = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
-        val runningTwo = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
-        val appDataMap = InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo)
+        val scheduled = Instance.scheduled(AppDefinition(appId))
+        val appDataMap = InstanceTracker.InstancesBySpec.forInstances(scheduled)
         f.taskLoader.load() returns Future.successful(appDataMap)
 
-        When("a new staged task gets added")
+        And("repository that returns error for store operation")
+        f.repository.store(any) returns Future.failed(new RuntimeException("fail"))
+
+        When("an update to provisioned is sent")
         val probe = TestProbe()
-        val instance = TestInstanceBuilder.newBuilder(appId).addTaskStaged().getInstance()
-        val helper = TaskStatusUpdateTestHelper.taskLaunchFor(instance, f.clock.now())
+        val helper = TaskStatusUpdateTestHelper.provision(scheduled, f.clock.now())
         val update = UpdateContext(f.clock.now() + 3.days, helper.operation)
 
-        And("repository store operation fails with no recovery")
-        f.repository.store(instance) returns Future.failed(new RuntimeException("fail"))
-
-        When("Instance update is received")
         probe.send(f.taskTrackerActor, update)
 
-        Then("Failure message is sent")
+        Then("Failure message is received")
         probe.fishForSpecificMessage() {
           case _: Status.Failure => true
           case _ => false

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -4,11 +4,11 @@ package core.task.tracker.impl
 import akka.Done
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.test.SettableClock
-import mesosphere.marathon.core.instance.TestInstanceBuilder
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.PathId
+import mesosphere.marathon.state.{AppDefinition, PathId}
 import mesosphere.marathon.test.MarathonTestHelper
 import org.apache.mesos.Protos.{TaskID, TaskStatus}
 import akka.actor.Status
@@ -31,12 +31,12 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
   }
 
   "InstanceTrackerDelegate" should {
-    "Provision succeeds" in {
+    "Schedule succeeds" in {
       val f = new Fixture
       val appId: PathId = PathId("/test")
-      val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
-      val stateOp = InstanceUpdateOperation.Provision(instance)
-      val expectedStateChange = InstanceUpdateEffect.Update(instance, None, events = Nil)
+      val scheduledInstance = Instance.scheduled(AppDefinition(appId))
+      val stateOp = InstanceUpdateOperation.Schedule(scheduledInstance)
+      val expectedStateChange = InstanceUpdateEffect.Update(scheduledInstance, None, events = Nil)
 
       When("process is called")
       val create = f.delegate.process(stateOp)
@@ -52,11 +52,11 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       create.futureValue shouldBe a[InstanceUpdateEffect.Update]
     }
 
-    "provisioning fails but the update stream keeps working" in {
+    "schedule fails but the update stream keeps working" in {
       val f = new Fixture
       val appId: PathId = PathId("/test")
-      val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId).getInstance()
-      val stateOp = InstanceUpdateOperation.Provision(instance)
+      val scheduledInstance = Instance.scheduled(AppDefinition(appId))
+      val stateOp = InstanceUpdateOperation.Schedule(scheduledInstance)
 
       When("process is called")
       val streamTerminated: Future[Done] = f.delegate.queue.watchCompletion()

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryHelperTest.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.launcher.impl.InstanceOpFactoryHelper
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.state.PathId
+import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.test.MarathonTestHelper
 import org.apache.mesos.{Protos => Mesos}
 
@@ -35,7 +35,7 @@ class InstanceOpFactoryHelperTest extends UnitTest {
 
       When("We create a launch operation")
       val error = intercept[AssertionError] {
-        f.helper.provision(taskInfo, task, instance)
+        f.helper.provision(taskInfo, instance.instanceId, instance.agentInfo.get, instance.runSpecVersion, task, Timestamp.now())
       }
 
       Then("An exception is thrown")
@@ -51,10 +51,11 @@ class InstanceOpFactoryHelperTest extends UnitTest {
       val taskInfo = MarathonTestHelper.makeOneCPUTask(task.taskId).build()
 
       When("We create a launch operation")
-      val launch = f.helper.provision(taskInfo, task, instance)
+      val now = Timestamp.now()
+      val launch = f.helper.provision(taskInfo, instance.instanceId, instance.agentInfo.get, instance.runSpecVersion, task, now)
 
       Then("The result is as expected")
-      launch.stateOp shouldEqual InstanceUpdateOperation.Provision(instance)
+      launch.stateOp shouldEqual InstanceUpdateOperation.Provision(instance.instanceId, instance.agentInfo.get, instance.runSpecVersion, Seq(task), now)
       launch.taskInfo shouldEqual taskInfo
       launch.oldInstance shouldBe empty
       launch.offerOperations should have size 1

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -67,7 +67,8 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       )
 
       val expectedState = instance.state.copy(condition = Condition.Provisioned)
-      assert(matched.instanceOp.stateOp == InstanceUpdateOperation.Provision(expectedTaskId.instanceId, expectedAgentInfo, app.version, Seq(expectedTask), expectedState.since))
+      val provisionOp = InstanceUpdateOperation.Provision(expectedTaskId.instanceId, expectedAgentInfo, app.version, Seq(expectedTask), expectedState.since)
+      matched.instanceOp.stateOp should be(provisionOp)
     }
 
     "Normal app -> None (insufficient offer)" in {

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -67,10 +67,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       )
 
       val expectedState = instance.state.copy(condition = Condition.Provisioned)
-      val expectedInstance = Instance(
-        expectedTaskId.instanceId, Some(expectedAgentInfo), expectedState, Map(expectedTaskId -> expectedTask),
-        runSpecVersion = app.version, app.unreachableStrategy, None)
-      assert(matched.instanceOp.stateOp == InstanceUpdateOperation.Provision(expectedInstance))
+      assert(matched.instanceOp.stateOp == InstanceUpdateOperation.Provision(expectedTaskId.instanceId, expectedAgentInfo, app.version, Seq(expectedTask), expectedState.since))
     }
 
     "Normal app -> None (insufficient offer)" in {
@@ -227,8 +224,8 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
             case launchTask: InstanceOp.LaunchTask =>
               inside(launchTask.stateOp) {
                 case provision: InstanceUpdateOperation.Provision =>
-                  provision.instance.agentInfo.get.host shouldBe updatedHostName
-                  provision.instance.agentInfo.get.agentId shouldBe Some(updatedAgentId)
+                  provision.agentInfo.host shouldBe updatedHostName
+                  provision.agentInfo.agentId shouldBe Some(updatedAgentId)
               }
           }
       }

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -55,7 +55,6 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
 
       val deserializedInstance = instanceTracker.instance(originalInstance.instanceId).futureValue
 
-      deserializedInstance should not be empty
       deserializedInstance should equal(Some(originalInstance))
     }
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -4,7 +4,7 @@ package tasks
 import akka.stream.scaladsl.Sink
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
-import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.{Provision, Schedule}
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.Schedule
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore


### PR DESCRIPTION
Summary:
InstanceUpdateOperation `Provision` contained the whole instance. Instance update operations might be queued so it might happen that once the update is applied, that instance we enqueued is already obsolete and the instance changed (e.g. the goal changed).

With this change we always work with the newest instance while applying provision update.

JIRA issues: MARATHON-8516
