### PR TITLE
Stop expunging instances at TaskKiller level

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -18,7 +18,6 @@ import mesosphere.marathon.state._
 
 import scala.async.Async.{async, await}
 import scala.concurrent.Future
-import scala.util.control.NonFatal
 
 class TaskKiller @Inject() (
     instanceTracker: InstanceTracker,

--- a/src/main/scala/mesosphere/marathon/core/instance/GoalChangeReason.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/GoalChangeReason.scala
@@ -17,7 +17,7 @@ object GoalChangeReason {
   case object DeletingApp extends GoalChangeReason
 
   /** The goal is changed because of an incoming http request */
-  case object UserRequest extends GoalChangeReason
+  case object UserRequestedWipe extends GoalChangeReason
 
   /** The goal is changed because a new version is being deployed */
   case object Upgrading extends GoalChangeReason

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.instance.update
 
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.{Goal, Instance, Reservation}
+import mesosphere.marathon.core.instance.{Goal, GoalChangeReason, Instance, Reservation}
 import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.task.{Task, TaskCondition}
 import mesosphere.marathon.state.{RunSpec, Timestamp}
@@ -72,8 +72,8 @@ object InstanceUpdateOperation {
 
   case class ReservationTimeout(instanceId: Instance.Id) extends InstanceUpdateOperation
 
-  case class ChangeGoal(instanceId: Instance.Id, goal: Goal) extends InstanceUpdateOperation {
-    override def shortString: String = s"${this.getClass.getSimpleName} instance update operation for $instanceId with new goal $goal"
+  case class ChangeGoal(instanceId: Instance.Id, goal: Goal, reason: GoalChangeReason) extends InstanceUpdateOperation {
+    override def shortString: String = s"${this.getClass.getSimpleName} instance update operation for $instanceId with new goal $goal because of $reason"
   }
 
   /** Expunge a task whose TaskOp was rejected */

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -163,7 +163,7 @@ private[tracker] class InstanceTrackerDelegate(
     import scala.concurrent.ExecutionContext.Implicits.global
 
     logger.info(s"adjusting $instanceId to goal $goal ($reason)")
-    process(InstanceUpdateOperation.ChangeGoal(instanceId, goal)).map(_ => Done)
+    process(InstanceUpdateOperation.ChangeGoal(instanceId, goal, reason)).map(_ => Done)
   }
 
   override val instanceUpdates: Source[InstanceChange, NotUsed] = {

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.InstanceUpdateEffect.Update
 import mesosphere.marathon.core.instance.update.InstanceUpdateOperation.RescheduleReserved
-import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.instance.{Goal, GoalChangeReason, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.task.bus.{MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper}
 import mesosphere.marathon.core.task.state.TaskConditionMapping
 import mesosphere.marathon.core.task.{Task, TaskCondition}
@@ -239,7 +239,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
       val scheduled = Instance.scheduled(runSpec)
 
       When("it is decommissioned")
-      val operation = InstanceUpdateOperation.ChangeGoal(scheduled.instanceId, Goal.Decommissioned)
+      val operation = InstanceUpdateOperation.ChangeGoal(scheduled.instanceId, Goal.Decommissioned, GoalChangeReason.UserRequestedWipe)
       val stateChange = updateOpResolver.resolve(Some(scheduled), operation)
 
       Then("it should be expunged")


### PR DESCRIPTION
Summary: expunging is moved to KillService actor, it use a newly introduced `wipe` parameter to correctly expunge instances.

JIRA issues: https://jira.mesosphere.com/browse/MARATHON-8531

