### PR TITLE
Unify instance migrations.

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
@@ -1,13 +1,26 @@
 package mesosphere.marathon
 package storage.migration
 
-import mesosphere.marathon.core.storage.store.PersistenceStore
+import java.time.OffsetDateTime
+
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.{Done, NotUsed}
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Flow, Sink}
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.instance.Instance.Id
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
-import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkPersistenceStore, ZkSerialized}
+import mesosphere.marathon.state.Instance
+import mesosphere.marathon.storage.repository.InstanceRepository
+import play.api.libs.json.{JsValue, Json}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Provides a help to get access to the underlying ZooKeeper store of the provided persistence store.
-  * See [[MigrationTo160]] for usage.
+  * See [[MigrationTo17]] for usage.
   */
 trait MaybeStore {
 
@@ -32,4 +45,63 @@ trait MaybeStore {
     */
   def maybeStore(persistenceStore: PersistenceStore[_, _, _]): Option[ZkPersistenceStore] = findZkStore(persistenceStore)
 
+}
+
+/**
+  * Provides a common pattern to migrate instances. This makes testing migrations easier.
+  */
+trait InstanceMigration extends MaybeStore with StrictLogging {
+
+  /**
+    * This function traverses all instances in ZK and passes them through the migration flow before saving the updates.
+    */
+  def migrateInstances(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+
+    val countingSink: Sink[Done, NotUsed] = Sink.fold[Int, Done](0) { case (count, Done) => count + 1 }
+      .mapMaterializedValue { f =>
+        f.map(i => logger.info(s"$i instances migrated"))
+        NotUsed
+      }
+
+    maybeStore(persistenceStore).map { store =>
+      instanceRepository
+        .ids()
+        .mapAsync(1) { instanceId =>
+          store.get[Id, JsValue](instanceId)
+        }
+        .collect {
+          case Some(jsValue) => jsValue
+        }
+        .via(migrationFlow)
+        .mapAsync(1) { updatedInstance =>
+          instanceRepository.store(updatedInstance)
+        }
+        .alsoTo(countingSink)
+        .runWith(Sink.ignore)
+    } getOrElse {
+      Future.successful(Done)
+    }
+  }
+
+  implicit val instanceResolver: IdResolver[Id, JsValue, String, ZkId] =
+    new IdResolver[Id, JsValue, String, ZkId] {
+      override def toStorageId(id: Id, version: Option[OffsetDateTime]): ZkId =
+        ZkId(category, id.idString, version)
+
+      override val category: String = "instance"
+
+      override def fromStorageId(key: ZkId): Id = Id.fromIdString(key.id)
+
+      override val hasVersions: Boolean = false
+
+      override def version(v: JsValue): OffsetDateTime = OffsetDateTime.MIN
+    }
+
+  implicit val instanceJsonUnmarshaller: Unmarshaller[ZkSerialized, JsValue] =
+    Unmarshaller.strict {
+      case ZkSerialized(byteString) =>
+        Json.parse(byteString.utf8String)
+    }
+
+  val migrationFlow: Flow[JsValue, Instance, NotUsed]
 }

--- a/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
@@ -71,11 +71,11 @@ object InstanceMigration extends MaybeStore with StrictLogging {
         .ids()
         .mapAsync(1) { instanceId =>
           store
-          .get[Id, JsValue](instanceId)
-          .map { 
-            case Some(jsValue) => Some(jsValue)
-            case None => logger.error(s"Failed to load an instance for $instanceId. It will be ignored"; None
-          }
+            .get[Id, JsValue](instanceId)
+            .map {
+              case Some(jsValue) => Some(jsValue)
+              case None => logger.error(s"Failed to load an instance for $instanceId. It will be ignored"); None
+            }
         }
         .collect {
           case Some(jsValue) => jsValue
@@ -91,6 +91,10 @@ object InstanceMigration extends MaybeStore with StrictLogging {
     }
   }
 
+  /**
+    * We copied the IdResolver and the unmarshaller so that changes to production won't impact any migration code. Some
+    * migrations may have to override this resolver.
+    */
   implicit val instanceResolver: IdResolver[Id, JsValue, String, ZkId] =
     new IdResolver[Id, JsValue, String, ZkId] {
       override def toStorageId(id: Id, version: Option[OffsetDateTime]): ZkId =

--- a/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
@@ -70,7 +70,12 @@ object InstanceMigration extends MaybeStore with StrictLogging {
       instanceRepository
         .ids()
         .mapAsync(1) { instanceId =>
-          store.get[Id, JsValue](instanceId)
+          store
+          .get[Id, JsValue](instanceId)
+          .map { 
+            case Some(jsValue) => Some(jsValue)
+            case None => logger.error(s"Failed to load an instance for $instanceId. It will be ignored"; None
+          }
         }
         .collect {
           case Some(jsValue) => jsValue

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo17.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo17.scala
@@ -25,11 +25,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class MigrationTo17(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _]) extends MigrationStep with StrictLogging {
 
   override def migrate()(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
-    MigrationTo17.migrateInstances(instanceRepository, persistenceStore)
+    InstanceMigration.migrateInstances(instanceRepository, persistenceStore, MigrationTo17.migrationFlow)
   }
 }
 
-object MigrationTo17 extends InstanceMigration with StrictLogging {
+object MigrationTo17 extends StrictLogging {
 
   import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 
@@ -132,7 +132,7 @@ object MigrationTo17 extends InstanceMigration with StrictLogging {
   def extractInstanceFromJson(jsValue: JsValue): Instance = jsValue.as[Instance](instanceJsonReads160)
 
   // This flow parses all provided instances and updates their conditions. It does not save the updated instances.
-  override val migrationFlow = Flow[JsValue]
+  val migrationFlow = Flow[JsValue]
     .map { jsValue =>
       extractInstanceFromJson(jsValue)
     }

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo18.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo18.scala
@@ -24,11 +24,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class MigrationTo18(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _]) extends MigrationStep with StrictLogging {
 
   override def migrate()(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
-    MigrationTo18.migrateInstances(instanceRepository, persistenceStore)
+    InstanceMigration.migrateInstances(instanceRepository, persistenceStore, MigrationTo18.migrationFlow)
   }
 }
 
-object MigrationTo18 extends InstanceMigration with StrictLogging {
+object MigrationTo18 extends StrictLogging {
 
   import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 
@@ -144,7 +144,7 @@ object MigrationTo18 extends InstanceMigration with StrictLogging {
     */
   def extractInstanceFromJson(jsValue: JsValue): ParsedValue[Instance] = jsValue.as[ParsedValue[Instance]](instanceJsonReads17)
 
-  override val migrationFlow = Flow[JsValue]
+  val migrationFlow = Flow[JsValue]
     .map(extractInstanceFromJson)
     .mapConcat {
       case ParsedValue(instance, Modified) =>

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo18100.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo18100.scala
@@ -24,11 +24,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class MigrationTo18100(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _]) extends MigrationStep with StrictLogging {
 
   override def migrate()(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
-    MigrationTo18100.migrateInstances(instanceRepository, persistenceStore)
+    InstanceMigration.migrateInstances(instanceRepository, persistenceStore, MigrationTo18100.migrationFlow)
   }
 }
 
-object MigrationTo18100 extends InstanceMigration with StrictLogging {
+object MigrationTo18100 extends StrictLogging {
 
   import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo18100.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo18100.scala
@@ -1,19 +1,15 @@
 package mesosphere.marathon
 package storage.migration
 
-import java.time.OffsetDateTime
-
 import akka.Done
-import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.scaladsl.Flow
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.v2.json.Formats
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.{Goal, Reservation}
 import mesosphere.marathon.core.instance.Instance.{AgentInfo, Id, InstanceState, agentFormat}
-import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkSerialized}
-import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
+import mesosphere.marathon.core.storage.store.PersistenceStore
 import mesosphere.marathon.core.task.{Task, TaskCondition}
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{Instance, Timestamp}
@@ -28,11 +24,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class MigrationTo18100(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _]) extends MigrationStep with StrictLogging {
 
   override def migrate()(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
-    MigrationTo18100.migrateInstanceCondition(instanceRepository, persistenceStore)
+    MigrationTo18100.migrateInstances(instanceRepository, persistenceStore)
   }
 }
 
-object MigrationTo18100 extends MaybeStore with StrictLogging {
+object MigrationTo18100 extends InstanceMigration with StrictLogging {
 
   import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 
@@ -96,49 +92,6 @@ object MigrationTo18100 extends MaybeStore with StrictLogging {
         val updatedState = state.copy(condition = condition)
         new Instance(instanceId, Some(agentInfo), updatedState, tasksMap, runSpecVersion, reservation)
       }
-  }
-
-  implicit val instanceResolver: IdResolver[Id, JsValue, String, ZkId] =
-    new IdResolver[Id, JsValue, String, ZkId] {
-      override def toStorageId(id: Id, version: Option[OffsetDateTime]): ZkId =
-        ZkId(category, id.idString, version)
-
-      override val category: String = "instance"
-
-      override def fromStorageId(key: ZkId): Id = Id.fromIdString(key.id)
-
-      override val hasVersions: Boolean = false
-
-      override def version(v: JsValue): OffsetDateTime = OffsetDateTime.MIN
-    }
-
-  implicit val instanceJsonUnmarshaller: Unmarshaller[ZkSerialized, JsValue] =
-    Unmarshaller.strict {
-      case ZkSerialized(byteString) =>
-        Json.parse(byteString.utf8String)
-    }
-
-  /**
-    * This function traverses all instances in ZK and sets the instance goal field.
-    */
-  def migrateInstanceCondition(instanceRepository: InstanceRepository, persistenceStore: PersistenceStore[_, _, _])(implicit mat: Materializer): Future[Done] = {
-
-    logger.info("Starting goal migration to Storage version 18.100")
-
-    maybeStore(persistenceStore).map { store =>
-      instanceRepository
-        .ids()
-        .mapAsync(1) { instanceId =>
-          store.get[Id, JsValue](instanceId)
-        }
-        .via(migrationFlow)
-        .mapAsync(1) { updatedInstance =>
-          instanceRepository.store(updatedInstance)
-        }
-        .runWith(Sink.ignore)
-    } getOrElse {
-      Future.successful(Done)
-    }
   }
 
   /**

--- a/src/test/scala/mesosphere/marathon/storage/migration/InstanceMigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/InstanceMigrationTest.scala
@@ -1,0 +1,61 @@
+package mesosphere.marathon
+package storage.migration
+
+import akka.{Done, NotUsed}
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.Instance.Id
+import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
+import mesosphere.marathon.state.{Instance, PathId}
+import mesosphere.marathon.storage.repository.InstanceRepository
+import play.api.libs.json.{JsObject, JsValue, Json}
+
+import scala.concurrent.Future
+
+class InstanceMigrationTest extends AkkaUnitTest with StrictLogging {
+
+  "Instance Migration" should {
+    "save only found and updated instances" in {
+
+      Given("two instances")
+      val f = new Fixture()
+
+      val instanceId1 = Id.forRunSpec(PathId("/app"))
+      val instanceId2 = Id.forRunSpec(PathId("/app2"))
+      val unknownInstanceId = Id.forRunSpec(PathId("/app3"))
+
+      f.instanceRepository.ids() returns Source(List(instanceId1, instanceId2, unknownInstanceId))
+      f.persistenceStore.get[Id, JsValue](equalTo(instanceId1))(any, any) returns Future(Some(f.legacyInstanceJson(instanceId1)))
+      f.persistenceStore.get[Id, JsValue](equalTo(instanceId2))(any, any) returns Future(Some(f.legacyInstanceJson(instanceId2)))
+      f.persistenceStore.get[Id, JsValue](equalTo(unknownInstanceId))(any, any) returns Future(None)
+      f.instanceRepository.store(any) returns Future.successful(Done)
+
+      When("they are migrated")
+      f.migration.migrateInstances(f.instanceRepository, f.persistenceStore).futureValue
+
+      Then("all updated instances are saved")
+      verify(f.instanceRepository, times(2)).store(any)
+    }
+  }
+
+  class Fixture {
+
+    val instanceRepository: InstanceRepository = mock[InstanceRepository]
+    val persistenceStore: ZkPersistenceStore = mock[ZkPersistenceStore]
+
+    val migration = new InstanceMigration {
+      override val migrationFlow: Flow[JsValue, Instance, NotUsed] = Flow[JsValue].map(_.as[Instance](Instance.instanceJsonReads))
+    }
+
+    def legacyInstanceJson(i: Id): JsObject = Json.parse(
+      s"""
+         |{
+         |  "instanceId": { "idString": "${i.idString}" },
+         |  "tasksMap": {},
+         |  "runSpecVersion": "2015-01-01T12:00:00.000Z",
+         |  "agentInfo": { "host": "localhost", "attributes": [] },
+         |  "state": { "since": "2015-01-01T12:00:00.000Z", "condition": { "str": "Running" }, "goal": "Running" }
+         |}""".stripMargin).as[JsObject]
+  }
+}

--- a/src/test/scala/mesosphere/marathon/storage/migration/InstanceMigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/InstanceMigrationTest.scala
@@ -1,8 +1,8 @@
 package mesosphere.marathon
 package storage.migration
 
-import akka.{Done, NotUsed}
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.Done
+import akka.stream.scaladsl.{Flow, Source}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.instance.Instance.Id

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo17Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo17Test.scala
@@ -3,44 +3,19 @@ package storage.migration
 
 import java.util.Base64
 
-import akka.Done
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.instance.{Goal, Instance}
-import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.PathId
-import mesosphere.marathon.storage.repository.InstanceRepository
 import org.apache.mesos.{Protos => MesosProtos}
 import org.scalatest.Inspectors
 import play.api.libs.json.{JsObject, JsValue, Json}
 
-import scala.concurrent.Future
-
 class MigrationTo17Test extends AkkaUnitTest with StrictLogging with Inspectors {
 
   "Migration to 17" should {
-    "save updated instances" in {
-
-      Given("two ephemeral instances")
-      val f = new Fixture()
-
-      val instanceId1 = Instance.Id.forRunSpec(PathId("/app"))
-      val instanceId2 = Instance.Id.forRunSpec(PathId("/app2"))
-
-      f.instanceRepository.ids() returns Source(List(instanceId1, instanceId2))
-      f.persistenceStore.get[Instance.Id, JsValue](equalTo(instanceId1))(any, any) returns Future(Some(f.legacyInstanceJson(instanceId1)))
-      f.persistenceStore.get[Instance.Id, JsValue](equalTo(instanceId2))(any, any) returns Future(Some(f.legacyInstanceJson(instanceId2)))
-      f.instanceRepository.store(any) returns Future.successful(Done)
-
-      When("they are migrated")
-      MigrationTo17.migrateInstanceGoals(f.instanceRepository, f.persistenceStore).futureValue
-
-      Then("all updated instances are saved")
-      verify(f.instanceRepository, times(2)).store(any)
-    }
-
     "update only instances that are found" in {
 
       Given("two ephemeral instances and one that was not found")
@@ -48,7 +23,7 @@ class MigrationTo17Test extends AkkaUnitTest with StrictLogging with Inspectors 
       val instanceId1 = Instance.Id.forRunSpec(PathId("/app"))
       val instanceId2 = Instance.Id.forRunSpec(PathId("/app2"))
 
-      val instances = Source(List(Some(f.legacyInstanceJson(instanceId1)), None, Some(f.legacyInstanceJson(instanceId2))))
+      val instances = Source(List(f.legacyInstanceJson(instanceId1), f.legacyInstanceJson(instanceId2)))
 
       When("they are run through the migration flow")
       val updatedInstances = instances.via(MigrationTo17.migrationFlow).runWith(Sink.seq).futureValue
@@ -65,7 +40,7 @@ class MigrationTo17Test extends AkkaUnitTest with StrictLogging with Inspectors 
       val instanceId1 = Instance.Id.forRunSpec(PathId("/app"))
       val instanceId2 = Instance.Id.forRunSpec(PathId("/app2"))
 
-      val instances = Source(List(Some(f.legacyInstanceJson(instanceId1)), None, Some(f.legacyResidentInstanceJson(instanceId2))))
+      val instances = Source(List(f.legacyInstanceJson(instanceId1), f.legacyResidentInstanceJson(instanceId2)))
 
       When("they are run through the migration flow")
       val updatedInstances = instances.via(MigrationTo17.migrationFlow).runWith(Sink.seq).futureValue
@@ -77,9 +52,6 @@ class MigrationTo17Test extends AkkaUnitTest with StrictLogging with Inspectors 
   }
 
   class Fixture {
-
-    val instanceRepository: InstanceRepository = mock[InstanceRepository]
-    val persistenceStore: ZkPersistenceStore = mock[ZkPersistenceStore]
 
     /**
       * Construct a 1.6.0 version JSON for an instance.

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18100Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18100Test.scala
@@ -37,9 +37,8 @@ class MigrationTo18100Test extends AkkaUnitTest with StrictLogging with TableDri
 
         val taskId = Task.Id(instanceId2)
         val instances = Source(List(
-          Some(f.legacyInstanceJson(instanceId1)),
-          None,
-          Some(f.legacyResidentInstanceJson(instanceId2, taskId.idString, f.task(taskId, mesosState)))
+          f.legacyInstanceJson(instanceId1),
+          f.legacyResidentInstanceJson(instanceId2, taskId.idString, f.task(taskId, mesosState))
         ))
 
         When("they are run through the migration flow")

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18100Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18100Test.scala
@@ -8,10 +8,8 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.storage.store.impl.zk.ZkPersistenceStore
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.PathId
-import mesosphere.marathon.storage.repository.InstanceRepository
 import org.apache.mesos.{Protos => MesosProtos}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import play.api.libs.json.{JsObject, JsValue, Json}
@@ -55,9 +53,6 @@ class MigrationTo18100Test extends AkkaUnitTest with StrictLogging with TableDri
   }
 
   class Fixture {
-
-    val instanceRepository: InstanceRepository = mock[InstanceRepository]
-    val persistenceStore: ZkPersistenceStore = mock[ZkPersistenceStore]
 
     /**
       * Construct a 1.6.0 version JSON for an instance.

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18Test.scala
@@ -51,7 +51,7 @@ class MigrationTo18Test extends AkkaUnitTest with StrictLogging with Inspectors 
       f.instanceRepository.store(equalTo(instance3)) returns Future.successful(Done) //instance is unchanged
 
       When("they are migrated")
-      MigrationTo18.migrateInstanceConditions(f.instanceRepository, f.persistenceStore).futureValue
+      MigrationTo18.migrateInstances(f.instanceRepository, f.persistenceStore).futureValue
 
       Then("all updated instances are saved")
       verify(f.instanceRepository, times(2)).store(any)

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo18Test.scala
@@ -51,7 +51,7 @@ class MigrationTo18Test extends AkkaUnitTest with StrictLogging with Inspectors 
       f.instanceRepository.store(equalTo(instance3)) returns Future.successful(Done) //instance is unchanged
 
       When("they are migrated")
-      MigrationTo18.migrateInstances(f.instanceRepository, f.persistenceStore).futureValue
+      InstanceMigration.migrateInstances(f.instanceRepository, f.persistenceStore, MigrationTo18.migrationFlow).futureValue
 
       Then("all updated instances are saved")
       verify(f.instanceRepository, times(2)).store(any)


### PR DESCRIPTION
Summary:
We can save some code and testing with a little instance migration
helper.

Depends on #6658.