### PR TITLE
Make instance tracker module base of scheduler module.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/CoreModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModule.scala
@@ -19,7 +19,7 @@ import mesosphere.marathon.core.pod.PodModule
 import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
-import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
+import mesosphere.marathon.core.task.tracker.SchedulerModule
 import mesosphere.marathon.storage.StorageModule
 
 /**
@@ -37,7 +37,7 @@ trait CoreModule {
   def electionModule: ElectionModule
   def eventModule: EventModule
   def groupManagerModule: GroupManagerModule
-  def instanceTrackerModule: InstanceTrackerModule
+  def instanceTrackerModule: SchedulerModule
   def healthModule: HealthModule
   def historyModule: HistoryModule
   def launcherModule: LauncherModule

--- a/src/main/scala/mesosphere/marathon/core/CoreModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModule.scala
@@ -19,7 +19,7 @@ import mesosphere.marathon.core.pod.PodModule
 import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
-import mesosphere.marathon.core.task.tracker.SchedulerModule
+import mesosphere.marathon.scheduler.SchedulerModule
 import mesosphere.marathon.storage.StorageModule
 
 /**

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -35,7 +35,7 @@ import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.storage.store.impl.zk.RichCuratorFramework
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
-import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
+import mesosphere.marathon.core.task.tracker.SchedulerModule
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
 import mesosphere.marathon.storage.{StorageConf, StorageConfig, StorageModule}
 import mesosphere.marathon.stream.EnrichedFlow
@@ -95,7 +95,7 @@ class CoreModuleImpl @Inject() (
   // TASKS
   val storageExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(marathonConf.asInstanceOf[StorageConf].storageExecutionContextSize(), "storage-module")
   override lazy val instanceTrackerModule =
-    new InstanceTrackerModule(metricsModule.metrics, clock, marathonConf, leadershipModule,
+    new SchedulerModule(metricsModule.metrics, clock, marathonConf, leadershipModule,
       storageModule.instanceRepository, storageModule.groupRepository, instanceUpdateSteps)(actorsModule.materializer)
   override lazy val taskJobsModule = new TaskJobsModule(marathonConf, leadershipModule, clock)
 

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -35,8 +35,8 @@ import mesosphere.marathon.core.readiness.ReadinessModule
 import mesosphere.marathon.core.storage.store.impl.zk.RichCuratorFramework
 import mesosphere.marathon.core.task.jobs.TaskJobsModule
 import mesosphere.marathon.core.task.termination.TaskTerminationModule
-import mesosphere.marathon.core.task.tracker.SchedulerModule
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
+import mesosphere.marathon.scheduler.SchedulerModule
 import mesosphere.marathon.storage.{StorageConf, StorageConfig, StorageModule}
 import mesosphere.marathon.stream.EnrichedFlow
 import mesosphere.util.NamedExecutionContext

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -6,8 +6,8 @@ import java.time.Clock
 import akka.actor.{ActorRef, Props}
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.termination.impl.{KillServiceActor, KillServiceDelegate}
-import mesosphere.marathon.core.task.tracker.SchedulerModule
 import mesosphere.marathon.metrics.Metrics
+import mesosphere.marathon.scheduler.SchedulerModule
 
 class TaskTerminationModule(
     instanceTrackerModule: SchedulerModule,

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -6,11 +6,11 @@ import java.time.Clock
 import akka.actor.{ActorRef, Props}
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.termination.impl.{KillServiceActor, KillServiceDelegate}
-import mesosphere.marathon.core.task.tracker.InstanceTrackerModule
+import mesosphere.marathon.core.task.tracker.SchedulerModule
 import mesosphere.marathon.metrics.Metrics
 
 class TaskTerminationModule(
-    instanceTrackerModule: InstanceTrackerModule,
+    instanceTrackerModule: SchedulerModule,
     leadershipModule: LeadershipModule,
     driverHolder: MarathonSchedulerDriverHolder,
     config: KillConfig,

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerUpdateStepProcessor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerUpdateStepProcessor.scala
@@ -9,6 +9,6 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
   * Internal processor that handles performing all required steps after a task tracker update.
   */
-private[tracker] trait InstanceTrackerUpdateStepProcessor {
+trait InstanceTrackerUpdateStepProcessor {
   def process(change: InstanceChange)(implicit ec: ExecutionContext): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -49,7 +49,7 @@ object InstanceTrackerActor {
     def instanceId: Instance.Id = operation.instanceId
   }
 
-  private[tracker] class ActorMetrics(val metrics: Metrics) {
+  class ActorMetrics(val metrics: Metrics) {
     // We can't use Metrics as we need custom names for compatibility.
     val stagedTasksMetric: SettableGauge = metrics.settableGauge("instances.staged")
     val runningTasksMetric: SettableGauge = metrics.settableGauge("instances.running")
@@ -66,7 +66,7 @@ object InstanceTrackerActor {
   * Holds the current in-memory version of all task state. It gets informed of task state changes
   * after they have been persisted.
   */
-private[impl] class InstanceTrackerActor(
+class InstanceTrackerActor(
     metrics: InstanceTrackerActor.ActorMetrics,
     instanceLoader: InstancesLoader,
     updateStepProcessor: InstanceTrackerUpdateStepProcessor,

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -29,7 +29,7 @@ import scala.util.{Failure, Success}
   * This is used for the "global" InstanceTracker trait and it is also
   * is used internally in this package to communicate with the InstanceTracker.
   */
-private[tracker] class InstanceTrackerDelegate(
+class InstanceTrackerDelegate(
     metrics: Metrics,
     clock: Clock,
     config: InstanceTrackerConfig,

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerUpdateStepProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerUpdateStepProcessorImpl.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * Takes care of processing [[InstanceChange]]s and will be called after an instance state
   * change has been persisted in the repository
   */
-private[tracker] class InstanceTrackerUpdateStepProcessorImpl(
+class InstanceTrackerUpdateStepProcessorImpl(
     metrics: Metrics,
     steps: Seq[InstanceChangeHandler]) extends InstanceTrackerUpdateStepProcessor with StrictLogging {
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstancesLoaderImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstancesLoaderImpl.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 /**
   * Loads all task data into an [[InstanceTracker.InstancesBySpec]] from an [[mesosphere.marathon.storage.repository.InstanceRepository]].
   */
-private[tracker] class InstancesLoaderImpl(
+class InstancesLoaderImpl(
     repo: InstanceView,
     config: InstanceTrackerConfig)(implicit val mat: Materializer)
   extends InstancesLoader with StrictLogging {

--- a/src/main/scala/mesosphere/marathon/scheduler/SchedulerModule.scala
+++ b/src/main/scala/mesosphere/marathon/scheduler/SchedulerModule.scala
@@ -1,5 +1,5 @@
 package mesosphere.marathon
-package core.task.tracker
+package scheduler
 
 import java.time.Clock
 

--- a/src/main/scala/mesosphere/marathon/scheduler/SchedulerModule.scala
+++ b/src/main/scala/mesosphere/marathon/scheduler/SchedulerModule.scala
@@ -6,12 +6,13 @@ import java.time.Clock
 import akka.stream.Materializer
 import mesosphere.marathon.core.instance.update.{InstanceChangeHandler, InstanceUpdateOpResolver}
 import mesosphere.marathon.core.leadership.LeadershipModule
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerConfig, InstanceTrackerUpdateStepProcessor}
 import mesosphere.marathon.core.task.tracker.impl._
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.storage.repository.{GroupRepository, InstanceRepository, InstanceView}
 
 /**
-  * Provides the interfaces to query or update the current instance state ([[InstanceTracker]]).
+  * Provides the interfaces to query or update the current instance state ([[mesosphere.marathon.core.task.tracker.InstanceTracker]]).
   */
 class SchedulerModule(
     metrics: Metrics,

--- a/src/main/scala/mesosphere/marathon/scheduler/SchedulerModule.scala
+++ b/src/main/scala/mesosphere/marathon/scheduler/SchedulerModule.scala
@@ -13,7 +13,7 @@ import mesosphere.marathon.storage.repository.{GroupRepository, InstanceReposito
 /**
   * Provides the interfaces to query or update the current instance state ([[InstanceTracker]]).
   */
-class InstanceTrackerModule(
+class SchedulerModule(
     metrics: Metrics,
     clock: Clock,
     config: InstanceTrackerConfig,

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.core.leadership.{AlwaysElectedLeadershipModule, Leade
 import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
 import mesosphere.marathon.core.task.termination.KillService
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerModule}
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, SchedulerModule}
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.{CaptureEvents, MarathonTestHelper, SettableClock}
@@ -37,7 +37,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
 
   case class Fixture() {
     val leadershipModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
-    val instanceTrackerModule: InstanceTrackerModule = MarathonTestHelper.createTaskTrackerModule(leadershipModule)
+    val instanceTrackerModule: SchedulerModule = MarathonTestHelper.createTaskTrackerModule(leadershipModule)
     implicit val instanceTracker: InstanceTracker = instanceTrackerModule.instanceTracker
     val groupManager: GroupManager = mock[GroupManager]
     implicit val eventStream: EventStream = new EventStream(system)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -12,9 +12,10 @@ import mesosphere.marathon.core.leadership.{AlwaysElectedLeadershipModule, Leade
 import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
 import mesosphere.marathon.core.task.termination.KillService
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, SchedulerModule}
+import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.state._
+import mesosphere.marathon.scheduler.SchedulerModule
 import mesosphere.marathon.test.{CaptureEvents, MarathonTestHelper, SettableClock}
 import org.apache.mesos.Protos.TaskStatus
 import org.apache.mesos.{Protos => mesos}

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerModule}
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, SchedulerModule}
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.state.PathId.StringPathId
@@ -43,7 +43,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
     implicit val state: InstanceRepository = spy(InstanceRepository.inMemRepository(store))
     val config: AllConf = MarathonTestHelper.defaultConfig()
     implicit val clock: SettableClock = new SettableClock()
-    val taskTrackerModule: InstanceTrackerModule = MarathonTestHelper.createTaskTrackerModule(
+    val taskTrackerModule: SchedulerModule = MarathonTestHelper.createTaskTrackerModule(
       AlwaysElectedLeadershipModule.forRefFactory(system), Some(state))
     implicit val instanceTracker: InstanceTracker = taskTrackerModule.instanceTracker
   }

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -10,9 +10,10 @@ import mesosphere.marathon.core.leadership.AlwaysElectedLeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.{AgentInfoPlaceholder, NetworkInfoPlaceholder}
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, SchedulerModule}
+import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.metrics.dummy.DummyMetrics
+import mesosphere.marathon.scheduler.SchedulerModule
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp, VersionInfo}
 import mesosphere.marathon.storage.repository.InstanceRepository

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -13,7 +13,7 @@ import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.pod.Network
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerModule}
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, SchedulerModule}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.raml.Resources
 import mesosphere.marathon.state.Container.Docker
@@ -339,7 +339,7 @@ object MarathonTestHelper {
   def createTaskTrackerModule(
     leadershipModule: LeadershipModule,
     instanceStore: Option[InstanceRepository] = None,
-    groupStore: Option[GroupRepository] = None)(implicit mat: Materializer): InstanceTrackerModule = {
+    groupStore: Option[GroupRepository] = None)(implicit mat: Materializer): SchedulerModule = {
 
     implicit val ctx = ExecutionContext.Implicits.global
     val instanceRepo = instanceStore.getOrElse {
@@ -358,7 +358,7 @@ object MarathonTestHelper {
     }
     val updateSteps = Seq.empty[InstanceChangeHandler]
 
-    new InstanceTrackerModule(metrics, clock, defaultConfig(), leadershipModule, instanceRepo, groupRepo, updateSteps) {
+    new SchedulerModule(metrics, clock, defaultConfig(), leadershipModule, instanceRepo, groupRepo, updateSteps) {
       // some tests create only one actor system but create multiple task trackers
       override protected lazy val instanceTrackerActorName: String = s"taskTracker_${Random.alphanumeric.take(10).mkString}"
     }

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -13,9 +13,10 @@ import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.core.pod.Network
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, SchedulerModule}
+import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.raml.Resources
+import mesosphere.marathon.scheduler.SchedulerModule
 import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state.Container.PortMapping
 import mesosphere.marathon.state.PathId._


### PR DESCRIPTION
Summary:
This will ease making the scheduler code its own sbt project.