### PR TITLE
Push only instanceid in RescheduleReserved

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -39,7 +39,7 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
           InstanceUpdateEffect.Update(updatedInstance, oldState = Some(oldInstance), Seq.empty)
         }
 
-      case RescheduleReserved(instance, runSpec) =>
+      case RescheduleReserved(_, runSpec) =>
         // TODO(alena): Create events
         updateExistingInstance(maybeInstance, op.instanceId) { i =>
           InstanceUpdateEffect.Update(

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -23,11 +23,9 @@ object InstanceUpdateOperation {
   /**
     * * Reschedules resident instance that already has a reservation but became terminal (reserved).
     *
-    * @param reservedInstance already existing reserved instance that is now in scheduled state.
+    * @param instanceId id of existing reserved instance that is now in scheduled state.
     */
-  case class RescheduleReserved(reservedInstance: Instance, runSpec: RunSpec) extends InstanceUpdateOperation {
-    override def instanceId: Instance.Id = reservedInstance.instanceId
-  }
+  case class RescheduleReserved(instanceId: Instance.Id, runSpec: RunSpec) extends InstanceUpdateOperation
 
   case class Reserve(instance: Instance) extends InstanceUpdateOperation {
     override def instanceId: Instance.Id = instance.instanceId

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -280,7 +280,7 @@ private[impl] class LaunchQueueActor(
       val existingReservedStoppedInstances = await(instanceTracker.specInstances(runSpec.id))
         .filter(i => i.hasReservation && i.state.condition.isTerminal && i.state.goal == Goal.Stopped) // resident to relaunch
         .take(queuedItem.add.count)
-      await(Future.sequence(existingReservedStoppedInstances.map { instance => instanceTracker.process(RescheduleReserved(instance, runSpec)) }))
+      await(Future.sequence(existingReservedStoppedInstances.map { instance => instanceTracker.process(RescheduleReserved(instance.instanceId, runSpec)) }))
 
       logger.debug(s"Rescheduled existing instances for ${runSpec.id}")
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -202,7 +202,7 @@ private class TaskLauncherActor(
           logger.info(s"Reschedule ${instance.instanceId} because of provision timeout.")
           async {
             if (instance.runSpec.isResident) {
-              await(instanceTracker.process(RescheduleReserved(instance, instance.runSpec)))
+              await(instanceTracker.process(RescheduleReserved(instance.instanceId, instance.runSpec)))
             } else {
               // Forget about old instance and schedule new one.
               await(instanceTracker.forceExpunge(instance.instanceId)): @silent

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -309,7 +309,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     "move instance to scheduled state when previously reserved" in new Fixture {
       val version = Timestamp(clock.instant())
       val runSpec = AppDefinition(id = PathId("foo"), versionInfo = VersionInfo.OnlyVersion(version))
-      val stateChange = updateOpResolver.resolve(Some(reservedInstance), RescheduleReserved(reservedInstance, runSpec))
+      val stateChange = updateOpResolver.resolve(Some(reservedInstance), RescheduleReserved(reservedInstance.instanceId, runSpec))
 
       inside(stateChange) {
         case update: Update =>


### PR DESCRIPTION
Summary:
It's not safe to pass the whole instance around since it might have changed since the operation was enqueued. Also in this case, only ID was actually necessary.

JIRA issues: MARATHON-8520
