### PR TITLE
Fix handling of the missing dcos certificate in SI tests

### DIFF
--- a/tests/shakedown/shakedown/clients/cli.py
+++ b/tests/shakedown/shakedown/clients/cli.py
@@ -44,9 +44,7 @@ def run_dcos_command(command, raise_on_error=False, print_output=True):
     print("\n>>{}\n".format(' '.join(call)))
 
     proc = subprocess.Popen(call, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    print('start communication')
     output, error = proc.communicate()
-    print('wait for return code...')
     return_code = proc.wait()
     stdout = output.decode('utf-8')
     stderr = error.decode('utf-8')

--- a/tests/shakedown/shakedown/clients/rpcclient.py
+++ b/tests/shakedown/shakedown/clients/rpcclient.py
@@ -32,7 +32,7 @@ def load_error_json_schema():
 
 
 def get_ca_file():
-    return Path(environ.get('DCOS_SSL_VERIFY'))
+    return None if 'DCOS_SSL_VERIFY' not in environ else Path(environ.get('DCOS_SSL_VERIFY'))
 
 
 def get_ssl_context():
@@ -44,7 +44,7 @@ def get_ssl_context():
 
     """
     cafile = get_ca_file()
-    if cafile.is_file():
+    if cafile and cafile.is_file():
         logger.info('Provide certificate %s', cafile)
         ssl_context = ssl.create_default_context(cafile=cafile)
         return ssl_context
@@ -61,7 +61,7 @@ def verify_ssl():
        * Path to ca certificate if one is found
     """
     cafile = get_ca_file()
-    if cafile.is_file():
+    if cafile and cafile.is_file():
         return str(cafile)
     else:
         return False


### PR DESCRIPTION
Previously an SI run would fail if `DCOS_SSL_VERIFY` would not be set properly. Additionally removed some unnecessary logging.