### PR TITLE
Speed up integration tests.

### DIFF
--- a/tests/integration/src/test/scala/mesosphere/IntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/IntegrationTest.scala
@@ -5,12 +5,12 @@ import mesosphere.marathon.integration.setup.RestResult
 import mesosphere.marathon.raml.{PodState, PodStatus}
 import org.scalatest._
 import org.scalatest.matchers.{BeMatcher, MatchResult}
-import org.scalatest.time.{Minutes, Seconds, Span}
+import org.scalatest.time.{Milliseconds, Minutes, Seconds, Span}
 
 trait IntegrationTestLike extends UnitTestLike {
   override val timeLimit = Span(15, Minutes)
 
-  override implicit lazy val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(300, Seconds))
+  override implicit lazy val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(300, Seconds), interval = Span(5, Milliseconds))
 
   // Integration tests using docker image provisioning with the Mesos containerizer need to be
   // run as root in a Linux environment. They have to be explicitly enabled through an env variable.

--- a/tests/integration/src/test/scala/mesosphere/IntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/IntegrationTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.time.{Milliseconds, Minutes, Seconds, Span}
 trait IntegrationTestLike extends UnitTestLike {
   override val timeLimit = Span(15, Minutes)
 
-  override implicit lazy val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(300, Seconds), interval = Span(5, Milliseconds))
+  override implicit lazy val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(60, Seconds), interval = Span(5, Milliseconds))
 
   // Integration tests using docker image provisioning with the Mesos containerizer need to be
   // run as root in a Linux environment. They have to be explicitly enabled through an env variable.

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -163,7 +163,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
         marathon.status(pod.id) should be(Stable)
         val status = marathon.status(pod.id).value
         val hosts = status.instances.flatMap(_.agentHostname)
-        hosts should have size(1)
+        hosts should have size (1)
         val ports = status.instances.flatMap(_.containers.flatMap(_.endpoints.flatMap(_.allocatedHostPort)))
         ports should have size (1)
         val facade = AppMockFacade(hosts.head, ports.head)


### PR DESCRIPTION
Summary:
With a patience config of five minutes we also scale the interval. This
diff sets the interval to five milliseconds.