### PR TITLE
Use distinct exist code for the incompatible LibMesos version

### DIFF
--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -19,4 +19,5 @@ help you figure out why the Marathon process stopped.
 |106        | `MesosSchedulerError` - The Mesos scheduler driver had an error      |
 |107        | `UncaughtException` - An internal unknown error could not be handled |
 |108        | The Framework ID could not be read.                                  |
+|109        | Provided LibMesos version is incompatible.                           |
 |137        | Killed by an external process or uncaught exception                  |

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -33,7 +33,7 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
     logger.info(s"Successfully loaded libmesos: version ${LibMesos.version}")
   } else {
     logger.error(s"Failed to load libmesos: ${LibMesos.version}")
-    System.exit(1)
+    System.exit(CrashStrategy.IncompatibleLibMesos.code)
   }
 
   val cliConf = new AllConf(args)

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -22,6 +22,7 @@ object CrashStrategy {
   case object MesosSchedulerError extends Reason { override val code: Int = 106 }
   case object UncaughtException extends Reason { override val code: Int = 107 }
   case object FrameworkIdMissing extends Reason { override val code: Int = 108 }
+  case object IncompatibleLibMesos extends Reason { override val code: Int = 109 }
 }
 
 case object JvmExitsCrashStrategy extends CrashStrategy {

--- a/src/main/scala/mesosphere/mesos/LibMesos.scala
+++ b/src/main/scala/mesosphere/mesos/LibMesos.scala
@@ -37,7 +37,7 @@ object LibMesos extends StrictLogging {
     */
   def isCompatible: Boolean = {
     if (version < LibMesosMinimumVersion) {
-      logger.error(s"Found libmesos version ${version} is incompatible with minimum required version: $LibMesosMinimumVersion")
+      logger.error(s"Found libmesos version $version is incompatible with minimum required version: $LibMesosMinimumVersion")
     }
     version >= LibMesosMinimumVersion
   }

--- a/src/main/scala/mesosphere/mesos/LibMesos.scala
+++ b/src/main/scala/mesosphere/mesos/LibMesos.scala
@@ -9,9 +9,9 @@ object LibMesos extends StrictLogging {
   /**
     * The changelog should describe why this version is needed.
     */
-  val MesosMasterMinimumVersion = SemanticVersion(1, 5, 0)
+  val MesosMasterMinimumVersion: SemanticVersion = SemanticVersion(1, 5, 0)
 
-  val LibMesosMinimumVersion = MesosMasterMinimumVersion
+  val LibMesosMinimumVersion: SemanticVersion = MesosMasterMinimumVersion
 
   /**
     * Try to load the libmesos version.
@@ -35,7 +35,12 @@ object LibMesos extends StrictLogging {
   /**
     * Indicates if this version of libmesos is compatible
     */
-  def isCompatible: Boolean = version >= LibMesosMinimumVersion
+  def isCompatible: Boolean = {
+    if (version < LibMesosMinimumVersion) {
+      logger.error(s"Found libmesos version ${version} is incompatible with minimum required version: $LibMesosMinimumVersion")
+    }
+    version >= LibMesosMinimumVersion
+  }
 
   /**
     * Indicates if the given version of Mesos Master is compatible.


### PR DESCRIPTION
Summary:
The incompatible LibMesos version now has a distinct exist code `108`. Additionally improved logging in such case.