### PR TITLE
Import ujson instead of upickle.

### DIFF
--- a/ci/dataDogClient.sc
+++ b/ci/dataDogClient.sc
@@ -2,7 +2,7 @@
 
 import java.time.Instant
 import scalaj.http._
-import upickle._
+import ujson._
 
 /**
  * Makes a POST request to DataDog's API with provided path and body.


### PR DESCRIPTION
Summary:
Our DataDog client was not reporting system test stats because of the
Ammonite 1.5.0 update.