### PR TITLE
Introduce a `Terminal` instance goal type 

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -142,7 +142,7 @@ class TaskReplaceActor(
         instanceTerminated(id)
         instancesStarted -= 1
       } // 2) Did someone tamper with new instance's goal? Don't do that - there should be only one "orchestrator" per service per time!
-      else if (considerTerminal(condition) && goal.isDoomed()) {
+      else if (considerTerminal(condition) && goal.isTerminal()) {
         logger.error(s"New $id is terminal ($condition) on agent $agentId during app $pathId restart (reservation: ${instance.reservation}) and the goal ($goal) is *NOT* Running! This means that someone is interfering with current deployment!")
       } else {
         logger.info(s"Unhandled InstanceChanged event for new instanceId=$id, considered terminal=${considerTerminal(condition)} and current goal=${instance.state.goal}")
@@ -165,7 +165,7 @@ class TaskReplaceActor(
         instanceTracker.setGoal(instance.instanceId, goal, GoalChangeReason.Upgrading)
           .pipeTo(self)
       } // 2) An old and decommissioned instance was successfully killed
-      else if (considerTerminal(condition) && instance.state.goal.isDoomed()) {
+      else if (considerTerminal(condition) && instance.state.goal.isTerminal()) {
         logger.info(s"Old $id became $condition. Launching more instances.")
         oldInstanceIds -= id
         instanceTerminated(id)

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -154,7 +154,6 @@ class TaskReplaceActor(
       val condition = ic.condition
       val instance = ic.instance
       val goal = instance.state.goal
-      val agentId = instance.agentInfo.fold(Option.empty[String])(_.agentId)
 
       // 1) An old instance terminated out of band and was not yet chosen to be decommissioned or stopped.
       // We stop/decommission the instance and let it be rescheduled with new instance RunSpec

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -142,7 +142,7 @@ class TaskReplaceActor(
         instanceTerminated(id)
         instancesStarted -= 1
       } // 2) Did someone tamper with new instance's goal? Don't do that - there should be only one "orchestrator" per service per time!
-      else if (considerTerminal(condition) && goal != Goal.Running) {
+      else if (considerTerminal(condition) && goal.isDoomed()) {
         logger.error(s"New $id is terminal ($condition) on agent $agentId during app $pathId restart (reservation: ${instance.reservation}) and the goal ($goal) is *NOT* Running! This means that someone is interfering with current deployment!")
       } else {
         logger.info(s"Unhandled InstanceChanged event for new instanceId=$id, considered terminal=${considerTerminal(condition)} and current goal=${instance.state.goal}")
@@ -166,7 +166,7 @@ class TaskReplaceActor(
         instanceTracker.setGoal(instance.instanceId, goal, GoalChangeReason.Upgrading)
           .pipeTo(self)
       } // 2) An old and decommissioned instance was successfully killed
-      else if (considerTerminal(condition) && instance.state.goal != Goal.Running) {
+      else if (considerTerminal(condition) && instance.state.goal.isDoomed()) {
         logger.info(s"Old $id became $condition. Launching more instances.")
         oldInstanceIds -= id
         instanceTerminated(id)

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -43,7 +43,7 @@ class TaskStartActor(
     case InstanceChanged(id, `version`, `pathId`, condition: Condition, instance) if condition.isTerminal =>
       logger.warn(s"New instance [$id] failed during app ${runSpec.id.toString} scaling, queueing another instance")
       instanceTerminated(id)
-      if (instance.state.goal != Goal.Running) {
+      if (instance.state.goal.isDoomed()) {
         launchQueue.add(runSpec, 1).pipeTo(self)
       }
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -43,7 +43,7 @@ class TaskStartActor(
     case InstanceChanged(id, `version`, `pathId`, condition: Condition, instance) if condition.isTerminal =>
       logger.warn(s"New instance [$id] failed during app ${runSpec.id.toString} scaling, queueing another instance")
       instanceTerminated(id)
-      if (instance.state.goal.isDoomed()) {
+      if (instance.state.goal.isTerminal()) {
         launchQueue.add(runSpec, 1).pipeTo(self)
       }
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -8,7 +8,7 @@ import akka.event.EventStream
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.{DeploymentStatus, InstanceChanged, InstanceHealthChanged}
-import mesosphere.marathon.core.instance.{Goal, Instance}
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.readiness.ReadinessCheckExecutor
 import mesosphere.marathon.core.task.tracker.InstanceTracker

--- a/src/main/scala/mesosphere/marathon/core/instance/Goal.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Goal.scala
@@ -8,9 +8,20 @@ import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsVal
   * Goal is set by an orchestration layer and interpreted by scheduler layer.
   * In the end it is used by low-level scheduler to make scheduling decisions e.g. should the task associated with this instance be launched or killed?
   */
-sealed trait Goal extends Product with Serializable
+sealed trait Goal extends Product with Serializable {
+
+  /**
+    * A doomed instance's task will be killed (eventually)
+    */
+  def isDoomed(): Boolean = this match {
+    case _: Goal.Doomed => true
+    case _ => false
+  }
+}
 
 object Goal {
+
+  sealed trait Doomed extends Goal
 
   /**
     * Expresses the intent that there should always be a running Mesos task associated by instance in this state.
@@ -24,14 +35,14 @@ object Goal {
     * for re-launch.
     * Instance with Stopped Goal might be changed to both [[Running]] or [[Decommissioned]].
     */
-  case object Stopped extends Goal
+  case object Stopped extends Goal with Doomed
 
   /**
     * All tasks associated with this instance shall be killed, and after they're reportedly terminal, the instance shall be removed because it's no longer needed.
     * This is typically used for ephemeral instances, when scaling down, deleting a service or upgrading.
     * This is terminal Goal, instance with this goal won't transition into any other Goal from now on.
     */
-  case object Decommissioned extends Goal
+  case object Decommissioned extends Goal with Doomed
 
   private val goalReader = new Reads[Goal] {
     override def reads(json: JsValue): JsResult[Goal] = {

--- a/src/main/scala/mesosphere/marathon/core/instance/Goal.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Goal.scala
@@ -35,14 +35,14 @@ object Goal {
     * for re-launch.
     * Instance with Stopped Goal might be changed to both [[Running]] or [[Decommissioned]].
     */
-  case object Stopped extends Goal with Doomed
+  case object Stopped extends Doomed
 
   /**
     * All tasks associated with this instance shall be killed, and after they're reportedly terminal, the instance shall be removed because it's no longer needed.
     * This is typically used for ephemeral instances, when scaling down, deleting a service or upgrading.
     * This is terminal Goal, instance with this goal won't transition into any other Goal from now on.
     */
-  case object Decommissioned extends Goal with Doomed
+  case object Decommissioned extends Doomed
 
   private val goalReader = new Reads[Goal] {
     override def reads(json: JsValue): JsResult[Goal] = {

--- a/src/main/scala/mesosphere/marathon/core/instance/Goal.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Goal.scala
@@ -13,15 +13,15 @@ sealed trait Goal extends Product with Serializable {
   /**
     * A doomed instance's task will be killed (eventually)
     */
-  def isDoomed(): Boolean = this match {
-    case _: Goal.Doomed => true
+  def isTerminal(): Boolean = this match {
+    case _: Goal.Terminal => true
     case _ => false
   }
 }
 
 object Goal {
 
-  sealed trait Doomed extends Goal
+  sealed trait Terminal extends Goal
 
   /**
     * Expresses the intent that there should always be a running Mesos task associated by instance in this state.
@@ -35,14 +35,14 @@ object Goal {
     * for re-launch.
     * Instance with Stopped Goal might be changed to both [[Running]] or [[Decommissioned]].
     */
-  case object Stopped extends Doomed
+  case object Stopped extends Terminal
 
   /**
     * All tasks associated with this instance shall be killed, and after they're reportedly terminal, the instance shall be removed because it's no longer needed.
     * This is typically used for ephemeral instances, when scaling down, deleting a service or upgrading.
     * This is terminal Goal, instance with this goal won't transition into any other Goal from now on.
     */
-  case object Decommissioned extends Doomed
+  case object Decommissioned extends Terminal
 
   private val goalReader = new Reads[Goal] {
     override def reads(json: JsValue): JsResult[Goal] = {

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActor.scala
@@ -274,7 +274,7 @@ private[impl] class LaunchQueueActor(
     val future = async {
       val runSpec = queuedItem.add.spec
       // Trigger TaskLaunchActor creation and sync with instance tracker.
-      val actorRef = launchers.getOrElse(runSpec.id, createAppTaskLauncher(runSpec))
+      launchers.getOrElse(runSpec.id, createAppTaskLauncher(runSpec))
 
       // Reuse resident instances that are stopped.
       val existingReservedStoppedInstances = await(instanceTracker.specInstances(runSpec.id))

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -71,7 +71,7 @@ private[impl] class KillServiceActor(
     async {
       val toKillBasedOnGoal = await(instanceTracker.instancesBySpec())
         .allInstances
-        .filter(i => i.state.goal != Goal.Running && i.isActive)
+        .filter(i => i.state.goal.isDoomed() && i.isActive)
 
       KillInstancesAndForget(toKillBasedOnGoal)
     }.pipeTo(self)
@@ -106,7 +106,7 @@ private[impl] class KillServiceActor(
       (inFlight.contains(id) || instancesToKill.contains(id)) =>
       handleTerminal(id)
 
-    case InstanceChanged(id, _, _, _, instance) if instance.state.goal != Goal.Running =>
+    case InstanceChanged(id, _, _, _, instance) if instance.state.goal.isDoomed() =>
       if (instancesToKill.contains(id)) {
         logger.info(s"Ignoring goal change to ${instance.state.goal} for ${instance.state.goal} since the instance is already queued.")
       } else {

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -10,7 +10,7 @@ import akka.actor.{Actor, Cancellable, Props}
 import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.{InstanceChanged, UnknownInstanceTerminated}
-import mesosphere.marathon.core.instance.{Goal, Instance}
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.Id
 import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -71,7 +71,7 @@ private[impl] class KillServiceActor(
     async {
       val toKillBasedOnGoal = await(instanceTracker.instancesBySpec())
         .allInstances
-        .filter(i => i.state.goal.isDoomed() && i.isActive)
+        .filter(i => i.state.goal.isTerminal() && i.isActive)
 
       KillInstancesAndForget(toKillBasedOnGoal)
     }.pipeTo(self)
@@ -106,7 +106,7 @@ private[impl] class KillServiceActor(
       (inFlight.contains(id) || instancesToKill.contains(id)) =>
       handleTerminal(id)
 
-    case InstanceChanged(id, _, _, _, instance) if instance.state.goal.isDoomed() =>
+    case InstanceChanged(id, _, _, _, instance) if instance.state.goal.isTerminal() =>
       if (instancesToKill.contains(id)) {
         logger.info(s"Ignoring goal change to ${instance.state.goal} for ${instance.state.goal} since the instance is already queued.")
       } else {


### PR DESCRIPTION
which designates an instance which task will be eventually killed. This is helpful in the orchestrator part of the code when distinguishing between the `Running` goal and the "doomed" goals (currently `Stopped` and `Decommissioned`).
