### PR TITLE
Provisioned only when running

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -48,7 +48,7 @@ case class Instance(
     */
   val isScheduled: Boolean = state.goal == Goal.Running && (state.condition.isTerminal || state.condition == Condition.Scheduled)
 
-  val isProvisioned: Boolean = state.condition == Condition.Provisioned
+  val isProvisioned: Boolean = state.condition == Condition.Provisioned && state.goal == Goal.Running
 
   def isKilling: Boolean = state.condition == Condition.Killing
   def isRunning: Boolean = state.condition == Condition.Running


### PR DESCRIPTION
We use that method in various places in orchestration logic to be able to determine if some instance "is being launched". I think to be precise, we should also filter by the goal there.
