### PR TITLE
Unify app and pod provision command.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/EnrichedTask.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package core.appinfo
 
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.instance.{Instance, Reservation}

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -69,15 +69,13 @@ case class Instance(
     * Factory method for creating provisioned instance from Scheduled instance
     * @return new instance in a provisioned state
     */
-  def provisioned(agentInfo: Instance.AgentInfo, runSpec: RunSpec, tasks: Seq[Task], now: Timestamp): Instance = {
+  def provisioned(agentInfo: Instance.AgentInfo, runSpec: RunSpec, tasks: Map[Task.Id, Task], now: Timestamp): Instance = {
     require(isScheduled, s"Instance '$instanceId' must not be in state '${state.condition}'. Scheduled instance is required to create provisioned instance.")
 
     this.copy(
       agentInfo = Some(agentInfo),
       state = Instance.InstanceState(Condition.Provisioned, now, None, None, this.state.goal),
-      tasksMap = tasks.map { task =>
-        task.taskId -> task
-      }(collection.breakOut),
+      tasksMap = tasks,
       runSpec = runSpec
     )
   }

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -49,7 +49,7 @@ object InstanceUpdateOperation {
     * matched.
     *
     */
-  case class Provision(instanceId: Instance.Id, agentInfo: Instance.AgentInfo, runSpec: RunSpec, tasks: Seq[Task], now: Timestamp) extends InstanceUpdateOperation
+  case class Provision(instanceId: Instance.Id, agentInfo: Instance.AgentInfo, runSpec: RunSpec, tasks: Map[Task.Id, Task], now: Timestamp) extends InstanceUpdateOperation
 
   /**
     * Describes an instance update.

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryHelper.scala
@@ -5,9 +5,7 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory}
 import mesosphere.marathon.core.matcher.base.util.OfferOperationFactory
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.metrics.Metrics
-import mesosphere.marathon.state.{RunSpec, Timestamp}
 import org.apache.mesos.{Protos => Mesos}
 
 class InstanceOpFactoryHelper(
@@ -19,17 +17,10 @@ class InstanceOpFactoryHelper(
 
   def provision(
     taskInfo: Mesos.TaskInfo,
-    instanceId: Instance.Id,
-    agentInfo: Instance.AgentInfo,
-    runSpec: RunSpec,
-    task: Task,
-    now: Timestamp): InstanceOp.LaunchTask = {
-
-    assume(task.taskId.mesosTaskId == taskInfo.getTaskId, "marathon task id and Mesos task id must be equal")
+    stateOp: InstanceUpdateOperation.Provision): InstanceOp.LaunchTask = {
 
     def createOperations = Seq(offerOperationFactory.launch(taskInfo))
 
-    val stateOp = InstanceUpdateOperation.Provision(instanceId, agentInfo, runSpec, Seq(task), now)
     InstanceOp.LaunchTask(taskInfo, stateOp, oldInstance = None, createOperations)
   }
 
@@ -37,10 +28,7 @@ class InstanceOpFactoryHelper(
     executorInfo: Mesos.ExecutorInfo,
     groupInfo: Mesos.TaskGroupInfo,
     instanceId: Instance.Id,
-    agentInfo: Instance.AgentInfo,
-    runSpec: RunSpec,
-    tasks: Seq[Task],
-    now: Timestamp): InstanceOp.LaunchTaskGroup = {
+    stateOp: InstanceUpdateOperation.Provision): InstanceOp.LaunchTaskGroup = {
 
     assume(
       executorInfo.getExecutorId.getValue == instanceId.executorIdString,
@@ -48,7 +36,6 @@ class InstanceOpFactoryHelper(
 
     def createOperations = Seq(offerOperationFactory.launch(executorInfo, groupInfo))
 
-    val stateOp = InstanceUpdateOperation.Provision(instanceId, agentInfo, runSpec, tasks, now)
     InstanceOp.LaunchTaskGroup(executorInfo, groupInfo, stateOp, oldInstance = None, createOperations)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -83,19 +83,15 @@ class InstanceOpFactoryImpl(
         } else {
           pod.containers.map { container => Task.Id(instanceId, Some(container)) }
         }
-        val (executorInfo, groupInfo, hostPorts) = TaskGroupBuilder.build(pod, offer,
+        val (executorInfo, groupInfo, networkInfos) = TaskGroupBuilder.build(pod, offer,
           instanceId, taskIds, builderConfig, runSpecTaskProc, matches.resourceMatch, None)
 
         val agentInfo = Instance.AgentInfo(offer)
         val taskIDs: Seq[Task.Id] = groupInfo.getTasksList.map { t => Task.Id.parse(t.getTaskId) }(collection.breakOut)
         val now = clock.now()
-        val instanceOp = taskOperationFactory.provision(
-          executorInfo,
-          groupInfo,
-          scheduledInstance.instanceId,
-          agentInfo,
-          pod,
-          Tasks.provisioned(taskIDs, agentInfo, hostPorts, pod, now), now)
+        val tasks = Tasks.provisioned(taskIDs, networkInfos, pod.version, now)
+        val stateOp = InstanceUpdateOperation.Provision(instanceId, agentInfo, pod, tasks, now)
+        val instanceOp = taskOperationFactory.provision(executorInfo, groupInfo, scheduledInstance.instanceId, stateOp)
         OfferMatchResult.Match(pod, offer, instanceOp, now)
       case matchesNot: ResourceMatchResponse.NoMatch =>
         OfferMatchResult.NoMatch(pod, offer, matchesNot.reasons, clock.now())
@@ -133,12 +129,9 @@ class InstanceOpFactoryImpl(
         val agentInfo = AgentInfo(offer)
 
         val now = clock.now()
-        val instanceOp = taskOperationFactory.provision(
-          taskInfo,
-          scheduledInstance.instanceId,
-          agentInfo,
-          app,
-          Task.provisioned(taskId, networkInfo, app.version, now), now)
+        val task = Tasks.provisioned(Seq(taskId), Map(taskId -> networkInfo), app.version, now)
+        val stateOp = InstanceUpdateOperation.Provision(scheduledInstance.instanceId, agentInfo, scheduledInstance.runSpec, task, now)
+        val instanceOp = taskOperationFactory.provision(taskInfo, stateOp)
 
         OfferMatchResult.Match(app, offer, instanceOp, now)
       case matchesNot: ResourceMatchResponse.NoMatch => OfferMatchResult.NoMatch(app, offer, matchesNot.reasons, clock.now())
@@ -276,7 +269,7 @@ class InstanceOpFactoryImpl(
             .build(offer, resourceMatch, Some(volumeMatch))
 
         val now = clock.now()
-        val provisionedTasks = Seq(Task.provisioned(newTaskId, networkInfo, app.version, now))
+        val provisionedTasks = Tasks.provisioned(Seq(newTaskId), Map(newTaskId -> networkInfo), app.version, now)
         val stateOp = InstanceUpdateOperation.Provision(reservedInstance.instanceId, agentInfo, app, provisionedTasks, now)
 
         taskOperationFactory.launchOnReservation(taskInfo, stateOp, reservedInstance)
@@ -308,11 +301,11 @@ class InstanceOpFactoryImpl(
             s"failed to get a task ID for the given container name: ${container.name}"))
         }
 
-        val (executorInfo, groupInfo, hostPorts) = TaskGroupBuilder.build(pod, offer,
+        val (executorInfo, groupInfo, networkInfos) = TaskGroupBuilder.build(pod, offer,
           instanceId, podContainerTaskIds, builderConfig, runSpecTaskProc, resourceMatch, Some(volumeMatch))
 
         val now = clock.now()
-        val provisionedTasks = Tasks.provisioned(podContainerTaskIds, agentInfo, hostPorts, pod, now)
+        val provisionedTasks = Tasks.provisioned(podContainerTaskIds, networkInfos, pod.version, now)
         val stateOp = InstanceUpdateOperation.Provision(reservedInstance.instanceId, agentInfo, pod, provisionedTasks, now)
 
         taskOperationFactory.launchOnReservation(executorInfo, groupInfo, stateOp, reservedInstance)
@@ -343,21 +336,8 @@ class InstanceOpFactoryImpl(
     val reservation = Reservation(persistentVolumeIds, state)
     val agentInfo = Instance.AgentInfo(offer)
 
-    val (reservationLabels, stateOp) = runSpec match {
-      case _: AppDefinition =>
-        // The first taskId does not have an attempt count - this is only the task created to hold the reservation and it
-        // will be replaced with a new task once we launch on an existing reservation this way, the reservation will be
-        // labeled with a taskId that does not relate to a task existing in Mesos (previously, Marathon reused taskIds so
-        // there was always a 1:1 correlation from reservation to taskId)
-        val reservationLabels = TaskLabels.labelsForTask(frameworkId, Reservation.Id(scheduledInstance.instanceId))
-        val stateOp = InstanceUpdateOperation.Reserve(Instance.scheduled(scheduledInstance, reservation, agentInfo))
-        (reservationLabels, stateOp)
-
-      case pod: PodDefinition =>
-        val reservationLabels = TaskLabels.labelsForTask(frameworkId, Reservation.Id(scheduledInstance.instanceId))
-        val stateOp = InstanceUpdateOperation.Reserve(Instance.scheduled(scheduledInstance, reservation, agentInfo))
-        (reservationLabels, stateOp)
-    }
+    val reservationLabels = TaskLabels.labelsForTask(frameworkId, Reservation.Id(scheduledInstance.instanceId))
+    val stateOp = InstanceUpdateOperation.Reserve(Instance.scheduled(scheduledInstance, reservation, agentInfo))
     taskOperationFactory.reserveAndCreateVolumes(reservationLabels, stateOp, resourceMatch.resources, localVolumes)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition.Terminal
 import mesosphere.marathon.core.instance.{Instance, Reservation}
-import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition}
+import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.update.TaskUpdateEffect
 import mesosphere.marathon.state._
@@ -18,7 +18,6 @@ import org.apache.mesos.{Protos => MesosProtos}
 
 import scala.concurrent.duration.FiniteDuration
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.core.task.Task.Id
 import play.api.libs.json._
 
 /**
@@ -473,75 +472,37 @@ object Task {
 
   implicit val taskFormat: Format[Task] = Json.format[Task]
 
-  /**
-    * Creates a new artificial task with the `Provisioned` condition that's used when provisioning an instance
-    * This method is used only for apps right now because of a different way we deal with NetworkInfo for apps and pods
-    *
-    * @return new task with condition Provisioned
-    */
-  def provisioned(taskId: Id, networkInfo: NetworkInfo, appVersion: Timestamp, now: Timestamp): Task = {
-    Task(
-      taskId = taskId,
-      runSpecVersion = appVersion,
-      status = Task.Status(stagedAt = now, condition = Condition.Provisioned, networkInfo = networkInfo)
-    )
-  }
 }
 
 object Tasks {
   /**
     * Creates a new artificial tasks with the `Provisioned` condition that are used when provisioning an instance
-    * This method is used only for pods right now because of a different way we deal with NetworkInfo for apps and pods
     *
-    * @return new task with condition Provisioned
+    * @return new tasks with condition Provisioned
     */
-  def provisioned(taskIds: Seq[Id], agentInfo: Instance.AgentInfo, hostPorts: Seq[Option[Int]], pod: PodDefinition, now: Timestamp): Seq[Task] = {
-    val taskNetworkInfos = podTaskNetworkInfos(pod, agentInfo, taskIds, hostPorts)
-
+  def provisioned(taskIds: Seq[Task.Id], taskNetworkInfos: Map[Task.Id, NetworkInfo], version: Timestamp, now: Timestamp): Map[Task.Id, Task] = {
     taskIds.map { taskId =>
       // the task level host ports are needed for fine-grained status/reporting later on
       val networkInfo = taskNetworkInfos.getOrElse(
         taskId,
         throw new IllegalStateException("failed to retrieve a task network info"))
-      Task(
+      taskId -> Task(
         taskId = taskId,
-        runSpecVersion = pod.version,
+        runSpecVersion = version,
         status = Task.Status(stagedAt = now, condition = Condition.Provisioned, networkInfo = networkInfo)
       )
-    }
+    }(collection.breakOut)
   }
+  def provisioned(taskId: Task.Id, networkInfo: NetworkInfo, version: Timestamp, now: Timestamp): Map[Task.Id, Task] =
+    provisioned(Seq(taskId), Map(taskId -> networkInfo), version, now)
 
-  private def podTaskNetworkInfos(
-    pod: PodDefinition,
-    agentInfo: Instance.AgentInfo,
-    taskIDs: Seq[Id],
-    hostPorts: Seq[Option[Int]]
-  ): Map[Id, NetworkInfo] = {
-
-    val reqPortsByCTName: Seq[(String, Option[Int])] = pod.containers.flatMap { ct =>
-      ct.endpoints.map { ep =>
-        ct.name -> ep.hostPort
-      }
-    }
-
-    val totalRequestedPorts = reqPortsByCTName.size
-    require(totalRequestedPorts == hostPorts.size, s"expected that number of allocated ports ${hostPorts.size}" +
-      s" would equal the number of requested host ports $totalRequestedPorts")
-
-    require(!hostPorts.flatten.contains(0), "expected that all dynamic host ports have been allocated")
-
-    val allocPortsByCTName: Seq[(String, Int)] = reqPortsByCTName.zip(hostPorts).collect {
-      case ((name, Some(_)), Some(allocatedPort)) => name -> allocatedPort
-    }(collection.breakOut)
-
-    taskIDs.map { taskId =>
-      // the task level host ports are needed for fine-grained status/reporting later on
-      val taskHostPorts: Seq[Int] = taskId.containerName.map { ctName =>
-        allocPortsByCTName.withFilter { case (name, port) => name == ctName }.map(_._2)
-      }.getOrElse(Seq.empty[Int])
-
-      val networkInfo = NetworkInfo(agentInfo.host, taskHostPorts, ipAddresses = Nil)
-      taskId -> networkInfo
-    }(collection.breakOut)
+  /**
+    * Task extractor from [[mesosphere.marathon.core.instance.Instance.tasksMap]].
+    *
+    * See [[mesosphere.marathon.core.appinfo.EnrichedTask.singleFromInstance()]] for an example.
+    */
+  def unapplySeq(iter: Map[Task.Id, Task]): Option[Seq[Task]] = {
+    if (iter.nonEmpty) Some(iter.values.to[Seq])
+    else None
   }
 }

--- a/src/main/scala/mesosphere/marathon/package.scala
+++ b/src/main/scala/mesosphere/marathon/package.scala
@@ -1,6 +1,5 @@
 package mesosphere
 
-import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Timestamp
 
 /**
@@ -28,18 +27,6 @@ package object marathon {
 
   object NonEmpty {
     def unapply[I <: Iterable[_]](iter: I): Boolean = iter.nonEmpty
-  }
-
-  /**
-    * Task extractor from [[mesosphere.marathon.core.instance.Instance.tasksMap]].
-    *
-    * See [[mesosphere.marathon.core.appinfo.EnrichedTask.singleFromInstance()]] for an example.
-    */
-  object Tasks {
-    def unapplySeq(iter: Map[Task.Id, Task]): Option[Seq[Task]] = {
-      if (iter.nonEmpty) Some(iter.values.to[Seq])
-      else None
-    }
   }
 
   /**

--- a/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskGroupBuilder.scala
@@ -15,8 +15,10 @@ import mesosphere.marathon.tasks.PortsMatch
 import mesosphere.mesos.protos.Implicits._
 import org.apache.mesos.Protos.{DurationInfo, KillPolicy}
 import org.apache.mesos.{Protos => mesos}
-
 import java.util.concurrent.TimeUnit.SECONDS
+
+import mesosphere.marathon.core.task.state.NetworkInfo
+
 import scala.collection.immutable.Seq
 
 object TaskGroupBuilder extends StrictLogging {
@@ -42,7 +44,7 @@ object TaskGroupBuilder extends StrictLogging {
     runSpecTaskProcessor: RunSpecTaskProcessor,
     resourceMatch: ResourceMatcher.ResourceMatch,
     volumeMatchOption: Option[PersistentVolumeMatcher.VolumeMatch]
-  ): (mesos.ExecutorInfo, mesos.TaskGroupInfo, Seq[Option[Int]]) = {
+  ): (mesos.ExecutorInfo, mesos.TaskGroupInfo, Map[Task.Id, NetworkInfo]) = {
     val packedResources = binPackResources(podDefinition, resourceMatch.resources)
 
     val allEndpoints = podDefinition.containers.flatMap(_.endpoints)
@@ -83,7 +85,9 @@ object TaskGroupBuilder extends StrictLogging {
     // call all configured run spec customizers here (plugin)
     runSpecTaskProcessor.taskGroup(podDefinition, executorInfo, taskGroup)
 
-    (executorInfo.build, taskGroup.build, resourceMatch.hostPorts)
+    val networkInfos = buildTaskNetworkInfos(podDefinition, offer.getHostname, taskIds, resourceMatch.hostPorts)
+
+    (executorInfo.build, taskGroup.build, networkInfos)
   }
 
   // This method just double-checks that the matched resources are exactly
@@ -673,5 +677,39 @@ object TaskGroupBuilder extends StrictLogging {
       .setName(pod.id.toHostname)
       .setVisibility(org.apache.mesos.Protos.DiscoveryInfo.Visibility.FRAMEWORK)
       .build
+  }
+
+  def buildTaskNetworkInfos(
+    pod: PodDefinition,
+    host: String,
+    taskIDs: Seq[Task.Id],
+    hostPorts: Seq[Option[Int]]
+  ): Map[Task.Id, NetworkInfo] = {
+
+    val reqPortsByCTName: Seq[(String, Option[Int])] = pod.containers.flatMap { ct =>
+      ct.endpoints.map { ep =>
+        ct.name -> ep.hostPort
+      }
+    }
+
+    val totalRequestedPorts = reqPortsByCTName.size
+    require(totalRequestedPorts == hostPorts.size, s"expected that number of allocated ports ${hostPorts.size}" +
+      s" would equal the number of requested host ports $totalRequestedPorts")
+
+    require(!hostPorts.flatten.contains(0), "expected that all dynamic host ports have been allocated")
+
+    val allocPortsByCTName: Seq[(String, Int)] = reqPortsByCTName.zip(hostPorts).collect {
+      case ((name, Some(_)), Some(allocatedPort)) => name -> allocatedPort
+    }(collection.breakOut)
+
+    taskIDs.map { taskId =>
+      // the task level host ports are needed for fine-grained status/reporting later on
+      val taskHostPorts: Seq[Int] = taskId.containerName.map { ctName =>
+        allocPortsByCTName.withFilter { case (name, port) => name == ctName }.map(_._2)
+      }.getOrElse(Seq.empty[Int])
+
+      val networkInfo = NetworkInfo(host, taskHostPorts, ipAddresses = Nil)
+      taskId -> networkInfo
+    }(collection.breakOut)
   }
 }

--- a/src/test/scala/mesosphere/marathon/SchedulerDriverFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerDriverFactoryTest.scala
@@ -5,7 +5,6 @@ import mesosphere.marathon.core.base.CrashStrategy
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.metrics.dummy.DummyMetrics
-import mesosphere.marathon.state
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.storage.repository.{FrameworkIdRepository, InstanceRepository}
 import mesosphere.marathon.test.TestCrashStrategy

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -212,7 +212,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val app = App(
         id = "/app", cmd = Some("cmd"), container = Option(container),
         secrets = Map("pullConfigSecret" -> SecretDef("/config")))
-      val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
+      val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
       clock += 5.seconds
@@ -235,7 +235,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
           pullConfig = Option(DockerPullConfig("pullConfigSecret")))))
       val app = App(
         id = "/app", cmd = Some("cmd"), container = Option(container))
-      val (body, plan) = prepareApp(app, groupManager)
+      val (body, _) = prepareApp(app, groupManager)
 
       When("The create request is made")
       clock += 5.seconds
@@ -257,7 +257,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
           image = "private/image",
           pullConfig = Option(DockerPullConfig("pullConfigSecret")))))
       val app = App(id = "/app", cmd = Some("cmd"), container = Option(container))
-      val (body, plan) = prepareApp(app, groupManager)
+      val (body, _) = prepareApp(app, groupManager)
 
       When("The create request is made")
       clock += 5.seconds

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.core.health.{Health, HealthCheck, MesosCommandHealthC
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.instance.{Instance, TestTaskBuilder}
 import mesosphere.marathon.core.leadership.{AlwaysElectedLeadershipModule, LeadershipModule}
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerModule}
@@ -58,7 +58,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
     await(instanceTracker.schedule(scheduledInstance))
     // provision
     val now = Timestamp.now()
-    val provisionedTasks = Seq(Task.provisioned(Task.Id(scheduledInstance.instanceId), NetworkInfoPlaceholder(), version, now))
+    val provisionedTasks = Tasks.provisioned(Task.Id(scheduledInstance.instanceId), NetworkInfoPlaceholder(), version, now)
     val updateOperation = InstanceUpdateOperation.Provision(scheduledInstance.instanceId, AgentInfoPlaceholder(), app, provisionedTasks, now)
     val updateEffect = await(instanceTracker.process(updateOperation)).asInstanceOf[InstanceUpdateEffect.Update]
 

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -22,7 +22,6 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
     version: Timestamp = Timestamp(10),
     taskCondition: Condition = Condition.Staging): TestTaskBuilder = {
     val taskId = Task.Id.parse(taskInfo.getTaskId)
-    val instance = instanceBuilder.getInstance().copy(instanceId = taskId.instanceId)
     this.copy(task = Some(TestTaskBuilder.Helper.makeTaskFromTaskInfo(
       taskInfo, offer, version, now, taskCondition).copy(
       taskId = taskId)))

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -13,7 +13,7 @@ import mesosphere.marathon.core.instance.Reservation.State.Suspended
 import mesosphere.marathon.core.instance.update.InstanceUpdateEffect.Update
 import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.pod.MesosContainer
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.bus.{MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper}
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
 import mesosphere.marathon.raml.Resources
@@ -249,7 +249,7 @@ class InstanceUpdaterTest extends UnitTest {
     val app = new AppDefinition(PathId("/test"))
     val scheduledInstance = Instance.scheduled(app)
     val taskId = Task.Id(scheduledInstance.instanceId)
-    val provisionedTasks = Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now(f.clock)))
+    val provisionedTasks = Tasks.provisioned(taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now(f.clock))
     val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), app, provisionedTasks, Timestamp.now(f.clock))
     val withStoppedGoal = provisionedInstance.copy(state = provisionedInstance.state.copy(goal = Goal.Stopped))
 
@@ -329,7 +329,7 @@ class InstanceUpdaterTest extends UnitTest {
 
     val app = AppDefinition(PathId("/test"))
     val scheduledReserved = TestInstanceBuilder.scheduledWithReservation(app)
-    val provisionedTasks = Seq(Task.provisioned(f.taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now(f.clock)))
+    val provisionedTasks = Tasks.provisioned(f.taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now(f.clock))
     val provisionedInstance = scheduledReserved.provisioned(f.agentInfo, app, provisionedTasks, Timestamp(f.clock.instant()))
     val killedOperation = InstanceUpdateOperation.MesosUpdate(provisionedInstance, Condition.Killed, MesosTaskStatusTestHelper.killed(f.taskId), Timestamp(f.clock.instant()))
     val updated = InstanceUpdater.mesosUpdate(provisionedInstance, killedOperation).asInstanceOf[Update]

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImplTest.scala
@@ -11,8 +11,10 @@ import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition}
 import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.Task.{EphemeralTaskId, TaskIdWithIncarnation}
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.raml.{Endpoint, Resources}
 import mesosphere.marathon.state.PathId
+import mesosphere.mesos.TaskGroupBuilder
 
 import scala.collection.immutable.Seq
 
@@ -27,7 +29,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, pod, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
+        agentInfo, pod, Tasks.provisioned(tc.taskIDs, tc.networkInfos, pod.version, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -38,7 +40,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, pod, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
+        agentInfo, pod, Tasks.provisioned(tc.taskIDs, tc.networkInfos, pod.version, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -49,7 +51,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, pod, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
+        agentInfo, pod, Tasks.provisioned(tc.taskIDs, tc.networkInfos, pod.version, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -65,7 +67,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, pod, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
+        agentInfo, pod, Tasks.provisioned(tc.taskIDs, tc.networkInfos, pod.version, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -81,7 +83,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(pod, tc.instanceId).provisioned(
-        agentInfo, pod, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
+        agentInfo, pod, Tasks.provisioned(tc.taskIDs, tc.networkInfos, pod.version, clock.now()), clock.now())
       check(tc, instance)
     }
 
@@ -97,7 +99,7 @@ class InstanceOpFactoryImplTest extends UnitTest {
       val tc = TestCase(pod, agentInfo)
       implicit val clock = new SettableClock()
       val instance = Instance.scheduled(tc.pod, tc.instanceId).provisioned(
-        agentInfo, pod, Tasks.provisioned(tc.taskIDs, agentInfo, tc.hostPortsAllocatedFromOffer, pod, clock.now()), clock.now())
+        agentInfo, pod, Tasks.provisioned(tc.taskIDs, tc.networkInfos, pod.version, clock.now()), clock.now())
       check(tc, instance)
     }
   }
@@ -157,7 +159,8 @@ object InstanceOpFactoryImplTest {
     containers = Seq(MesosContainer(name = "ct1", resources = someRes))
   )
 
-  val agentInfo = AgentInfo("agent1", None, None, None, Seq.empty)
+  val host = "agent1"
+  val agentInfo = AgentInfo(host, None, None, None, Seq.empty)
 
   case class TestCase(pod: PodDefinition, agentInfo: AgentInfo) {
     val instanceId: Instance.Id = Instance.Id.forRunSpec(pod.id)
@@ -174,5 +177,7 @@ object InstanceOpFactoryImplTest {
       case Some(port) => Some(port)
       case None => None
     }
+
+    val networkInfos: Map[Task.Id, NetworkInfo] = TaskGroupBuilder.buildTaskNetworkInfos(pod, host, taskIDs, hostPortsAllocatedFromOffer)
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLauncherImplTest.scala
@@ -5,6 +5,7 @@ import java.util
 import java.util.Collections
 
 import mesosphere.UnitTest
+import mesosphere.marathon.core.instance.update.InstanceUpdateOperation
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launcher.{InstanceOp, TaskLauncher}
 import mesosphere.marathon.core.task.Task
@@ -27,9 +28,8 @@ class TaskLauncherImplTest extends UnitTest {
   private[this] def launch(taskInfoBuilder: TaskInfo.Builder): InstanceOp.LaunchTask = {
     val taskInfo = taskInfoBuilder.build()
     val instance = TestInstanceBuilder.newBuilderWithInstanceId(instanceId).addTaskWithBuilder().taskFromTaskInfo(taskInfo).build().getInstance()
-    val task: Task = instance.appTask
-    new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role"))
-      .provision(taskInfo, instance.instanceId, instance.agentInfo.get, instance.runSpec, task, Timestamp.now())
+    val stateOp = InstanceUpdateOperation.Provision(instanceId, instance.agentInfo.get, instance.runSpec, instance.tasksMap, Timestamp.now())
+    new InstanceOpFactoryHelper(metrics, Some("principal"), Some("role")).provision(taskInfo, stateOp)
   }
   private[this] val appId = PathId("/test")
   private[this] val instanceId = Instance.Id.forRunSpec(appId)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -15,7 +15,7 @@ import mesosphere.marathon.core.launchqueue.LaunchQueueConfig
 import mesosphere.marathon.core.matcher.base.OfferMatcher.MatchedInstanceOps
 import mesosphere.marathon.core.matcher.base.util.{ActorOfferMatcher, InstanceOpSourceDelegate}
 import mesosphere.marathon.core.matcher.manager.OfferMatcherManager
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder, TaskConditionMapping}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
@@ -53,7 +53,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
     val app = AppDefinition(id = PathId("/testapp"))
     val scheduledInstance = Instance.scheduled(app)
     val taskId = Task.Id(scheduledInstance.instanceId)
-    val provisionedTasks = Seq(Task.provisioned(taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now()))
+    val provisionedTasks = Tasks.provisioned(taskId, NetworkInfoPlaceholder(), app.version, Timestamp.now())
     val provisionedInstance = scheduledInstance.provisioned(AgentInfoPlaceholder(), app, provisionedTasks, Timestamp.now())
     val runningInstance = TestInstanceBuilder.newBuilder(app.id, version = app.version, now = Timestamp.now()).addTaskRunning().getInstance()
     val marathonTask: Task = provisionedInstance.appTask
@@ -206,7 +206,6 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, Some(now))
 
       When("the launcher receives the update for the provisioned instance")
-      val taskId = Task.Id(f.scheduledInstance.instanceId)
       val provisionedInstance = f.scheduledInstance.provisioned(TestInstanceBuilder.defaultAgentInfo, f.app, f.provisionedTasks, clock.now())
       val update = InstanceUpdated(provisionedInstance, Some(f.scheduledInstance.state), Seq.empty)
       // setting new state in instancetracker here
@@ -320,7 +319,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       assert(activeCount(launcherRef) == 0)
     }
 
-    s"unreachable task queue statistics return expected values" in new Fixture {
+    "unreachable task queue statistics return expected values" in new Fixture {
       val lostInstance = TestInstanceBuilder.newBuilder(f.app.id, version = f.app.version, now = Timestamp.now()).addTaskWithBuilder().taskUnreachable().build().instance
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(lostInstance))
 
@@ -370,7 +369,6 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       Given("a provisioned instance")
 
       val scheduledInstanceB = Instance.scheduled(f.app)
-      val taskId = Task.Id(scheduledInstanceB.instanceId)
       val provisionedInstance = scheduledInstanceB.provisioned(TestInstanceBuilder.defaultAgentInfo, f.app, f.provisionedTasks, clock.now())
       Mockito.when(instanceTracker.instancesBySpecSync).thenReturn(InstanceTracker.InstancesBySpec.forInstances(f.scheduledInstance, provisionedInstance))
 

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -51,8 +51,11 @@ object TaskStatusUpdateTestHelper {
 
   def provision(instance: Instance, timestamp: Timestamp = defaultTimestamp) = {
     val provisioned = TestInstanceBuilder.newBuilderWithInstanceId(instance.instanceId).addTaskProvisioned().getInstance()
-    val operation = InstanceUpdateOperation.Provision(instance.instanceId, provisioned.agentInfo.get, provisioned.runSpec, provisioned.tasksMap.values.to[Seq], timestamp)
-    val effect = InstanceUpdateEffect.Update(instance.provisioned(provisioned.agentInfo.get, provisioned.runSpec, provisioned.tasksMap.values.to[Seq], timestamp), oldState = Some(instance), events = Nil)
+    val operation = InstanceUpdateOperation.Provision(instance.instanceId, provisioned.agentInfo.get, provisioned.runSpec, provisioned.tasksMap, timestamp)
+    val effect = InstanceUpdateEffect.Update(
+      instance.provisioned(provisioned.agentInfo.get, provisioned.runSpec, provisioned.tasksMap, timestamp),
+      oldState = Some(instance),
+      events = Nil)
     TaskStatusUpdateTestHelper(operation, effect)
   }
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -67,7 +67,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
       )
 
       val expectedState = instance.state.copy(condition = Condition.Provisioned)
-      val provisionOp = InstanceUpdateOperation.Provision(expectedTaskId.instanceId, expectedAgentInfo, app, Seq(expectedTask), expectedState.since)
+      val provisionOp = InstanceUpdateOperation.Provision(expectedTaskId.instanceId, expectedAgentInfo, app, Map(expectedTaskId -> expectedTask), expectedState.since)
       matched.instanceOp.stateOp should be(provisionOp)
     }
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -8,7 +8,7 @@ import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.Schedule
 import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
-import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
 import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerModule}
 import mesosphere.marathon.metrics.Metrics
@@ -410,7 +410,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
         scheduledInstance.instanceId,
         AgentInfoPlaceholder(),
         app,
-        Seq(Task.provisioned(Task.Id(scheduledInstance.instanceId), NetworkInfoPlaceholder(), app.version, Timestamp.now())),
+        Tasks.provisioned(Task.Id(scheduledInstance.instanceId), NetworkInfoPlaceholder(), app.version, Timestamp.now()),
         Timestamp.now()))
     ).asInstanceOf[InstanceUpdateEffect.Update]
 


### PR DESCRIPTION
Summary:
This is a follow up to #6677 and #6687. It unifies `Tasks.provisioned` and
`Tasks.provisioned` by moving the Pod network info building into the
`TaskGroupBuilder`. We also pass around the instances as a map instead
of a sequence.