### PR TITLE
Make Reserved a proper command that can be enqueued

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -5,7 +5,7 @@ import java.util.{Base64, UUID}
 
 import com.fasterxml.uuid.{EthernetAddress, Generators}
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.Instance.InstanceState
+import mesosphere.marathon.core.instance.Instance.{AgentInfo, InstanceState}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{PathId, Timestamp, UnreachableDisabled, UnreachableEnabled, UnreachableStrategy, _}
 import mesosphere.marathon.stream.Implicits._
@@ -75,6 +75,15 @@ case class Instance(
       runSpec = runSpec
     )
   }
+
+  /**
+    * Creates new instance that is scheduled and has reservation (for resident run specs)
+    */
+  def reserved(reservation: Reservation, agentInfo: AgentInfo): Instance = {
+    this.copy(
+      reservation = Some(reservation),
+      agentInfo = Some(agentInfo))
+  }
 }
 
 object Instance {
@@ -112,15 +121,6 @@ object Instance {
    * @return An instance in the scheduled state.
    */
   def scheduled(runSpec: RunSpec): Instance = scheduled(runSpec, Id.forRunSpec(runSpec.id))
-
-  /**
-    * Creates new instance that is scheduled and has reservation (for resident run specs)
-    */
-  def scheduled(scheduledInstance: Instance, reservation: Reservation, agentInfo: AgentInfo): Instance = {
-    scheduledInstance.copy(
-      reservation = Some(reservation),
-      agentInfo = Some(agentInfo))
-  }
 
   /**
     * Describes the state of an instance which is an accumulation of task states.

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolver.scala
@@ -59,7 +59,7 @@ private[marathon] class InstanceUpdateOpResolver(clock: Clock) extends StrictLog
         updateExistingInstance(maybeInstance, op.instanceId)(updater.changeGoal(_, op, clock.now()))
 
       case op: Reserve =>
-        updateExistingInstance(maybeInstance, op.instanceId)(_ => updater.reserve(op, clock.now()))
+        updateExistingInstance(maybeInstance, op.instanceId)(updater.reserve(_, op, clock.now()))
 
       case op: ForceExpunge =>
         maybeInstance match {

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOperation.scala
@@ -2,8 +2,8 @@ package mesosphere.marathon
 package core.instance.update
 
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.Goal
-import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.{Goal, Instance, Reservation}
+import mesosphere.marathon.core.instance.Instance.AgentInfo
 import mesosphere.marathon.core.task.{Task, TaskCondition}
 import mesosphere.marathon.state.{RunSpec, Timestamp}
 import org.apache.mesos
@@ -27,9 +27,7 @@ object InstanceUpdateOperation {
     */
   case class RescheduleReserved(instanceId: Instance.Id, runSpec: RunSpec) extends InstanceUpdateOperation
 
-  case class Reserve(instance: Instance) extends InstanceUpdateOperation {
-    override def instanceId: Instance.Id = instance.instanceId
-  }
+  case class Reserve(instanceId: Instance.Id, reservation: Reservation, agentInfo: AgentInfo) extends InstanceUpdateOperation
 
   /**
     * Creates a new instance. Scheduled instance has no information where it might run.

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -33,9 +33,10 @@ object InstanceUpdater extends StrictLogging {
       reservation = updatedReservation)
   }
 
-  private[marathon] def reserve(op: Reserve, now: Timestamp): InstanceUpdateEffect = {
-    val events = eventsGenerator.events(op.instance, task = None, now, previousState = None)
-    InstanceUpdateEffect.Update(op.instance, oldState = None, events)
+  private[marathon] def reserve(instance: Instance, op: Reserve, now: Timestamp): InstanceUpdateEffect = {
+    val updatedInstance = instance.reserved(op.reservation, op.agentInfo)
+    val events = eventsGenerator.events(updatedInstance, task = None, now, previousState = None)
+    InstanceUpdateEffect.Update(updatedInstance, oldState = None, events)
   }
 
   private def shouldBeExpunged(instance: Instance): Boolean =

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -341,7 +341,7 @@ class InstanceOpFactoryImpl(
     val agentInfo = Instance.AgentInfo(offer)
 
     val reservationLabels = TaskLabels.labelsForTask(frameworkId, Reservation.Id(scheduledInstance.instanceId))
-    val stateOp = InstanceUpdateOperation.Reserve(Instance.scheduled(scheduledInstance, reservation, agentInfo))
+    val stateOp = InstanceUpdateOperation.Reserve(scheduledInstance.instanceId, reservation, agentInfo)
     instanceOperationFactory.reserveAndCreateVolumes(reservationLabels, stateOp, resourceMatch.resources, localVolumes)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -338,9 +338,10 @@ private class TaskLauncherActor(
         instanceMap += instanceId -> existingInstance.provisioned(agentInfo, runSpecVersion, tasks, now)
         scheduleTaskOpTimeout(context, instanceOp)
         logger.info(s"Updated instance map to ${instanceMap.values.map(i => i.instanceId -> i.state.condition)}")
-      case InstanceUpdateOperation.Reserve(instance) =>
-        assert(instanceMap.contains(instance.instanceId), s"Internal task launcher state did not include reserved instance ${instance.instanceId}")
-        instanceMap += instance.instanceId -> instance
+      case InstanceUpdateOperation.Reserve(instanceId, reservation, agentInfo) =>
+        assert(instanceMap.contains(instanceId), s"Internal task launcher state did not include reserved instance $instanceId")
+        val existingInstance = instanceMap(instanceId)
+        instanceMap += instanceId -> existingInstance.reserved(reservation, agentInfo)
         scheduleTaskOpTimeout(context, instanceOp)
         logger.info(s"Updated instance map to reserve ${instanceMap.values.map(i => i.instanceId -> i.state.condition)}")
       case other =>

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -191,5 +191,5 @@ object TestInstanceBuilder {
     def appTask[T <: Task]: T = new LegacyInstanceImprovement(instance).appTask.asInstanceOf[T]
   }
 
-  def scheduledWithReservation(runSpec: RunSpec, localVolumes: Seq[LocalVolumeId] = Seq.empty, state: Reservation.State = Reservation.State.New(None)): Instance = Instance.scheduled(Instance.scheduled(runSpec, Instance.Id.forRunSpec(runSpec.id)), Reservation(localVolumes, state), AgentInfoPlaceholder())
+  def scheduledWithReservation(runSpec: RunSpec, localVolumes: Seq[LocalVolumeId] = Seq.empty, state: Reservation.State = Reservation.State.New(None)): Instance = Instance.scheduled(runSpec, Instance.Id.forRunSpec(runSpec.id)).reserved(Reservation(localVolumes, state), AgentInfoPlaceholder())
 }

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -184,7 +184,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     }
 
     "Processing a Reserve for an existing instanceId" in new Fixture {
-      val stateChange = updateOpResolver.resolve(Some(reservedInstance), InstanceUpdateOperation.Reserve(reservedInstance))
+      val stateChange = updateOpResolver.resolve(Some(reservedInstance), InstanceUpdateOperation.Reserve(reservedInstance.instanceId, reservedInstance.reservation.get, reservedInstance.agentInfo.get))
 
       Then("result in an Update")
       stateChange shouldBe an[InstanceUpdateEffect.Update]


### PR DESCRIPTION
Summary:
All our instance update operations can be enqueued so they have to be commutitive. We cannot push the whole instance inside that operation because of that. 

JIRA issues: MARATHON-8520
