### PR TITLE
For instance tracker subscription, send the initial snapshot as a single message

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceChangeHandler.scala
@@ -23,6 +23,8 @@ trait InstanceChangeHandler {
   def process(update: InstanceChange): Future[Done]
 }
 
+case class InstancesSnapshot(instances: Seq[Instance])
+
 /**
   * An event notifying of an [[Instance]] change.
   */

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.StrictLogging
 import java.time.Clock
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdated}
+import mesosphere.marathon.core.instance.update.{ InstancesSnapshot, InstanceChange, InstanceUpdated }
 import mesosphere.marathon.core.launcher.OfferMatchResult
 import mesosphere.marathon.core.launchqueue.impl.OfferMatchStatistics.RunSpecOfferStatistics
 import mesosphere.marathon.core.launchqueue.impl.{OfferMatchStatistics, RateLimiter}
@@ -121,14 +121,18 @@ object LaunchStats extends StrictLogging {
   def apply(
     groupManager: GroupManager,
     clock: Clock,
-    instanceUpdates: Source[InstanceChange, NotUsed],
+    instanceUpdates: Source[(InstancesSnapshot, Source[InstanceChange, NotUsed]), NotUsed],
     delayUpdates: Source[RateLimiter.DelayUpdate, NotUsed],
     offerMatchUpdates: Source[OfferMatchStatistics.OfferMatchUpdate, NotUsed]
   )(implicit mat: Materializer, ec: ExecutionContext): LaunchStats = {
 
     val delays = delayUpdates.runWith(delayFold)
 
-    val launchingInstances = instanceUpdates.map { i => (clock.now(), i) }.runWith(launchingInstancesFold)
+    val launchingInstances = instanceUpdates.
+      flatMapConcat { case (snapshot, updates) =>
+        Source(snapshot.instances.map { i => InstanceUpdated(i, None, Nil) }).concat(updates)
+      }.
+      map { i => (clock.now(), i) }.runWith(launchingInstancesFold)
 
     val (runSpecStatistics, noMatchStatistics) =
       offerMatchUpdates

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -4,7 +4,7 @@ package core.task.tracker
 import akka.{Done, NotUsed}
 import akka.stream.scaladsl.Source
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.instance.update.InstanceChange
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstancesSnapshot}
 import mesosphere.marathon.core.instance.{Goal, GoalChangeReason, Instance}
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.Task
@@ -87,7 +87,7 @@ trait InstanceTracker extends StrictLogging {
   /**
     * An ongoing source of instance updates. On materialization, receives an update for all current instances
     */
-  val instanceUpdates: Source[InstanceChange, NotUsed]
+  val instanceUpdates: Source[(InstancesSnapshot, Source[InstanceChange, NotUsed]), NotUsed]
 }
 
 object InstanceTracker {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -12,7 +12,7 @@ import akka.pattern.pipe
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.TaskCounts
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation, InstanceUpdated}
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation, InstancesSnapshot, InstanceUpdated}
 import mesosphere.marathon.core.leadership.LeaderDeferrable
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.{RepositoryStateUpdated, UpdateContext}
 import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor}
@@ -129,10 +129,8 @@ private[impl] class InstanceTrackerActor(
       case InstanceTrackerActor.Subscribe =>
         if (!subscribers.contains(sender)) {
           subscribers += sender
-          // Send initial "created" events to subscribers so they can have a consistent view of instance state
-          instancesBySpec.allInstances.foreach { instance =>
-            sender ! InstanceUpdated(instance, None, Nil)
-          }
+          // Send current snapshot of events to new subscriber so they can have a consistent view of instance state
+          sender ! InstancesSnapshot(instancesBySpec.allInstances)
         }
 
       case InstanceTrackerActor.Unsubscribe =>

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -11,7 +11,7 @@ import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult}
 import akka.util.Timeout
 import akka.{Done, NotUsed}
 import mesosphere.marathon.core.async.ExecutionContexts
-import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdateEffect, InstanceUpdateOperation}
+import mesosphere.marathon.core.instance.update.{InstancesSnapshot, InstanceChange, InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.instance.{Goal, GoalChangeReason, Instance}
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.UpdateContext
 import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerConfig}
@@ -166,8 +166,8 @@ private[tracker] class InstanceTrackerDelegate(
     process(InstanceUpdateOperation.ChangeGoal(instanceId, goal)).map(_ => Done)
   }
 
-  override val instanceUpdates: Source[InstanceChange, NotUsed] = {
-    Source.actorRef(Int.MaxValue, OverflowStrategy.fail)
+  override val instanceUpdates: Source[(InstancesSnapshot, Source[InstanceChange, NotUsed]), NotUsed] = {
+    Source.actorRef[Any](Int.MaxValue, OverflowStrategy.fail)
       .watchTermination()(Keep.both)
       .mapMaterializedValue {
         case (ref, done) =>
@@ -176,6 +176,12 @@ private[tracker] class InstanceTrackerDelegate(
           }(ExecutionContexts.callerThread)
           instanceTrackerRef.tell(InstanceTrackerActor.Subscribe, ref)
           NotUsed
+      }.prefixAndTail(1).map {
+        case (Seq(el: InstancesSnapshot), rest) =>
+          // The contract is that all messages delivered after the first snapshot message will be instance change
+          (el, rest.asInstanceOf[Source[InstanceChange, NotUsed]]): @silent
+        case _ =>
+          throw new IllegalStateException("First message expected to be an InstancesSnapshot; this is a bug")
       }
   }
 }


### PR DESCRIPTION
This is a pre-requisite to the race-free kill subscription watcher PR, to follow