### PR TITLE
Expunge scheduled instances

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -111,7 +111,7 @@ class TaskReplaceActor(
 
   def replaceBehavior: Receive = {
     // New instance failed to start, restart it
-    case InstanceChanged(id, `version`, `pathId`, condition, Instance(instanceId, Some(agentInfo), state, tasksMap, runSpec, reservation)) if !oldInstanceIds(id) && considerTerminal(condition) =>
+    case InstanceChanged(id, runSpecVersion, `pathId`, condition, Instance(instanceId, Some(agentInfo), state, tasksMap, runSpec, reservation)) if !oldInstanceIds(id) && considerTerminal(condition) =>
       logger.warn(s"New instance $id is terminal on agent ${agentInfo.agentId} during app $pathId restart: $condition reservation: $reservation")
       instanceTerminated(id)
       instancesStarted -= 1
@@ -119,7 +119,7 @@ class TaskReplaceActor(
 
     // An old instance terminated out of band and was not yet chosen to be decommissioned or stopped
     // we should decommission/stop the instance and let it be rescheduled with new instance id
-    case InstanceChanged(id, _, `pathId`, condition, instance) if oldInstanceIds(id) && considerTerminal(condition) && instance.state.goal == Goal.Running =>
+    case InstanceChanged(id, runSpecVersion, `pathId`, condition, instance) if oldInstanceIds(id) && considerTerminal(condition) && instance.state.goal == Goal.Running =>
       logger.info(s"Old instance $id became $condition during an upgrade but still has goal Running. We will decommission that instance and launch new one with new instance id.")
       oldInstanceIds -= id
       instanceTerminated(id)
@@ -127,8 +127,8 @@ class TaskReplaceActor(
       instanceTracker.setGoal(instance.instanceId, goal)
         .flatMap(_ => killService.killInstance(instance, KillReason.Upgrading))
         .pipeTo(self)
-    // Old instance successfully killed	    // Old instance successfully killed
-    case InstanceChanged(id, _, `pathId`, condition, instance) if oldInstanceIds(id) && instance.state.goal != Goal.Running && considerTerminal(condition) =>
+    // Old instance successfully killed
+    case InstanceChanged(id, runSpecVersion, `pathId`, condition, instance) if oldInstanceIds(id) && considerTerminal(condition) && instance.state.goal != Goal.Running =>
       // Within the v2 deployment orchestration logic, it's close to impossible to handle a status update
       // before the instance is updated and persisted. Ideally this actor would be able to handle e.g. a TASK_FAILED
       // for an old instance, update it's goal to Decommissioned in that case, and launch a new instance of the new
@@ -142,7 +142,8 @@ class TaskReplaceActor(
         .pipeTo(self)
 
     // Ignore change events, that are not handled in parent receives
-    case _: InstanceChanged =>
+    case e: InstanceChanged =>
+      logger.warn(s">>> Unhandled InstanceChanged event for instanceId=${e.id}, oldInstanceIds(id)=${oldInstanceIds(e.id)}, considerTerminal(condition)=${considerTerminal(e.condition)}, goal=${e.instance.state.goal}")
 
     case Status.Failure(e) =>
       // This is the result of failed launchQueue.addAsync(...) call. Log the message and

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -56,6 +56,7 @@ class TaskReplaceActor(
 
   // All instances to kill as set for quick lookup
   private[this] var oldInstanceIds: SortedSet[Id] = instancesToRemove.map(_.instanceId).to[SortedSet]
+  private[this] def newInstanceIds(id: Instance.Id): Boolean = !oldInstanceIds(id)
 
   // All instances to kill queued up
   private[this] val toKill: mutable.Queue[Instance.Id] = instancesToRemove.map(_.instanceId).to[mutable.Queue]
@@ -111,7 +112,7 @@ class TaskReplaceActor(
 
   def replaceBehavior: Receive = {
     // New instance failed to start, restart it
-    case InstanceChanged(id, runSpecVersion, `pathId`, condition, Instance(instanceId, Some(agentInfo), state, tasksMap, runSpec, reservation)) if !oldInstanceIds(id) && considerTerminal(condition) =>
+    case InstanceChanged(id, runSpecVersion, `pathId`, condition, Instance(instanceId, Some(agentInfo), state, tasksMap, runSpec, reservation)) if newInstanceIds(id) && considerTerminal(condition) =>
       logger.warn(s"New instance $id is terminal on agent ${agentInfo.agentId} during app $pathId restart: $condition reservation: $reservation")
       instanceTerminated(id)
       instancesStarted -= 1
@@ -142,8 +143,8 @@ class TaskReplaceActor(
         .pipeTo(self)
 
     // Ignore change events, that are not handled in parent receives
-    case e: InstanceChanged =>
-      logger.warn(s">>> Unhandled InstanceChanged event for instanceId=${e.id}, oldInstanceIds(id)=${oldInstanceIds(e.id)}, considerTerminal(condition)=${considerTerminal(e.condition)}, goal=${e.instance.state.goal}")
+    case InstanceChanged(id, runSpecVersion, `pathId`, condition, instance) =>
+      logger.info(s"Unhandled InstanceChanged event for instanceId=$id, old instance=${oldInstanceIds(id)}, considered terminal=${considerTerminal(condition)} and goal=${instance.state.goal}")
 
     case Status.Failure(e) =>
       // This is the result of failed launchQueue.addAsync(...) call. Log the message and

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangedEventsGenerator.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangedEventsGenerator.scala
@@ -1,9 +1,9 @@
 package mesosphere.marathon
 package core.instance.update
 
-import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.{InstanceChanged, MarathonEvent, MesosStatusUpdateEvent}
 import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Timestamp
 import org.apache.mesos.Protos.TaskState
@@ -11,8 +11,11 @@ import org.apache.mesos.Protos.TaskState
 import scala.collection.immutable.Seq
 
 object InstanceChangedEventsGenerator {
-  def events(instance: Instance, task: Option[Task], now: Timestamp, previousCondition: Option[Condition]): Seq[MarathonEvent] = {
-    val stateChanged = previousCondition.fold(true)(_ != instance.state.condition)
+  def events(instance: Instance, task: Option[Task], now: Timestamp, previousState: Option[InstanceState]): Seq[MarathonEvent] = {
+    val stateChanged = previousState.fold(true) { previous =>
+      previous.condition != instance.state.condition ||
+        previous.goal != instance.state.goal
+    }
     val runSpecId = instance.runSpecId
     val version = instance.runSpecVersion
 

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -56,18 +56,10 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
         updateExistingInstance(maybeInstance, op.instanceId)(updater.reservationTimeout(_, clock.now()))
 
       case op: ChangeGoal =>
-        updateExistingInstance(maybeInstance, op.instanceId)(i => {
-          val updatedInstance = i.copy(state = i.state.copy(goal = op.goal))
-          val events = InstanceChangedEventsGenerator.events(updatedInstance, task = None, clock.now(), previousCondition = Some(i.state.condition))
-
-          logger.info(s"Updating goal of instance ${i.instanceId} to ${op.goal}")
-          InstanceUpdateEffect.Update(updatedInstance, oldState = Some(i), events = Nil)
-        })
+        updateExistingInstance(maybeInstance, op.instanceId)(updater.goalChange(_, op, clock.now()))
 
       case op: Reserve =>
-        updateExistingInstance(maybeInstance, op.instanceId) { _ =>
-          updater.reserve(op, clock.now())
-        }
+        updateExistingInstance(maybeInstance, op.instanceId)(_ => updater.reserve(op, clock.now()))
 
       case op: ForceExpunge =>
         maybeInstance match {

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -56,7 +56,7 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
         updateExistingInstance(maybeInstance, op.instanceId)(updater.reservationTimeout(_, clock.now()))
 
       case op: ChangeGoal =>
-        updateExistingInstance(maybeInstance, op.instanceId)(updater.goalChange(_, op, clock.now()))
+        updateExistingInstance(maybeInstance, op.instanceId)(updater.changeGoal(_, op, clock.now()))
 
       case op: Reserve =>
         updateExistingInstance(maybeInstance, op.instanceId)(_ => updater.reserve(op, clock.now()))

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -11,7 +11,7 @@ import org.apache.mesos
 sealed trait InstanceUpdateOperation {
   def instanceId: Instance.Id
 
-  def shortString: String = s"${this.getClass.getCanonicalName} instance update operation for $instanceId"
+  def shortString: String = s"${this.getClass.getSimpleName} instance update operation for $instanceId"
 }
 
 object InstanceUpdateOperation {
@@ -65,7 +65,7 @@ object InstanceUpdateOperation {
 
     override def instanceId: Instance.Id = instance.instanceId
 
-    override def shortString: String = s"${this.getClass.getCanonicalName} update operation for $instanceId with new status ${mesosStatus.getState}"
+    override def shortString: String = s"${this.getClass.getSimpleName} update operation for $instanceId with new status ${mesosStatus.getState}"
   }
 
   object MesosUpdate {
@@ -76,7 +76,9 @@ object InstanceUpdateOperation {
 
   case class ReservationTimeout(instanceId: Instance.Id) extends InstanceUpdateOperation
 
-  case class ChangeGoal(instanceId: Instance.Id, goal: Goal) extends InstanceUpdateOperation
+  case class ChangeGoal(instanceId: Instance.Id, goal: Goal) extends InstanceUpdateOperation {
+    override def shortString: String = s"${this.getClass.getSimpleName} instance update operation for $instanceId with new goal $goal"
+  }
 
   /** Expunge a task whose TaskOp was rejected */
   case class ForceExpunge(instanceId: Instance.Id) extends InstanceUpdateOperation

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -122,11 +122,10 @@ object InstanceUpdater extends StrictLogging {
     InstanceUpdateEffect.Update(instance, oldState = None, events = Nil)
   }
 
-  private[marathon] def goalChange(instance: Instance, op: InstanceUpdateOperation.ChangeGoal, now: Timestamp): InstanceUpdateEffect = {
+  private[marathon] def changeGoal(instance: Instance, op: InstanceUpdateOperation.ChangeGoal, now: Timestamp): InstanceUpdateEffect = {
     val updatedInstance = instance.copy(state = instance.state.copy(goal = op.goal))
 
     if (InstanceUpdater.shouldBeExpunged(updatedInstance)) {
-      InstanceUpdateEffect.Update(updatedInstance, oldState = Some(instance), events = Nil)
       logger.info(s"Instance ${instance.instanceId} goal updated to ${op.goal}. Because of that instance should be expunged now.")
       InstanceUpdateEffect.Expunge(updatedInstance, events = Nil)
     } else {

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -110,7 +110,7 @@ object InstanceUpdater extends StrictLogging {
       // TODO(cleanup): Using Killed for now; we have no specific state yet bit this must be considered Terminal
       state = instance.state.copy(condition = Condition.Killed)
     )
-    val events = InstanceChangedEventsGenerator.events(
+    val events = eventsGenerator.events(
       updatedInstance, task = None, now, previousCondition = Some(instance.state.condition))
 
     logger.debug(s"Force expunge ${instance.instanceId}")
@@ -129,7 +129,7 @@ object InstanceUpdater extends StrictLogging {
       logger.info(s"Instance ${instance.instanceId} goal updated to ${op.goal}. Because of that instance should be expunged now.")
       InstanceUpdateEffect.Expunge(updatedInstance, events = Nil)
     } else {
-      val events = InstanceChangedEventsGenerator.events(updatedInstance, task = None, now, previousCondition = Some(instance.state.condition))
+      val events = eventsGenerator.events(updatedInstance, task = None, now, previousCondition = Some(instance.state.condition))
 
       logger.info(s"Updating goal of instance ${instance.instanceId} to ${op.goal}")
       InstanceUpdateEffect.Update(updatedInstance, oldState = Some(instance), events = Nil)

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -366,7 +366,7 @@ private class TaskLauncherActor(
   //TODO(karsten): We may want to change it to `!backOffs.get(configRef).exists(clock.now() < _)` so that instances without a defined back off do not start.
   private[this] def backoffActive(configRef: RunSpecConfigRef): Boolean = backOffs.get(configRef).forall(_ > clock.now())
   private[this] def shouldLaunchInstances(): Boolean = {
-    if(scheduledInstances.nonEmpty) logger.info(s"Scheduled instances: $scheduledInstances, backOffs: $backOffs")
+    if (scheduledInstances.nonEmpty) logger.info(s"Scheduled instances: $scheduledInstances, backOffs: $backOffs")
     scheduledInstances.nonEmpty && scheduledVersions.exists { configRef => !backoffActive(configRef) }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueInstancesActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueInstancesActor.scala
@@ -54,8 +54,10 @@ private[jobs] object OverdueInstancesActor {
 
     private[this] def killOverdueInstances(now: Timestamp, instances: Seq[Instance]): Unit = {
       val instancesToKill = overdueInstances(now, instances)
-      logger.info(s"Killing overdue instances: ${instancesToKill.map(_.instanceId).mkString(", ")}")
-      killService.killInstancesAndForget(instancesToKill, KillReason.Overdue)
+      if (instancesToKill.nonEmpty) {
+        logger.info(s"Killing overdue instances: ${instancesToKill.map(_.instanceId).mkString(", ")}")
+        killService.killInstancesAndForget(instancesToKill, KillReason.Overdue)
+      }
     }
 
     private[this] def overdueInstances(now: Timestamp, instances: Seq[Instance]): Seq[Instance] = {

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
@@ -72,13 +72,10 @@ private[termination] object KillAction extends StrictLogging {
     val allTerminal: Boolean = taskIds.isEmpty
 
     if (isUnkillable || allTerminal) {
-      val msg = if (isUnkillable)
-        s"it is ${maybeCondition.fold("unknown")(_.toString)}"
-      else
-        "none of its tasks are running"
+      val msg = if (isUnkillable) s"it is ${maybeCondition.fold("unknown")(_.toString)}"
+                else "none of its tasks are running"
       if (hasReservations) {
-        logger.info(
-          s"Ignoring kill request for ${instanceId}; killing it while ${msg} is unsupported")
+        logger.info(s"Ignoring kill request for ${instanceId}; killing it while ${msg} is unsupported")
         KillAction.Noop
       } else {
         logger.warn(s"Expunging ${instanceId} from state because ${msg}")

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
@@ -72,19 +72,19 @@ private[termination] object KillAction extends StrictLogging {
     val allTerminal: Boolean = taskIds.isEmpty
 
     if (isUnkillable || allTerminal) {
-      val msg = if (isUnkillable) s"it is ${maybeCondition.fold("unknown")(_.toString)}"
+      val msg = if (isUnkillable) s"its condition is ${maybeCondition.fold("unknown")(_.toString)}"
       else "none of its tasks are running"
       if (hasReservations) {
-        logger.info(s"Ignoring kill request for ${instanceId}; killing it while ${msg} is unsupported")
+        logger.info(s"Ignoring kill request for $instanceId; killing it while $msg is unsupported")
         KillAction.Noop
       } else {
-        logger.warn(s"Expunging ${instanceId} from state because ${msg}")
+        logger.warn(s"Expunging $instanceId from state because $msg")
         // we will eventually be notified of a taskStatusUpdate after the instance has been expunged
         KillAction.ExpungeFromState
       }
     } else {
       val knownOrNot = if (knownInstance.isDefined) "known" else "unknown"
-      logger.warn("Killing {} {} of instance {}", knownOrNot, taskIds.mkString(","), instanceId)
+      logger.warn(s"Killing $knownOrNot ${taskIds.mkString(",")} of instance $instanceId")
       KillAction.IssueKillRequest
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillAction.scala
@@ -73,7 +73,7 @@ private[termination] object KillAction extends StrictLogging {
 
     if (isUnkillable || allTerminal) {
       val msg = if (isUnkillable) s"it is ${maybeCondition.fold("unknown")(_.toString)}"
-                else "none of its tasks are running"
+      else "none of its tasks are running"
       if (hasReservations) {
         logger.info(s"Ignoring kill request for ${instanceId}; killing it while ${msg} is unsupported")
         KillAction.Noop

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
@@ -62,7 +62,7 @@ object KillStreamWatcher extends StrictLogging {
         statefulMapConcat { () =>
           var pendingInstanceIds = instanceIdsSet
           // this is used for logging to help prevent polluting the logs
-          val name = s"kill-watcher-${UUID.randomUUID()}"
+          val name = s"kill-watcher-${instanceIds.headOption.fold("")(i => i.safeRunSpecId)}-${UUID.randomUUID()}"
 
           { (id: Instance.Id) =>
             pendingInstanceIds -= id

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -98,10 +98,8 @@ private[tracker] class InstanceTrackerDelegate(
         val effectF = (instanceTrackerRef ? update)
           .mapTo[InstanceUpdateEffect]
           .transform {
-            case s @ Success(_) =>
-              logger.info(s"Completed processing instance update ${update.operation.shortString}"); s
-            case f @ Failure(e: AskTimeoutException) =>
-              logger.error(s"Timed out waiting for response for update $update", e); f
+            case s @ Success(_) => logger.info(s"Completed processing instance update ${update.operation.shortString}"); s
+            case f @ Failure(e: AskTimeoutException) => logger.error(s"Timed out waiting for response for update $update", e); f
             case f @ Failure(t: Throwable) => logger.error(s"An unexpected error occurred during update processing of: $update", t); f
           }
         promise.completeWith(effectF)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -88,7 +88,7 @@ private[tracker] class InstanceTrackerDelegate(
     * Number of parallel updates for *different Instance.Ids* is controlled via [[InstanceTrackerConfig.internalInstanceTrackerNumParallelUpdates]]
     * parameter.
     */
-  // format: off
+  // format: OFF
   val queue = Source
     .queue[QueuedUpdate](config.internalInstanceTrackerUpdateQueueSize(), OverflowStrategy.dropNew)
     .groupBy(config.internalInstanceTrackerNumParallelUpdates(), queued => Math.abs(queued.update.instanceId.idString.hashCode) % config.internalInstanceTrackerNumParallelUpdates())
@@ -124,7 +124,7 @@ private[tracker] class InstanceTrackerDelegate(
     }
     promise.future
   }
-  // format: on
+  // format: ON
 
   override def schedule(instance: Instance): Future[Done] = {
     require(

--- a/src/main/scala/mesosphere/marathon/experimental/repository/TemplateRepository.scala
+++ b/src/main/scala/mesosphere/marathon/experimental/repository/TemplateRepository.scala
@@ -73,7 +73,6 @@ class TemplateRepository(val store: ZooKeeperPersistenceStore, val base: String)
     */
   def toNode(template: Template[_]): Node = Node(storePath(template.id, version(template)), ByteString(template.toProtoByteArray))
 
-
   /**
     * This implementation uses MD5 of the serialized template as described here [[https://alvinalexander.com/source-code/scala-method-create-md5-hash-of-string]]
     *

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -27,7 +27,7 @@ import scala.concurrent.{Future, Promise}
 
 class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
   "TaskReplaceActor" should {
-    "Replace without health checks" in {
+    "replace old tasks without health checks" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -58,7 +58,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "New and already started tasks should not be killed" in {
+    "not kill new and already started tasks" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -92,7 +92,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "Replace with health checks" in {
+    "replace old tasks with health checks" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -126,7 +126,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "Replace and scale down from more than new minCapacity" in {
+    "replace and scale down from more than new minCapacity" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -171,7 +171,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "Replace with minimum running tasks" in {
+    "replace tasks with minimum running number of tasks" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -230,7 +230,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "Replace with rolling upgrade without over-capacity" in {
+    "replace tasks during rolling upgrade *without* over-capacity" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -301,7 +301,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "Replace with rolling upgrade with minimal over-capacity" in {
+    "replace tasks during rolling upgrade *with* minimal over-capacity" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -371,7 +371,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "Replace with rolling upgrade with 2/3 over-capacity" in {
+    "replace tasks during rolling upgrade with 2/3 over-capacity" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -436,7 +436,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "Downscale with rolling upgrade with 1 over-capacity" in {
+    "downscale tasks during rolling upgrade with 1 over-capacity" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -514,7 +514,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       expectTerminated(ref)
     }
 
-    "If all tasks are replaced already, the actor stops immediately" in {
+    "stop the actor if all tasks are replaced already" in {
       Given("An app without health checks and readiness checks, as well as 2 tasks of this version")
       val f = new Fixture
       val app = AppDefinition(id = "/myApp".toPath, instances = 2)
@@ -534,7 +534,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       promise.future.futureValue
     }
 
-    "If all tasks are replaced already, we will wait for the readiness checks" in {
+    "wait for readiness checks if all tasks are replaced already" in {
       Given("An app without health checks but readiness checks, as well as 1 task of this version")
       val f = new Fixture
       val check = ReadinessCheck()
@@ -554,7 +554,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       promise.future.futureValue
     }
 
-    "If all tasks are replaced already, we will wait for the readiness checks and health checks" in {
+    " wait for the readiness checks and health checks if all tasks are replaced already" in {
       Given("An app without health checks but readiness checks, as well as 1 task of this version")
       val f = new Fixture
       val ready = ReadinessCheck()
@@ -584,7 +584,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       promise.future.futureValue
     }
 
-    "Wait until the tasks are killed" in {
+    "wait until the tasks are killed" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -616,7 +616,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       f.killService.killed should contain(instanceB.instanceId)
     }
 
-    "Tasks to replace need to wait for health and readiness checks" in {
+    "wait for health and readiness checks for new tasks" in {
       val f = new Fixture
       val app = AppDefinition(
         id = "/myApp".toPath,
@@ -702,9 +702,9 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
     def instanceChanged(app: AppDefinition, condition: Condition): InstanceChanged = {
       val instanceId = Instance.Id.forRunSpec(app.id)
-      val instance: Instance = mock[Instance]
-      when(instance.instanceId).thenReturn(instanceId)
-      when(instance.state).thenReturn(InstanceState(Condition.Running, Timestamp.now(), None, None, Goal.Running))
+      val state = InstanceState(Condition.Running, Timestamp.now(), None, None, Goal.Running)
+      val instance: Instance = Instance(instanceId, None, state, Map.empty, app, None)
+
       InstanceChanged(instanceId, app.version, app.id, condition, instance)
     }
 

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -190,7 +190,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       stateChange shouldBe an[InstanceUpdateEffect.Update]
     }
 
-    "Revert" in new Fixture {
+    "Revert an update operation" in new Fixture {
       val stateChange = updateOpResolver.resolve(Some(reservedInstance), InstanceUpdateOperation.Revert(reservedInstance))
 
       Then("result in an Update")
@@ -230,6 +230,19 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
+      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+    }
+
+    "expunge a Scheduled instance after it was decommissioned" in new Fixture {
+      Given("a scheduled instance (no tasks)")
+      val runSpec = AppDefinition(id = appId)
+      val scheduled = Instance.scheduled(runSpec)
+
+      When("it is decommissioned")
+      val operation = InstanceUpdateOperation.ChangeGoal(scheduled.instanceId, Goal.Decommissioned)
+      val stateChange = updateOpResolver.resolve(Some(scheduled), operation)
+
+      Then("it should be expunged")
       stateChange shouldBe a[InstanceUpdateEffect.Expunge]
     }
 

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -98,7 +98,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
         )
 
         val events = eventsGenerator.events(
-          expectedState, Some(updatedTask), stateOp.now, previousCondition = Some(existingInstance.state.condition))
+          expectedState, Some(updatedTask), stateOp.now, previousState = Some(existingInstance.state))
         stateChange shouldEqual InstanceUpdateEffect.Update(expectedState, instance, events)
       }
 
@@ -128,7 +128,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
         val stateChange = updateOpResolver.resolve(instance, stateOp)
 
         Then("result in an expunge")
-        stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+        stateChange shouldBe an[InstanceUpdateEffect.Expunge]
       }
     }
 
@@ -164,7 +164,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(instance, stateOp)
 
       Then("result in an expunge")
-      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+      stateChange shouldBe an[InstanceUpdateEffect.Expunge]
     }
 
     "ReservationTimeout for an unknown instance" in new Fixture {
@@ -204,7 +204,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(Some(existingDecommissionedInstance), update.operation)
 
       Then("result in an expunge")
-      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+      stateChange shouldBe an[InstanceUpdateEffect.Expunge]
     }
 
     "expunge after TASK_GONE for a running decommissioned instance" in new Fixture {
@@ -212,7 +212,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(Some(existingDecommissionedInstance), update.operation)
 
       Then("result in an expunge")
-      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+      stateChange shouldBe an[InstanceUpdateEffect.Expunge]
     }
 
     "not expunge after TASK_GONE for instance with goal running" in new Fixture {
@@ -230,7 +230,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
-      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+      stateChange shouldBe an[InstanceUpdateEffect.Expunge]
     }
 
     "expunge a Scheduled instance after it was decommissioned" in new Fixture {
@@ -243,7 +243,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(Some(scheduled), operation)
 
       Then("it should be expunged")
-      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+      stateChange shouldBe an[InstanceUpdateEffect.Expunge]
     }
 
     "Processing a TASK_DROPPED update for a starting task" in new Fixture {
@@ -253,7 +253,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
-      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+      stateChange shouldBe an[InstanceUpdateEffect.Expunge]
     }
 
     "Processing a TASK_UNREACHABLE update for a staging task" in new Fixture {
@@ -303,7 +303,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
 
       Then("result in an expunge")
-      stateChange shouldBe a[InstanceUpdateEffect.Expunge]
+      stateChange shouldBe an[InstanceUpdateEffect.Expunge]
     }
 
     "move instance to scheduled state when previously reserved" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -25,17 +25,17 @@ import scala.concurrent.duration._
 class InstanceUpdaterTest extends UnitTest {
 
   "A staged instance" when {
-    "Processing a TASK_RUNNING update for a staged instance" should {
+    "processing a TASK_RUNNING update for a staged instance" should {
       val f = new Fixture
 
-      // Setup staged instance with a staged task
+      Given(" a staged instance with a staged task")
       val mesosTaskStatus = MesosTaskStatusTestHelper.staging(f.taskId)
       val stagedStatus = f.taskStatus.copy(startedAt = None, condition = Condition.Staging, mesosStatus = Some(mesosTaskStatus))
       val stagedTask = f.task.copy(status = stagedStatus)
       val stagedState = f.instanceState.copy(condition = Condition.Staging)
       val stagedInstance = f.instance.copy(tasksMap = Map(f.taskId -> stagedTask), state = stagedState)
 
-      // Update to running
+      And("the instance receives a TASK_RUNNING mesos update")
       val operation = InstanceUpdateOperation.MesosUpdate(stagedInstance, f.mesosTaskStatus, f.clock.now())
       val result = InstanceUpdater.mesosUpdate(stagedInstance, operation)
 
@@ -44,7 +44,7 @@ class InstanceUpdaterTest extends UnitTest {
   }
 
   "A Running instance" when {
-    "Processing an Unreachable update" should {
+    "processing an Unreachable update" should {
       val f = new Fixture
       val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId)
       val operation = InstanceUpdateOperation.MesosUpdate(f.instance, newMesosStatus, f.clock.now())

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
@@ -69,6 +69,7 @@ class LaunchQueueActorTest extends AkkaUnitTest with ImplicitSender {
         LaunchQueueActor.props(
           config, instanceTracker, groupManager, runSpecActorProps, delayUpdates))
 
+      @volatile
       var changes = List.empty[InstanceChange]
 
       // Mock the behaviour of the TaskLauncherActor
@@ -77,7 +78,6 @@ class LaunchQueueActorTest extends AkkaUnitTest with ImplicitSender {
           case change: InstanceChange =>
             changes = change :: changes
             sender() ! Done
-          case "GetChanges" => sender() ! changes // not part of the LauncherActor protocol. Only used to verify changes.
         }
       }
     }

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -302,7 +302,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
       assert(launcherRef.underlyingActor.instancesToLaunch == 1)
     }
 
-    "decomissioned task is not counted in as active or to be launched" in new Fixture {
+    "decommissioned task is not counted in as active or to be launched" in new Fixture {
       val update = TaskStatusUpdateTestHelper.finished(f.provisionedInstance).wrapped
       val updatedInstance = update.instance.copy(state = update.instance.state.copy(goal = Goal.Decommissioned))
 

--- a/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
@@ -35,7 +35,7 @@ class KillServiceMock(system: ActorSystem) extends KillService with Mockito {
   override def killInstance(instance: Instance, reason: KillReason): Future[Done] = synchronized {
     val id = instance.instanceId
     val updatedInstance = instance.copy(state = instance.state.copy(condition = Condition.Killed, goal = Goal.Decommissioned))
-    val events = customStatusUpdates.getOrElse(id, eventsGenerator.events(updatedInstance, task = None, now = clock.now(), previousCondition = Some(instance.state.condition)))
+    val events = customStatusUpdates.getOrElse(id, eventsGenerator.events(updatedInstance, task = None, now = clock.now(), previousState = Some(instance.state)))
     events.foreach(system.eventStream.publish)
     numKilled += 1
     killed += id

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
@@ -25,8 +25,8 @@ class KillStreamWatcherTest extends AkkaUnitTest {
 
   "killedInstanceFlow yields Done when all instance Ids are seen" in {
 
-    val instanceIds = List("a", "b", "c").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
-    val otherInstanceIds = List("e", "g", "f").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
+    val instanceIds = List("/a", "/b", "/c").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
+    val otherInstanceIds = List("/e", "/g", "/f").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
 
     val result = Source(otherInstanceIds ++ instanceIds).
       via(KillStreamWatcher.killedInstanceFlow(instanceIds)).
@@ -36,7 +36,7 @@ class KillStreamWatcherTest extends AkkaUnitTest {
   }
 
   "killedInstanceFlow does not yield Done when not all instance Ids are seen" in {
-    val instanceIds = List("a", "b", "c").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
+    val instanceIds = List("/a", "/b", "/c").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
 
     val result = Source(instanceIds.tail).
       via(KillStreamWatcher.killedInstanceFlow(instanceIds)).

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -271,13 +271,13 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val f = new Fixture
         val appId: PathId = PathId("/app")
         val running = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
-        val runningDecomissioned = running.copy(state = running.state.copy(goal = Goal.Decommissioned))
-        val appDataMap = InstanceTracker.InstancesBySpec.forInstances(runningDecomissioned)
+        val runningDecommissioned = running.copy(state = running.state.copy(goal = Goal.Decommissioned))
+        val appDataMap = InstanceTracker.InstancesBySpec.forInstances(runningDecommissioned)
         f.taskLoader.load() returns Future.successful(appDataMap)
 
         When("a running and decommissioned task is killed")
         val probe = TestProbe()
-        val helper = TaskStatusUpdateTestHelper.killed(runningDecomissioned)
+        val helper = TaskStatusUpdateTestHelper.killed(runningDecommissioned)
         val update = helper.operation.asInstanceOf[InstanceUpdateOperation.MesosUpdate]
 
         And("and expunged")
@@ -297,8 +297,8 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         Given("an task instance tracker with initial state")
         val appId: PathId = PathId("/app")
         val running = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
-        val runningDecomissioned = running.copy(state = running.state.copy(goal = Goal.Decommissioned))
-        val appDataMap = InstanceTracker.InstancesBySpec.forInstances(runningDecomissioned)
+        val runningDecommissioned = running.copy(state = running.state.copy(goal = Goal.Decommissioned))
+        val appDataMap = InstanceTracker.InstancesBySpec.forInstances(runningDecommissioned)
         f.taskLoader.load() returns Future.successful(appDataMap)
 
         When("a task in decommissioned gets killed")


### PR DESCRIPTION
Summary:
Previously, in a scenario where an instance is `Scheduled` but no tasks are yet launched if the goal is changed to `Decommission`
it is never expunged. This fix resolves this issue.

Fixes: MARATHON-8532
