### PR TITLE
Fix compiler warnings

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,4 +1,0 @@
-{
-  "phabricator.uri": "https://phabricator.mesosphere.com",
-  "repository.callsign": "marathon"
-}

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,6 @@ lazy val commonSettings = Seq(
     "-feature",
     "-unchecked",
     "-Xfuture",
-    "-Xlog-reflective-calls",
     "-Xlint",
     //FIXME: CORE-977 and MESOS-7368 are filed and need to be resolved to re-enable this
     // "-Xfatal-warnings",

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
@@ -3,16 +3,16 @@ package core.launchqueue
 
 import akka.NotUsed
 import akka.stream.Materializer
-import akka.stream.scaladsl.{ Keep, Sink, Source }
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import java.time.Clock
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{ InstanceChange, InstanceUpdated }
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdated}
 import mesosphere.marathon.core.launcher.OfferMatchResult
 import mesosphere.marathon.core.launchqueue.impl.OfferMatchStatistics.RunSpecOfferStatistics
 import mesosphere.marathon.core.launchqueue.impl.{OfferMatchStatistics, RateLimiter}
-import mesosphere.marathon.state.{ PathId, RunSpec, RunSpecConfigRef, Timestamp }
+import mesosphere.marathon.state.{PathId, RunSpec, RunSpecConfigRef, Timestamp}
 import mesosphere.marathon.stream.{EnrichedSink, LiveFold}
 import mesosphere.mesos.{NoOfferMatchReason}
 import scala.concurrent.{ExecutionContext, Future}
@@ -21,7 +21,7 @@ import scala.async.Async._
 /**
   * See LaunchStats$.apply
   */
-class LaunchStats private [launchqueue] (
+class LaunchStats private[launchqueue] (
     getRunSpec: PathId => Option[RunSpec],
     delays: LiveFold.Folder[Map[RunSpecConfigRef, Timestamp]],
     launchingInstances: LiveFold.Folder[Map[Instance.Id, LaunchStats.LaunchingInstance]],
@@ -87,23 +87,23 @@ object LaunchStats extends StrictLogging {
     }
   })
 
-  private [launchqueue] case class LaunchingInstance(since: Timestamp, instance: Instance)
+  private[launchqueue] case class LaunchingInstance(since: Timestamp, instance: Instance)
 
   /**
     * Current known list of active instances
     */
-  private [launchqueue] val launchingInstancesFold:
-      Sink[(Timestamp, InstanceChange), LiveFold.Folder[Map[Instance.Id, LaunchStats.LaunchingInstance]]] =
-    EnrichedSink.liveFold(Map.empty[Instance.Id, LaunchingInstance])({ case (instances, (timestamp, change)) =>
-      change match {
-        case InstanceUpdated(newInstance, _, _) if newInstance.isScheduled || newInstance.isProvisioned =>
-          val newRecord = instances.get(change.id)
-            .map { launchingInstance => launchingInstance.copy(instance = newInstance) }
-            .getOrElse { LaunchingInstance(timestamp, newInstance) }
-          instances + (change.id -> newRecord)
-        case _ =>
-          instances - (change.id)
-      }
+  private[launchqueue] val launchingInstancesFold: Sink[(Timestamp, InstanceChange), LiveFold.Folder[Map[Instance.Id, LaunchStats.LaunchingInstance]]] =
+    EnrichedSink.liveFold(Map.empty[Instance.Id, LaunchingInstance])({
+      case (instances, (timestamp, change)) =>
+        change match {
+          case InstanceUpdated(newInstance, _, _) if newInstance.isScheduled || newInstance.isProvisioned =>
+            val newRecord = instances.get(change.id)
+              .map { launchingInstance => launchingInstance.copy(instance = newInstance) }
+              .getOrElse { LaunchingInstance(timestamp, newInstance) }
+            instances + (change.id -> newRecord)
+          case _ =>
+            instances - (change.id)
+        }
     })
 
   /**
@@ -123,7 +123,7 @@ object LaunchStats extends StrictLogging {
     clock: Clock,
     instanceUpdates: Source[InstanceChange, NotUsed],
     delayUpdates: Source[RateLimiter.DelayUpdate, NotUsed],
-    offerMatchUpdates: Source[OfferMatchStatistics.OfferMatchUpdate, NotUsed],
+    offerMatchUpdates: Source[OfferMatchStatistics.OfferMatchUpdate, NotUsed]
   )(implicit mat: Materializer, ec: ExecutionContext): LaunchStats = {
 
     val delays = delayUpdates.runWith(delayFold)
@@ -146,18 +146,18 @@ object LaunchStats extends StrictLogging {
     * @param backOffUntil timestamp until which no further launch attempts will be made
     */
   case class QueuedInstanceInfoWithStatistics(
-    runSpec: RunSpec,
-    inProgress: Boolean,
-    instancesLeftToLaunch: Int,
-    finalInstanceCount: Int,
-    backOffUntil: Option[Timestamp],
-    startedAt: Timestamp,
-    rejectSummaryLastOffers: Map[NoOfferMatchReason, Int],
-    rejectSummaryLaunchAttempt: Map[NoOfferMatchReason, Int],
-    processedOffersCount: Int,
-    unusedOffersCount: Int,
-    lastMatch: Option[OfferMatchResult.Match],
-    lastNoMatch: Option[OfferMatchResult.NoMatch],
-    lastNoMatches: Seq[OfferMatchResult.NoMatch]
+      runSpec: RunSpec,
+      inProgress: Boolean,
+      instancesLeftToLaunch: Int,
+      finalInstanceCount: Int,
+      backOffUntil: Option[Timestamp],
+      startedAt: Timestamp,
+      rejectSummaryLastOffers: Map[NoOfferMatchReason, Int],
+      rejectSummaryLaunchAttempt: Map[NoOfferMatchReason, Int],
+      processedOffersCount: Int,
+      unusedOffersCount: Int,
+      lastMatch: Option[OfferMatchResult.Match],
+      lastNoMatch: Option[OfferMatchResult.NoMatch],
+      lastNoMatches: Seq[OfferMatchResult.NoMatch]
   )
 }

--- a/src/main/scala/mesosphere/marathon/experimental/repository/TemplateRepository.scala
+++ b/src/main/scala/mesosphere/marathon/experimental/repository/TemplateRepository.scala
@@ -168,9 +168,12 @@ class TemplateRepository(val store: ZooKeeperPersistenceStore, val base: String)
     Done
   }
 
-  def children(pathId: PathId): Try[Seq[String]] = exists(pathId) match {
-    case true => Try(trie.getChildren(storePath(pathId), false).asScala.to[Seq])
-    case false => Failure(new NoNodeException(s"No contents for path $pathId found"))
+  def children(pathId: PathId): Try[Seq[String]] = {
+    if (exists(pathId)) {
+      Try(trie.getChildren(storePath(pathId), false).asScala.to[Seq])
+    } else {
+      Failure(new NoNodeException(s"No contents for path $pathId found"))
+    }
   }
 
   def exists(pathId: PathId): Boolean = trie.existsNode(storePath(pathId))

--- a/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
@@ -72,10 +72,7 @@ object InstanceMigration extends MaybeStore with StrictLogging {
         .mapAsync(1) { instanceId =>
           store
             .get[Id, JsValue](instanceId)
-            .map {
-              case Some(jsValue) => Some(jsValue)
-              case None => logger.error(s"Failed to load an instance for $instanceId. It will be ignored"); None
-            }
+            .map(maybeValue => maybeValue.orElse { logger.error(s"Failed to load an instance for $instanceId. It will be ignored"); None })
         }
         .collect {
           case Some(jsValue) => jsValue

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -207,7 +207,7 @@ object Migration {
       // From here onwards we are not bound to the build version anymore.
       StorageVersions(17) -> { (migration) => new MigrationTo17(migration.instanceRepo, migration.persistenceStore) },
       StorageVersions(18) -> { (migration) => new MigrationTo18(migration.instanceRepo, migration.persistenceStore) },
-      StorageVersions(18, 100) -> { (migration) => new MigrationTo18100(migration.instanceRepo, migration.persistenceStore) },
+      StorageVersions(18, 100) -> { (migration) => new MigrationTo18100(migration.instanceRepo, migration.persistenceStore) }
     )
 }
 


### PR DESCRIPTION
Summary:
- Fixed a few compiler warnings
- Removed old and unused `.arcconfig` file
- Removed `-Xlog-reflective-calls` compiler flag since we use reflection
- Removed a couple of trailing `,` that scalariform was complaining about