### PR TITLE
Use the same logic as we have in TaskReplaceActor

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -54,7 +54,7 @@ class TaskStartActor(
         logger.warn(s"New $id is terminal ($condition) on agent $agentId during app $pathId restart: $condition reservation: ${instance.reservation}. Waiting for the task to restart...")
         instanceTerminated(id)
       } // 2) Did someone tamper with new instance's goal? Don't do that - there should be only one "orchestrator" per service per time!
-      else if (goal != Goal.Running) {
+      else {
         logger.error(s"New $id is terminal ($condition) on agent $agentId during app $pathId restart (reservation: ${instance.reservation}) and the goal ($goal) is *NOT* Running! This means that someone is interfering with current deployment!")
         instanceTerminated(id)
         launchQueue.add(runSpec, 1).pipeTo(self)

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -2,11 +2,12 @@ package mesosphere.marathon
 package core.deployment.impl
 
 import akka.Done
-import akka.pattern._
 import akka.actor.{Actor, ActorRef, Props, Status}
 import akka.event.EventStream
+import akka.pattern._
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
+import mesosphere.marathon.core.deployment.impl.TaskStartActor._
 import mesosphere.marathon.core.event.{DeploymentStatus, InstanceChanged, InstanceHealthChanged}
 import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
@@ -15,10 +16,8 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.RunSpec
 
 import scala.async.Async.{async, await}
-import scala.concurrent.{Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits.global
-import TaskStartActor._
-import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal
+import scala.concurrent.{Future, Promise}
 
 class TaskStartActor(
     val deploymentManagerActor: ActorRef,

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -18,6 +18,7 @@ import scala.async.Async.{async, await}
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits.global
 import TaskStartActor._
+import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal
 
 class TaskStartActor(
     val deploymentManagerActor: ActorRef,
@@ -45,11 +46,21 @@ class TaskStartActor(
   override def receive: Receive = readinessBehavior orElse commonBehavior
 
   def commonBehavior: Receive = {
-    case InstanceChanged(id, `version`, `pathId`, condition: Condition, instance) if condition.isTerminal =>
-      logger.warn(s"New instance [$id] failed during app ${runSpec.id.toString} scaling, queueing another instance")
-      instanceTerminated(id)
-      if (instance.state.goal != Goal.Running) {
+    case InstanceChanged(id, `version`, `pathId`, condition: Condition, instance) =>
+      val goal = instance.state.goal
+      val agentId = instance.agentInfo.fold(Option.empty[String])(_.agentId)
+
+      // 1) Did the new instance task fail?
+      if (considerTerminal(condition) && goal == Goal.Running) {
+        logger.warn(s"New $id is terminal ($condition) on agent $agentId during app $pathId restart: $condition reservation: ${instance.reservation}. Waiting for the task to restart...")
+        instanceTerminated(id)
+      } // 2) Did someone tamper with new instance's goal? Don't do that - there should be only one "orchestrator" per service per time!
+      else if (considerTerminal(condition) && goal != Goal.Running) {
+        logger.error(s"New $id is terminal ($condition) on agent $agentId during app $pathId restart (reservation: ${instance.reservation}) and the goal ($goal) is *NOT* Running! This means that someone is interfering with current deployment!")
+        instanceTerminated(id)
         launchQueue.add(runSpec, 1).pipeTo(self)
+      } else {
+        logger.info(s"Unhandled InstanceChanged event for new instanceId=$id, considered terminal=${considerTerminal(condition)} and current goal=${instance.state.goal}")
       }
 
     case Sync => async {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -14,6 +14,7 @@ import mesosphere.marathon.core.instance.Goal.{Decommissioned, Stopped}
 import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
+import mesosphere.marathon.core.task.state.AgentInfoPlaceholder
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{AppDefinition, Command, Timestamp}
@@ -233,6 +234,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val instance: Instance = mock[Instance]
       instance.instanceId returns id
       instance.state returns Instance.InstanceState(condition, Timestamp.now(), None, None, goal)
+      instance.agentInfo returns Some(AgentInfoPlaceholder())
       InstanceChanged(id, app.version, app.id, condition, instance)
     }
 


### PR DESCRIPTION
This is a port of a recent fix from @zen-dog to `TaskStartActor`. I believe this might also fix some races on master.
