### PR TITLE
Update Ammonite in AMI `JenkinsMarathonCI-Debian9-2018-12-17`.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ ansiColor('xterm') {
       user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#marathon-dev')
     }
   }
-  node('JenkinsMarathonCI-Debian9-2018-04-09') {
+  node('JenkinsMarathonCI-Debian9-2018-12-17') {
     stage("Run Pipeline") {
       try {
         checkout scm

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 ansiColor('xterm') {
-  node('JenkinsMarathonCI-Debian9-2018-04-09') {
+  node('JenkinsMarathonCI-Debian9-2018-12-17') {
 
     properties([
       parameters([

--- a/ami/install.bash
+++ b/ami/install.bash
@@ -67,7 +67,8 @@ apt-get -y update
 # Install but do not start Mesos master/slave processes
 # The CI task will install Mesos later.
 apt-get install -y --force-yes --no-install-recommends mesos=$MESOS_VERSION
-systemctl stop mesos-master.service mesos-slave.service mesos_executor.slice
+systemctl stop mesos-master.service mesos-slave.service
+systemctl disable mesos-master.service mesos-slave.service
 
 # Add user to docker group
 gpasswd -a admin docker

--- a/ami/marathon-jenkins-ami.json
+++ b/ami/marathon-jenkins-ami.json
@@ -10,8 +10,8 @@
   "builders": [{
     "type": "amazon-ebs",
     "region": "us-east-1",
-    "source_ami": "ami-f6e6948c",
-    "instance_type": "m4.xlarge",
+    "source_ami": "ami-0bd9223868b4778d7",
+    "instance_type": "m5.2xlarge",
     "vpc_id": "vpc-f46c7c8d",
     "subnet_id": "subnet-1d724531",
     "ssh_username": "admin",

--- a/ci/dataDogClient.sc
+++ b/ci/dataDogClient.sc
@@ -2,7 +2,7 @@
 
 import java.time.Instant
 import scalaj.http._
-import upickle._
+import ujson._
 
 /**
  * Makes a POST request to DataDog's API with provided path and body.

--- a/ci/githubClient.sc
+++ b/ci/githubClient.sc
@@ -8,7 +8,7 @@ import $file.awsClient
 
 import scala.util.control.NonFatal
 import scalaj.http._
-import upickle._
+import ujson._
 
 /**
  * Makes a POST request to GitHub's API with path and body.

--- a/ci/provision.sc
+++ b/ci/provision.sc
@@ -102,7 +102,7 @@ def killStaleTestProcesses(): Unit = {
 }
 
 def installDcosCli(): Unit = {
-  val command = Path.root / 'usr / 'local / 'bin / 'dcos
+  val command = os.root / 'usr / 'local / 'bin / 'dcos
 
   if( ! (exists! command)) {
     val os = %%("uname", "-s").out.string.trim.toLowerCase

--- a/tests/system/test_marathon_universe.py
+++ b/tests/system/test_marathon_universe.py
@@ -91,7 +91,7 @@ def package(request):
     try:
         uninstall_package_and_wait(package_name)
         delete_persistent_data('{}-role'.format(package_name), 'dcos-service-{}'.format(package_name))
-    except Exception as e:
+    except Exception:
         # cleanup does NOT fail the test
         logger.exception('Faild to uninstall {} package'.format(package_name))
 


### PR DESCRIPTION
Summary:
We're using the latest Debian9 as a base image and `m5.2xlarge` instances. Updated AMI's `install.bash` script with recommended Docker installation.

Co-authored-by: Karsten Jeschkies <k@jeschkies.xyz>
