### PR TITLE
Enable Marathon 1.6 to start on Java 9+ BP

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,6 +1,5 @@
 -mem 8192
 -J-XX:MaxMetaspaceSize=512m
--J-XX:+UseConcMarkSweepGC
 -J-XX:+CMSClassUnloadingEnabled
 -J-server
 -J-XX:+CMSParallelRemarkEnabled

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,7 +93,10 @@ object Dependencies {
     Test.akkaHttpTestKit % "test",
     Test.junit % "test",
     Test.scalacheck % "test"
-  ) ++ Curator.all ++ Kamon.all).map(
+  ) ++ Curator.all
+    ++ Kamon.all
+    ++ Java9Compatibility.all
+  ).map(
     _.excludeAll(excludeSlf4jLog4j12)
      .excludeAll(excludeLog4j)
      .excludeAll(excludeJCL)
@@ -210,6 +213,18 @@ object Dependency {
   val servletApi = "javax.servlet" % "servlet-api" % V.ServletApi
   val uuidGenerator = "com.fasterxml.uuid" % "java-uuid-generator" % V.UUIDGenerator
   val wixAccord = "com.wix" %% "accord-core" % V.WixAccord
+
+  object Java9Compatibility {
+
+    val javaXAnnotationApi = "javax.annotation" % "javax.annotation-api" % "1.3.2" % "compile"
+
+    val jaxbApi = "javax.xml.bind" % "jaxb-api" % "2.3.1" % "compile"
+
+    val all: Seq[ModuleID] = Seq(
+      javaXAnnotationApi,
+      jaxbApi
+    )
+  }
 
   object Curator {
     /**


### PR DESCRIPTION
Enable Marathon 1.6 to start on Java 9+ BP

Summary: in jdk9 javax.annotation is not present by default, and marathon can't start due to jersey requires it. This fix adds this dependency to our build.
Backport of #6688 

JIRA issues: MARATHON-8503
