### PR TITLE
Prohibit usage of reserved keywords as parts of path ids (#6632)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,25 @@
 ## Change from 1.6.549 to 1.6.xxx
 
 ### Default for "max-open-connections" increased for asynchronous standby proxy, now configurable
+### Removed deprecated metrics
+We removed deprecated Kamon based metrics from the code base (see the 1.7.xxx changelog for details on new metrics). This led to removal of deprecated command line arguments e.g. old reporters like `--reporter_graphite`, `--reporter_datadog`, `--reporter_datadog` and `--metrics_averaging_window`.
+### Apps names restrictions (breaking change)
+From now on, apps which uses ids which ends with "restart", "tasks", "versions" won't be valid anymore. Such apps already had broken behavior (for example it wasn't possible to use a `GET /v2/apps` endpoint with them), so we made that constraint more explicit. Existing apps with such names will continue working, however all operations on them (except deletion) will result in an error. Please take care of renaming them before upgrading Marathon.
+
+### Fixed issues
+
+- [MARATHON-8482](https://jira.mesosphere.com/browse/MARATHON-8482) - We fixed a possibly incorrect behavior around killing overdue tasks: `--task_launch_confirm_timeout` parameter properly controls the time the task spends in `Provisioned` stage (between being launched and receiving `TASK_STAGING` status update).
+
+### Closing connection on slow event consumers
+
+Prior to 1.8 Marathon would drop events from the event stream for slow consumers. Starting with 1.8 Marathon will close
+the connection instead to raise awareness of problematic consumers. A consumer is considered slow when it fails to read
+`event_stream_max_outstanding_messages` events in time, ie Marathon buffered so many events. Consumers can and should
+reconnect when the connection was dropped by Marathon.
+
+## Changes to 1.7.xxx
+
+### New metrics names (breaking change)
 
 In some clusters with heavy standby-proxy usage, a limit of 32 max-open-connections was too small. This default has been increased to 64. In addition, the flag `--leader_proxy_max_open_connections` has been introduced to tune the value further, if needed.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,26 +1,9 @@
 ## Change from 1.6.549 to 1.6.xxx
 
-### Default for "max-open-connections" increased for asynchronous standby proxy, now configurable
-### Removed deprecated metrics
-We removed deprecated Kamon based metrics from the code base (see the 1.7.xxx changelog for details on new metrics). This led to removal of deprecated command line arguments e.g. old reporters like `--reporter_graphite`, `--reporter_datadog`, `--reporter_datadog` and `--metrics_averaging_window`.
 ### Apps names restrictions (breaking change)
 From now on, apps which uses ids which ends with "restart", "tasks", "versions" won't be valid anymore. Such apps already had broken behavior (for example it wasn't possible to use a `GET /v2/apps` endpoint with them), so we made that constraint more explicit. Existing apps with such names will continue working, however all operations on them (except deletion) will result in an error. Please take care of renaming them before upgrading Marathon.
 
-### Fixed issues
-
-- [MARATHON-8482](https://jira.mesosphere.com/browse/MARATHON-8482) - We fixed a possibly incorrect behavior around killing overdue tasks: `--task_launch_confirm_timeout` parameter properly controls the time the task spends in `Provisioned` stage (between being launched and receiving `TASK_STAGING` status update).
-
-### Closing connection on slow event consumers
-
-Prior to 1.8 Marathon would drop events from the event stream for slow consumers. Starting with 1.8 Marathon will close
-the connection instead to raise awareness of problematic consumers. A consumer is considered slow when it fails to read
-`event_stream_max_outstanding_messages` events in time, ie Marathon buffered so many events. Consumers can and should
-reconnect when the connection was dropped by Marathon.
-
-## Changes to 1.7.xxx
-
-### New metrics names (breaking change)
-
+### Default for "max-open-connections" increased for asynchronous standby proxy, now configurable
 In some clusters with heavy standby-proxy usage, a limit of 32 max-open-connections was too small. This default has been increased to 64. In addition, the flag `--leader_proxy_max_open_connections` has been introduced to tune the value further, if needed.
 
 ### Docker image now allows user `nobody`

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -278,6 +278,13 @@ class AppsResource @Inject() (
       deploymentResult(await(groupManager.updateRoot(appId.parent, deleteApp, version = version, force = force)))
     }
   }
+  @DELETE
+  @Path("""{id:.+}/restart""")
+  def deleteRestart(
+    @DefaultValue("true")@QueryParam("force") force: Boolean,
+    @PathParam("id") id: String,
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = delete(force, id + "/restart", req, asyncResponse)
 
   @Path("{appId:.+}/tasks")
   def appTasksResource(): AppTasksResource = appTasksRes

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -132,12 +132,19 @@ object PathId {
     id.path.forall(part => ID_PATH_SEGMENT_PATTERN.pattern.matcher(part).matches())
   }
 
+  private val reservedKeywords = Seq("restart", "tasks", "versions")
+
+  private val withoutReservedKeywords = isTrue[PathId](s"must not end with any of the following reserved keywords: ${reservedKeywords.mkString(", ")}") { id =>
+    id.path.lastOption.forall(last => !reservedKeywords.contains(id.path.last))
+  }
+
   /**
     * For external usage. Needed to overwrite the whole description, e.g. id.path -> id.
     */
   implicit val pathIdValidator = validator[PathId] { path =>
     path is childOf(path.parent)
     path is validPathChars
+    path is withoutReservedKeywords
   }
 
   /**


### PR DESCRIPTION
Summary: new validation for pathId was added. Deletion of a broken app is still possible due to workaround.

JIRA Issues: MARATHON-8466

(cherry picked from commit 5ac9db240dd3ef01b77c9c3f1bc2e883e042e278)
