### PR TITLE
Fix overscaling during app upgrade

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActor.scala
@@ -254,7 +254,7 @@ class DeploymentManagerActor(
     async {
       await(Future.sequence(cancellations))
 
-      logger.info(s"Conflicting deployments ${toCancel.map(_.plan.id)} for deployment ${plan.id} have been canceled")
+      logger.info(s"Conflicting deployments ${conflicts.map(_.plan.id)} for deployment ${plan.id} have been canceled")
       self ! LaunchDeployment(plan)
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/ReadinessBehavior.scala
@@ -78,9 +78,6 @@ trait ReadinessBehavior extends StrictLogging { this: Actor =>
   def instanceTerminated(instanceId: Instance.Id): Unit = {
     healthy -= instanceId
     ready -= instanceId
-    subscriptions.keys.withFilter(_.taskId.instanceId == instanceId).foreach { key =>
-      subscriptions.get(key).foreach(_.cancel())
-    }
   }
 
   def healthyInstances: Set[Instance.Id] = healthy

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -114,7 +114,7 @@ class TaskReplaceActor(
   private def initialized: Receive = readinessBehavior orElse replaceBehavior
 
   /**
-    * This actor is a good example on how future orchestrator might handle the instances. The logic below handles instance
+    * This actor is a bad example on how future orchestrator might handle the instances. The logic below handles instance
     * changed across three dimensions:
     *
     * a) old vs. new - instances with old RunSpec version are gradually replaced with the new one
@@ -122,8 +122,11 @@ class TaskReplaceActor(
     *            Goal.Running then it will be automatically rescheduled by the TaskLauncherActor
     * c) condition - we additionally check whether or not the instance is considered terminal/active
     *
-    * This actor finishes its work when all old instances are successfully decommissioned and all new ones are up and
-    * running (and possibly ready and healthy).
+    * What makes it so hard to work with, is the fact, that it basically counts old and new instances and the additional
+    * dimensions are expressed through filters on the [[InstanceChanged]] events. It can be a more robust state-machine
+    * which ideally has a set of new and old instances which then decommissions old ones and schedules new ones, never
+    * incrementing/decrementing counters and never over/under scales.
+    *
     */
   def replaceBehavior: Receive = {
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -59,7 +59,7 @@ class TaskReplaceActor(
   private[this] def newInstanceIds(id: Instance.Id): Boolean = !oldInstanceIds(id)
 
   // All instances to kill queued up
-  private[this] val toKill: mutable.Queue[Instance.Id] = instancesToRemove.map(_.instanceId).to[mutable.Queue]
+  private[this] val toKill: mutable.Queue[Instance.Id] = instancesToRemove.filter(_.state.goal == Goal.Running).map(_.instanceId).to[mutable.Queue]
 
   // The number of started instances. Defaults to the number of already started instances.
   var instancesStarted: Int = instancesAlreadyStarted.size
@@ -167,7 +167,7 @@ class TaskReplaceActor(
 
   def reconcileAlreadyStartedInstances(): Unit = {
     logger.info(s"Reconciling instances during ${runSpec.id} deployment: found ${instancesAlreadyStarted.size} already started instances " +
-      s"and ${oldInstanceIds.size} old instances: ${if (currentInstances.size > 0) currentInstances.map{ i => i.instanceId -> i.state.condition } else ""}")
+      s"and ${oldInstanceIds.size} old instances: ${if (currentInstances.size > 0) currentInstances.map{ i => i.instanceId -> i.state.condition } else "[]"}")
     instancesAlreadyStarted.foreach(reconcileHealthAndReadinessCheck)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -57,12 +57,15 @@ class TaskReplaceActor(
 
   // compute all variables maintained in this actor =========================================================
 
+  // Only old instances that still have the Goal.Running
+  val oldActiveInstances = oldInstances.filter(_.state.goal == Goal.Running)
+
   // All instances to kill as set for quick lookup
-  private[this] var oldInstanceIds: SortedSet[Id] = oldInstances.map(_.instanceId).to[SortedSet]
+  private[this] var oldInstanceIds: SortedSet[Id] = oldActiveInstances.map(_.instanceId).to[SortedSet]
   private[this] def newInstanceIds(id: Instance.Id): Boolean = !oldInstanceIds(id)
 
   // All instances to kill queued up
-  private[this] val toKill: mutable.Queue[Instance.Id] = oldInstances.filter(_.state.goal == Goal.Running).map(_.instanceId).to[mutable.Queue]
+  private[this] val toKill: mutable.Queue[Instance.Id] = oldActiveInstances.map(_.instanceId).to[mutable.Queue]
 
   // The number of started instances. Defaults to the number of already started instances.
   var instancesStarted: Int = instancesAlreadyStarted.size

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -50,7 +50,7 @@ class TaskReplaceActor(
   }
 
   // The ignition strategy for this run specification
-  private[this] val ignitionStrategy = computeRestartStrategy(runSpec, currentInstances.size)
+  private[this] val ignitionStrategy = computeRestartStrategy(runSpec, currentInstances.filter(_.state.goal == Goal.Running).size)
 
   // compute all variables maintained in this actor =========================================================
 

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -126,10 +126,10 @@ object InstanceUpdater extends StrictLogging {
     val events = eventsGenerator.events(updatedInstance, task = None, now, previousState = Some(instance.state))
 
     if (InstanceUpdater.shouldBeExpunged(updatedInstance)) {
-      logger.info(s"Instance ${instance.instanceId} with current condition ${instance.state.condition} has it's goal updated to ${op.goal}. Because of that instance should be expunged now.")
+      logger.info(s"Instance ${instance.instanceId} with current condition ${instance.state.condition} has it's goal updated from ${instance.state.goal} to ${op.goal}. Because of that instance should be expunged now.")
       InstanceUpdateEffect.Expunge(updatedInstance, events = events)
     } else {
-      logger.info(s"Updating goal of instance ${instance.instanceId} with current condition ${instance.state.condition} to ${op.goal}")
+      logger.info(s"Instance ${instance.instanceId} with current condition ${instance.state.condition} has it's goal updated from ${instance.state.goal} to ${op.goal}.")
       InstanceUpdateEffect.Update(updatedInstance, oldState = Some(instance), events = events)
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -289,7 +289,7 @@ private[impl] class LaunchQueueActor(
       if (instancesToSchedule.nonEmpty) {
         await(instanceTracker.schedule(instancesToSchedule))
       }
-      logger.info(s"Scheduling (${instancesToSchedule.length}) new instances (first five: ${instancesToSchedule.take(5)} ) " +
+      logger.info(s"Scheduling ${instancesToSchedule.length} new instances (first five: ${instancesToSchedule.take(5)} ) " +
         s"and rescheduling (${existingReservedStoppedInstances.length}) reserved instances due to LaunchQueue.Add for ${runSpec.id}")
 
       AddFinished(queuedItem)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -68,7 +68,7 @@ trait InstanceTracker extends StrictLogging {
   def schedule(instance: Instance): Future[Done]
 
   def schedule(instances: Instance*)(implicit ec: ExecutionContext): Future[Done] = {
-    logger.info(s"Scheduling instances $instances")
+    logger.info(s"Scheduling instances ${instances.mkString(",\n")}")
     Future.sequence(instances.map(schedule)).map { _ => Done }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -117,7 +117,7 @@ private[tracker] class InstanceTrackerDelegate(
 
     val promise = Promise[InstanceUpdateEffect]
     queue.offer(QueuedUpdate(update, promise)).map {
-      case QueueOfferResult.Enqueued => logger.info(s"Queued instance update operation ${update.operation.shortString}")
+      case QueueOfferResult.Enqueued => logger.info(s"Queued ${update.operation.shortString}")
       case QueueOfferResult.Dropped => throw new RuntimeException(s"Dropped instance update: $update")
       case QueueOfferResult.Failure(ex) => throw new RuntimeException(s"Failed to process instance update $update because", ex)
       case QueueOfferResult.QueueClosed => throw new RuntimeException(s"Failed to process instance update $update because the queue is closed")

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/ResidentTaskIntegrationTest.scala
@@ -64,7 +64,7 @@ class ResidentTaskIntegrationTest extends AkkaIntegrationTest with EmbeddedMarat
         containerPath = containerPath,
         cmd = s"""echo data > $containerPath/data && sleep 1000""")
 
-      When("a task is launched")
+      When("deployment is successful")
       val result = createAsynchronously(app)
 
       Then("it successfully writes to the persistent volume and then finishes")


### PR DESCRIPTION
SI `test_app_update_rollback` caught a bug where `TaskReplaceActor` would overscale during app upgrades due to the recent introduction of instance goals. This commit fixes this bug.

Fixes: MARATHON-8537
