### PR TITLE
Expunge scheduled instance

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -38,7 +38,7 @@ object InstanceUpdater extends StrictLogging {
     InstanceUpdateEffect.Update(op.instance, oldState = None, events)
   }
 
-  private def shouldBeExpunged(instance: Instance): Boolean =
+  def shouldBeExpunged(instance: Instance): Boolean =
     instance.tasksMap.values.forall(t => t.isTerminal || t.isReserved) && instance.state.goal == Goal.Decommissioned
 
   private[marathon] def mesosUpdate(instance: Instance, op: MesosUpdate): InstanceUpdateEffect = {


### PR DESCRIPTION
Summary:
Consider following scenario:

- New instance is created, its condition is `Scheduled` and it has no task
- before we get to making that instance match on any offer, someone changes goal to `Decommission`
- `InstanceUpdateOpResolver` processes that and issues `InstanceUpdateOperation.Update`
this instance will NEVER BE EXPUNGED

JIRA issues: MARATHON-8532
