### PR TITLE
Re-enable previously removed integration test

### DIFF
--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -97,7 +97,7 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       waitForStatusUpdates(StatusUpdate.TASK_FINISHED)
     }
 
-    "resident task is launched completely on reserved resources" ignore new Fixture {
+    "resident task is launched completely on reserved resources" in new Fixture {
       Given("A clean state of the cluster since we check reserved resources")
       cleanUp()
 
@@ -124,7 +124,6 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
       Then("there are no used resources anymore but there are the same reserved resources")
       val state2: RestResult[ITMesosState] = mesos.state
 
-      // TODO(karsten): This fails because we also restart an instance in a reserved state. See MARATHON-8208 for a fix.
       withClue("used_resources") {
         state2.value.agents.head.usedResources should be(empty)
       }


### PR DESCRIPTION
It was put to ignore during phase 2 and never revived. Thanks @zen-dog 