### PR TITLE
Use InstanceTracker subscription mechanism to wait for instance terminality

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -15,6 +15,7 @@ import mesosphere.marathon.core.instance.{Goal, GoalChangeReason, Instance}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.KillService
+import mesosphere.marathon.core.task.termination.impl.KillStreamWatcher
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{PathId, RunSpec}
 import mesosphere.marathon.storage.repository.{DeploymentRepository, GroupRepository}
@@ -408,7 +409,7 @@ class SchedulerActions(
         await(launchQueue.purge(runSpec.id))
 
         logger.info(s"Adjusting goals for instances ${instances.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
-        val instancesAreTerminal = killService.watchForKilledInstances(instances)(mat)
+        val instancesAreTerminal = KillStreamWatcher.watchForKilledInstances(instanceTracker.instanceUpdates, instances)(mat)
         val changeGoalsFuture = instances.map { i =>
           if (i.hasReservation) instanceTracker.setGoal(i.instanceId, Goal.Stopped, GoalChangeReason.OverCapacity)
           else instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -409,7 +409,7 @@ class SchedulerActions(
         await(launchQueue.purge(runSpec.id))
 
         logger.info(s"Adjusting goals for instances ${instances.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
-        val instancesAreTerminal = KillStreamWatcher.watchForKilledInstances(instanceTracker.instanceUpdates, instances)(mat)
+        val instancesAreTerminal = KillStreamWatcher.watchForKilledInstances(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)
         val changeGoalsFuture = instances.map { i =>
           if (i.hasReservation) instanceTracker.setGoal(i.instanceId, Goal.Stopped, GoalChangeReason.OverCapacity)
           else instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -409,7 +409,7 @@ class SchedulerActions(
         await(launchQueue.purge(runSpec.id))
 
         logger.info(s"Adjusting goals for instances ${instances.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
-        val instancesAreTerminal = KillStreamWatcher.watchForKilledInstances(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)
+        val instancesAreTerminal = KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)
         val changeGoalsFuture = instances.map { i =>
           if (i.hasReservation) instanceTracker.setGoal(i.instanceId, Goal.Stopped, GoalChangeReason.OverCapacity)
           else instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)

--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -40,9 +40,8 @@ class TaskKiller @Inject() (
           val activeInstances = foundInstances.filter(_.isActive)
 
           if (wipe) {
-            val instancesAreTerminal: Future[Done] = KillStreamWatcher.watchForDecomissionedInstances(
-              instanceTracker.instanceUpdates,
-              activeInstances.map(_.instanceId)(collection.breakOut))
+            val instancesAreTerminal: Future[Done] = KillStreamWatcher.watchForDecommissionedInstances(
+              instanceTracker.instanceUpdates, activeInstances)
             await(Future.sequence(foundInstances.map(i => instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.UserRequest)))): @silent
             await(doForceExpunge(foundInstances.map(_.instanceId))): @silent
             await(instancesAreTerminal): @silent

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -193,7 +193,8 @@ private class DeploymentActor(
     val instances = await(instanceTracker.specInstances(runSpec.id))
 
     logger.info(s"Killing all instances of ${runSpec.id}: ${instances.map(_.instanceId)}")
-    val instancesAreTerminal = KillStreamWatcher.watchForDecomissionedInstances(instanceTracker.instanceUpdates, instances.map(_.instanceId)(collection.breakOut))
+    val instancesAreTerminal = KillStreamWatcher.watchForDecommissionedInstances(
+      instanceTracker.instanceUpdates, instances)
     await(Future.sequence(instances.map(i => instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.DeletingApp))))
     await(instancesAreTerminal)
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -144,7 +144,7 @@ private class DeploymentActor(
 
   private def killInstancesIfNeeded(instancesToKill: Seq[Instance]): Future[Done] = async {
     logger.debug("Kill instances {}", instancesToKill)
-    val instancesAreTerminal = KillStreamWatcher.watchForKilledInstances(instanceTracker.instanceUpdates, instancesToKill)
+    val instancesAreTerminal = KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instancesToKill)
     val changeGoalsFuture = instancesToKill.map(i => {
       if (i.hasReservation) instanceTracker.setGoal(i.instanceId, Goal.Stopped, GoalChangeReason.DeploymentScaling)
       else instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.DeploymentScaling)

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.StrictLogging
 import java.time.Clock
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{ InstancesSnapshot, InstanceChange, InstanceUpdated }
+import mesosphere.marathon.core.instance.update.{InstancesSnapshot, InstanceChange, InstanceUpdated}
 import mesosphere.marathon.core.launcher.OfferMatchResult
 import mesosphere.marathon.core.launchqueue.impl.OfferMatchStatistics.RunSpecOfferStatistics
 import mesosphere.marathon.core.launchqueue.impl.{OfferMatchStatistics, RateLimiter}
@@ -132,8 +132,9 @@ object LaunchStats extends StrictLogging {
     val delays = delayUpdates.runWith(delayFold)
 
     val launchingInstances = instanceUpdates.
-      flatMapConcat { case (snapshot, updates) =>
-        Source(snapshot.instances.map { i => InstanceUpdated(i, None, Nil) }).concat(updates)
+      flatMapConcat {
+        case (snapshot, updates) =>
+          Source(snapshot.instances.map { i => InstanceUpdated(i, None, Nil) }).concat(updates)
       }.
       map { i => (clock.now(), i) }.runWith(launchingInstancesFold)
 

--- a/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/KillService.scala
@@ -1,12 +1,8 @@
 package mesosphere.marathon
 package core.task.termination
 
-import akka.Done
-import akka.stream.Materializer
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
-
-import scala.concurrent.Future
 
 /**
   * A service that handles killing tasks. This will take care about extra logic for lost tasks,
@@ -31,10 +27,4 @@ trait KillService {
     * @param reason the reason why the task shall be killed.
     */
   def killUnknownTask(taskId: Task.Id, reason: KillReason): Unit
-
-  /**
-    * Begins watching immediately for terminated instances. Future is completed when all instances are reported in a
-    * terminal condition.
-    */
-  def watchForKilledInstances(instances: Seq[Instance])(implicit materializer: Materializer): Future[Done]
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/TaskTerminationModule.scala
@@ -26,5 +26,5 @@ class TaskTerminationModule(
   private[this] lazy val taskKillServiceActor: ActorRef =
     leadershipModule.startWhenLeader(taskKillServiceActorProps, "taskKillServiceActor")
 
-  val taskKillService: KillService = new KillServiceDelegate(taskKillServiceActor, actorSystem.eventStream)
+  val taskKillService: KillService = new KillServiceDelegate(taskKillServiceActor, instanceTracker)
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -1,12 +1,11 @@
 package mesosphere.marathon
 package core.task.termination.impl
 
-import akka.stream.scaladsl.Sink
 import java.time.Clock
 
 import akka.Done
-import akka.pattern.pipe
 import akka.actor.{Actor, Cancellable, Props}
+import akka.pattern.pipe
 import akka.stream.ActorMaterializer
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event.{InstanceChanged, UnknownInstanceTerminated}
@@ -19,9 +18,9 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.Timestamp
 
-import scala.collection.mutable
-import scala.concurrent.{Future, Promise}
 import scala.async.Async.{async, await}
+import scala.collection.mutable
+import scala.concurrent.Promise
 
 /**
   * An actor that handles killing instances in chunks and depending on the instance state.
@@ -132,7 +131,7 @@ private[impl] class KillServiceActor(
   def killInstances(instances: Seq[Instance], maybePromise: Option[Promise[Done]]): Unit = {
     val instanceIds = instances.map(_.instanceId)
     logger.debug(s"Adding instances $instanceIds to the queue")
-    maybePromise.map(p => p.completeWith(watchForKilledInstances(instances)))
+    maybePromise.map(p => p.completeWith(KillStreamWatcher.watchForKilledInstances(instanceTracker.instanceUpdates, instances)))
     instances
       .filterNot(instance => inFlight.keySet.contains(instance.instanceId)) // Don't trigger a kill request for instances that are already being killed
       .foreach { instance =>
@@ -145,17 +144,6 @@ private[impl] class KillServiceActor(
         )
       }
     processKills()
-  }
-
-  /**
-    * Begins watching immediately for terminated instances. Future is completed when all instances are seen.
-    */
-  def watchForKilledInstances(instances: Seq[Instance]): Future[Done] = {
-    // Note - we toss the materialized cancellable. We are okay to do this here because KillServiceActor will continue to retry
-    // killing the instanceIds in question, forever, until this Future completes.
-    KillStreamWatcher.
-      watchForKilledInstances(context.system.eventStream, instances).
-      runWith(Sink.head)
   }
 
   def processKills(): Unit = {

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -132,7 +132,7 @@ private[impl] class KillServiceActor(
   def killInstances(instances: Seq[Instance], maybePromise: Option[Promise[Done]]): Unit = {
     val instanceIds = instances.map(_.instanceId)
     logger.debug(s"Adding instances $instanceIds to the queue")
-    maybePromise.map(p => p.completeWith(KillStreamWatcher.watchForKilledInstances(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)))
+    maybePromise.map(p => p.completeWith(KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)))
     instances
       .filterNot(instance => inFlight.keySet.contains(instance.instanceId)) // Don't trigger a kill request for instances that are already being killed
       .foreach { instance =>

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceDelegate.scala
@@ -1,20 +1,16 @@
 package mesosphere.marathon
 package core.task.termination.impl
 
-import akka.Done
 import akka.actor.ActorRef
-import akka.event.EventStream
-import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
+import mesosphere.marathon.core.task.tracker.InstanceTracker
 
 import scala.collection.immutable.Seq
-import scala.concurrent.Future
 
-private[termination] class KillServiceDelegate(actorRef: ActorRef, eventStream: EventStream) extends KillService with StrictLogging {
+private[termination] class KillServiceDelegate(actorRef: ActorRef, instanceTracker: InstanceTracker) extends KillService with StrictLogging {
   import KillServiceActor._
 
   override def killUnknownTask(taskId: Task.Id, reason: KillReason): Unit = {
@@ -27,17 +23,5 @@ private[termination] class KillServiceDelegate(actorRef: ActorRef, eventStream: 
       logger.info(s"Kill and forget following instances for reason $reason: ${instances.map(_.instanceId).mkString(",")}")
       actorRef ! KillInstancesAndForget(instances)
     }
-  }
-
-  /**
-    * Begins watching immediately for terminated instances. Future is completed when all instances are seen.
-    */
-  def watchForKilledInstances(instances: Seq[Instance])(implicit materializer: Materializer): Future[Done] = {
-    // Note - we toss the materialized cancellable. We are okay to do this here
-    // because KillServiceActor will continue to retry killing the instanceIds
-    // in question, forever, until this Future completes.
-    KillStreamWatcher.
-      watchForKilledInstances(eventStream, instances).
-      runWith(Sink.head)(materializer)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
@@ -5,7 +5,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.instance.update.{InstanceDeleted, InstanceUpdated}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal
@@ -14,53 +14,35 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import scala.concurrent.Future
 
 object KillStreamWatcher extends StrictLogging {
+  private type TerminalPredicate = (Instance, Set[Task.Id]) => Boolean
 
-  private[impl] def emitPendingTerminal(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance]): Source[Set[Instance.Id], NotUsed] = {
-    def terminalWhenKilledOrReplaced(instance: Instance, taskIds: Set[Task.Id]) =
-      considerTerminal(instance.state.condition) || instance.tasksMap.values.forall(t => !taskIds(t.taskId))
+  private[impl] val whenTerminalOrReplaced: TerminalPredicate = (instance: Instance, taskIds: Set[Task.Id]) =>
+    considerTerminal(instance.state.condition) || instance.tasksMap.values.forall(t => !taskIds(t.taskId))
+
+  private[impl] val whenTerminalAndDecommissioned: TerminalPredicate = (instance: Instance, _: Set[Task.Id]) =>
+    instance.state.goal == Goal.Decommissioned && considerTerminal(instance.state.condition)
+
+  private[impl] def emitPendingTerminal(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance], predicate: TerminalPredicate): Source[Set[Instance.Id], NotUsed] = {
+
+    val instancesMap: Map[Instance.Id, Set[Task.Id]] =
+      instances.map { i => i.instanceId -> i.tasksMap.values.map(_.taskId).toSet }(collection.breakOut)
 
     instanceUpdates
       .flatMapConcat {
         case (snapshot, updates) =>
-          val initialPendingInstances: Map[Instance.Id, Set[Task.Id]] = instances.map { i => i.instanceId -> i.tasksMap.values.map(_.taskId).toSet }(collection.breakOut)
-          val alreadyTerminalInstanceIds: Set[Instance.Id] = snapshot.instances.iterator
-            .filter { i => initialPendingInstances.contains(i.instanceId) }
-            .filter { i => terminalWhenKilledOrReplaced(i, initialPendingInstances(i.instanceId)) }
-            .map(_.instanceId)
-            .to[Set]
-
-          val pendingInstances = initialPendingInstances -- alreadyTerminalInstanceIds
-
-          updates
-            .filter { change => pendingInstances.contains(change.id) }
-            .scan(pendingInstances) {
-              case (remaining, deleted: InstanceDeleted) =>
-                remaining - deleted.id
-              case (remaining, InstanceUpdated(instance, _, _)) if terminalWhenKilledOrReplaced(instance, remaining.getOrElse(instance.instanceId, Set.empty)) =>
-                remaining - instance.instanceId
-              case (remaining, _) =>
-                remaining
-            }
-            .map { pending => pending.keySet }
-            .takeWhile(_.nonEmpty, inclusive = true)
-      }
-  }
-
-  private[impl] def emitPendingDecomissioned(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Set[Instance.Id]): Source[Set[Instance.Id], NotUsed] = {
-    instanceUpdates
-      .flatMapConcat {
-        case (snapshot, updates) =>
-
           val pendingInstanceIds: Set[Instance.Id] = snapshot.instances.iterator
-            .filter { i => instances(i.instanceId) }
+            .filter { i => instancesMap.contains(i.instanceId) }
+            .filterNot { i => predicate(i, instancesMap(i.instanceId)) }
             .map(_.instanceId)
             .to[Set]
 
           updates
-            .filter { change => pendingInstanceIds.contains(change.id) }
+            .filter { change => instancesMap.contains(change.id) }
             .scan(pendingInstanceIds) {
               case (remaining, deleted: InstanceDeleted) =>
                 remaining - deleted.id
+              case (remaining, InstanceUpdated(instance, _, _)) if predicate(instance, instancesMap.getOrElse(instance.instanceId, Set.empty)) =>
+                remaining - instance.instanceId
               case (remaining, _) =>
                 remaining
             }
@@ -73,7 +55,7 @@ object KillStreamWatcher extends StrictLogging {
     */
   def watchForKilledInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance])(implicit materializer: Materializer): Future[Done] = {
     KillStreamWatcher.
-      emitPendingTerminal(instanceUpdates, instances)
+      emitPendingTerminal(instanceUpdates, instances, whenTerminalOrReplaced)
       .takeWhile { pendingTerminalInstances => pendingTerminalInstances.nonEmpty }
       .runWith(Sink.ignore)
   }
@@ -88,9 +70,9 @@ object KillStreamWatcher extends StrictLogging {
     * @param materializer Akka stream materializer
     * @return
     */
-  def watchForDecomissionedInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instanceIds: Set[Instance.Id])(implicit materializer: Materializer): Future[Done] = {
+  def watchForDecommissionedInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance])(implicit materializer: Materializer): Future[Done] = {
     KillStreamWatcher.
-      emitPendingDecomissioned(instanceUpdates, instanceIds)
+      emitPendingTerminal(instanceUpdates, instances, whenTerminalAndDecommissioned)
       .takeWhile { pendingTerminalInstances => pendingTerminalInstances.nonEmpty }
       .runWith(Sink.ignore)
   }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
@@ -1,17 +1,14 @@
 package mesosphere.marathon
 package core.task.termination.impl
 
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Sink, Source}
-import akka.{Done, NotUsed}
+import akka.NotUsed
+import akka.stream.scaladsl.Source
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.instance.update.{InstanceDeleted, InstanceUpdated}
+import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.InstanceChangedPredicates.considerTerminal
 import mesosphere.marathon.core.task.tracker.InstanceTracker
-
-import scala.concurrent.Future
 
 object KillStreamWatcher extends StrictLogging {
   /**
@@ -20,28 +17,14 @@ object KillStreamWatcher extends StrictLogging {
     */
   private type TerminalPredicate = (Instance, Set[Task.Id]) => Boolean
 
-  /**
-    * Predicate used to determine whether or not the tasks associated with an instance have been killed.
-    *
-    * When a process sends some kill request, it's usually in the context of killing the tasks associated with an
-    * instance at some given point in time. We count this kill as successful if we see that the taskIds have changed,
-    * or if the instance itself is in a state we consider terminal.
-    */
-  private[impl] val whenTerminalOrReplaced: TerminalPredicate = (instance: Instance, taskIds: Set[Task.Id]) =>
+  private val considerTerminalIfConditionTerminalOrTasksReplaced: TerminalPredicate = (instance: Instance, taskIds: Set[Task.Id]) =>
     considerTerminal(instance.state.condition) || instance.tasksMap.values.forall(t => !taskIds(t.taskId))
 
   /**
     * Predicate used to determine whether or not an instance has been decommissioned.
     *
-    * When an instance has been marked as goal decommissioned, it's safe to assume that it is never coming back, since
-    * it's illegal to change an instance goal from Decommissioned back to running. As such, we assume an instance is
-    * decommissioned as soon as it is both marked as goal decommissioned, and the instance is considered terminal.
-    *
-    * Were we to only wait for the instance to become terminal, and not for the goal to also be decommissioned, then we
-    * could conclude too early that an instance is decommissioned, as it is possible that some random restart could
-    * precede the receipt of the update goal command.
     */
-  private[impl] val whenTerminalAndDecommissioned: TerminalPredicate = (instance: Instance, _: Set[Task.Id]) =>
+  private val considerTerminalIfConditionTerminalAndGoalDecommissioned: TerminalPredicate = (instance: Instance, _: Set[Task.Id]) =>
     instance.state.goal == Goal.Decommissioned && considerTerminal(instance.state.condition)
 
   /**
@@ -50,10 +33,10 @@ object KillStreamWatcher extends StrictLogging {
     *
     * @param instanceUpdates InstanceTracker instance state subscription stream
     * @param instances The instances in question to watch
-    * @param predicate The mechanism to judge instance terminality; are we watching for tasks to be killed, or instance to be decommissioned.
+    * @param terminalPredicate The mechanism to judge instance terminality; are we watching for tasks to be killed, or instance to be decommissioned.
     * @return Source of instanceIds which emits a diminishing Set of pending instanceIds, and completes when that set is empty.
     */
-  private[impl] def emitPendingTerminal(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance], predicate: TerminalPredicate): Source[Set[Instance.Id], NotUsed] = {
+  private def emitPendingTerminal(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance], terminalPredicate: TerminalPredicate): Source[Set[Instance.Id], NotUsed] = {
 
     val instanceTasks: Map[Instance.Id, Set[Task.Id]] =
       instances.map { i => i.instanceId -> i.tasksMap.values.map(_.taskId).toSet }(collection.breakOut)
@@ -63,7 +46,7 @@ object KillStreamWatcher extends StrictLogging {
         case (snapshot, updates) =>
           val pendingInstanceIds: Set[Instance.Id] = snapshot.instances.iterator
             .filter { i => instanceTasks.contains(i.instanceId) }
-            .filterNot { i => predicate(i, instanceTasks(i.instanceId)) }
+            .filterNot { i => terminalPredicate(i, instanceTasks(i.instanceId)) }
             .map(_.instanceId)
             .to[Set]
 
@@ -72,7 +55,7 @@ object KillStreamWatcher extends StrictLogging {
             .scan(pendingInstanceIds) {
               case (remaining, deleted: InstanceDeleted) =>
                 remaining - deleted.id
-              case (remaining, InstanceUpdated(instance, _, _)) if predicate(instance, instanceTasks(instance.instanceId)) =>
+              case (remaining, InstanceUpdated(instance, _, _)) if terminalPredicate(instance, instanceTasks(instance.instanceId)) =>
                 remaining - instance.instanceId
               case (remaining, _) =>
                 remaining
@@ -82,29 +65,37 @@ object KillStreamWatcher extends StrictLogging {
   }
 
   /**
-    * Wait until either the instances are expunged, the tasks associated with the instances are terminal, or have been
-    * replaced with new tasks.
+    * Returns a Source that emits a diminishing set of instances that are not yet killed. The source completes when all
+    * instances are considered killed.
+    *
+    * When a process sends some kill request, it's usually in the context of killing the tasks associated with an
+    * instance at some given point in time. We count an instance as killed if it has different taskIds than those
+    * specified with the watch, or if the instance itself is in a state we consider terminal.
+    *
+    * @param instanceUpdates InstanceTracker instanceUpdates feed
+    * @param instanceIds Instance ids to wait to be considered killed
+    * @return Akka stream Source as described
+    *
     */
-  def watchForKilledInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance])(implicit materializer: Materializer): Future[Done] = {
-    KillStreamWatcher.
-      emitPendingTerminal(instanceUpdates, instances, whenTerminalOrReplaced)
-      .runWith(Sink.ignore)
-  }
+  def watchForKilledInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance]): Source[Set[Instance.Id], NotUsed] =
+    emitPendingTerminal(instanceUpdates, instances, considerTerminalIfConditionTerminalOrTasksReplaced)
 
   /**
-    * Wait for instances to be decommissioned and expunged from the instance tracker.
+    * Returns a Source that emits a diminishing set of instances that are not yet considered decommissioned. The source
+    * completes when all instances are considered decommissioned.
     *
-    * Since goals cannot be transitioned from decommissioned to running, it is safe to call this watcher method before
-    * or after the goal update is processed.
+    * When an instance has been marked as goal decommissioned, it's safe to assume that it is never coming back, since
+    * it's illegal to change an instance goal from Decommissioned back to running. As such, we assume an instance is
+    * decommissioned as soon as it is both marked as goal decommissioned, and the instance is considered terminal.
+    *
+    * Were we to only wait for the instance to become terminal, and not for the goal to also be decommissioned, then we
+    * could conclude too early that an instance is decommissioned, as it is possible that some random restart could
+    * precede the receipt of the update goal command.
     *
     * @param instanceUpdates InstanceTracker instanceUpdates feed
     * @param instanceIds Instance ids to wait to be expunged from the instance tracker due to decomissioning
-    * @param materializer Akka stream materializer
-    * @return
+    * @return Akka stream Source as described
     */
-  def watchForDecommissionedInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance])(implicit materializer: Materializer): Future[Done] = {
-    KillStreamWatcher.
-      emitPendingTerminal(instanceUpdates, instances, whenTerminalAndDecommissioned)
-      .runWith(Sink.ignore)
-  }
+  def watchForDecommissionedInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance]): Source[Set[Instance.Id], NotUsed] =
+    emitPendingTerminal(instanceUpdates, instances, considerTerminalIfConditionTerminalAndGoalDecommissioned)
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
@@ -51,7 +51,7 @@ object KillStreamWatcher extends StrictLogging {
     * @param instanceUpdates InstanceTracker instance state subscription stream
     * @param instances The instances in question to watch
     * @param predicate The mechanism to judge instance terminality; are we watching for tasks to be killed, or instance to be decommissioned.
-    * @return
+    * @return Source of instanceIds which emits a diminishing Set of pending instanceIds, and completes when that set is empty.
     */
   private[impl] def emitPendingTerminal(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance], predicate: TerminalPredicate): Source[Set[Instance.Id], NotUsed] = {
 
@@ -88,7 +88,6 @@ object KillStreamWatcher extends StrictLogging {
   def watchForKilledInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance])(implicit materializer: Materializer): Future[Done] = {
     KillStreamWatcher.
       emitPendingTerminal(instanceUpdates, instances, whenTerminalOrReplaced)
-      .takeWhile { pendingTerminalInstances => pendingTerminalInstances.nonEmpty }
       .runWith(Sink.ignore)
   }
 
@@ -106,7 +105,6 @@ object KillStreamWatcher extends StrictLogging {
   def watchForDecommissionedInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance])(implicit materializer: Materializer): Future[Done] = {
     KillStreamWatcher.
       emitPendingTerminal(instanceUpdates, instances, whenTerminalAndDecommissioned)
-      .takeWhile { pendingTerminalInstances => pendingTerminalInstances.nonEmpty }
       .runWith(Sink.ignore)
   }
 }

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
@@ -77,7 +77,7 @@ object KillStreamWatcher extends StrictLogging {
     * @return Akka stream Source as described
     *
     */
-  def watchForKilledInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance]): Source[Set[Instance.Id], NotUsed] =
+  def watchForKilledTasks(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance]): Source[Set[Instance.Id], NotUsed] =
     emitPendingTerminal(instanceUpdates, instances, considerTerminalIfConditionTerminalOrTasksReplaced)
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcher.scala
@@ -14,14 +14,45 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import scala.concurrent.Future
 
 object KillStreamWatcher extends StrictLogging {
+  /**
+    * We have two separate predicates for determining instance terminality: tasks have since been restarted, or instance
+    * is decommissioned.
+    */
   private type TerminalPredicate = (Instance, Set[Task.Id]) => Boolean
 
+  /**
+    * Predicate used to determine whether or not the tasks associated with an instance have been killed.
+    *
+    * When a process sends some kill request, it's usually in the context of killing the tasks associated with an
+    * instance at some given point in time. We count this kill as successful if we see that the taskIds have changed,
+    * or if the instance itself is in a state we consider terminal.
+    */
   private[impl] val whenTerminalOrReplaced: TerminalPredicate = (instance: Instance, taskIds: Set[Task.Id]) =>
     considerTerminal(instance.state.condition) || instance.tasksMap.values.forall(t => !taskIds(t.taskId))
 
+  /**
+    * Predicate used to determine whether or not an instance has been decommissioned.
+    *
+    * When an instance has been marked as goal decommissioned, it's safe to assume that it is never coming back, since
+    * it's illegal to change an instance goal from Decommissioned back to running. As such, we assume an instance is
+    * decommissioned as soon as it is both marked as goal decommissioned, and the instance is considered terminal.
+    *
+    * Were we to only wait for the instance to become terminal, and not for the goal to also be decommissioned, then we
+    * could conclude too early that an instance is decommissioned, as it is possible that some random restart could
+    * precede the receipt of the update goal command.
+    */
   private[impl] val whenTerminalAndDecommissioned: TerminalPredicate = (instance: Instance, _: Set[Task.Id]) =>
     instance.state.goal == Goal.Decommissioned && considerTerminal(instance.state.condition)
 
+  /**
+    * Given instance updates, and a set of instances, emit a set of instanceIds that are not yet expunged or considered
+    * terminal. Excludes instances that are expunged or considered terminal in the initial snapshot.
+    *
+    * @param instanceUpdates InstanceTracker instance state subscription stream
+    * @param instances The instances in question to watch
+    * @param predicate The mechanism to judge instance terminality; are we watching for tasks to be killed, or instance to be decommissioned.
+    * @return
+    */
   private[impl] def emitPendingTerminal(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance], predicate: TerminalPredicate): Source[Set[Instance.Id], NotUsed] = {
 
     val instancesMap: Map[Instance.Id, Set[Task.Id]] =
@@ -51,7 +82,8 @@ object KillStreamWatcher extends StrictLogging {
   }
 
   /**
-    * Wait until either the tasks associated with the instances are terminal, or have been replaced with new tasks.
+    * Wait until either the instances are expunged, the tasks associated with the instances are terminal, or have been
+    * replaced with new tasks.
     */
   def watchForKilledInstances(instanceUpdates: InstanceTracker.InstanceUpdates, instances: Iterable[Instance])(implicit materializer: Materializer): Future[Done] = {
     KillStreamWatcher.
@@ -63,7 +95,8 @@ object KillStreamWatcher extends StrictLogging {
   /**
     * Wait for instances to be decommissioned and expunged from the instance tracker.
     *
-    * Since goals cannot be transitioned from decommissioned to running, it is safe to call this watcher method before or after the goal update is processed.
+    * Since goals cannot be transitioned from decommissioned to running, it is safe to call this watcher method before
+    * or after the goal update is processed.
     *
     * @param instanceUpdates InstanceTracker instanceUpdates feed
     * @param instanceIds Instance ids to wait to be expunged from the instance tracker due to decomissioning

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -87,10 +87,11 @@ trait InstanceTracker extends StrictLogging {
   /**
     * An ongoing source of instance updates. On materialization, receives an update for all current instances
     */
-  val instanceUpdates: Source[(InstancesSnapshot, Source[InstanceChange, NotUsed]), NotUsed]
+  val instanceUpdates: InstanceTracker.InstanceUpdates
 }
 
 object InstanceTracker {
+  type InstanceUpdates = Source[(InstancesSnapshot, Source[InstanceChange, NotUsed]), NotUsed]
   /**
     * Contains all tasks grouped by app ID.
     */

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -424,6 +424,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty[Instance])
     instanceTracker.specInstancesSync(any) returns Seq.empty[Instance]
     instanceTracker.setGoal(any, any, any) returns Future.successful(Done)
+    instanceTracker.instanceUpdates returns Source.empty
     val killService = new KillServiceMock(system)
 
     val queue: LaunchQueue = mock[LaunchQueue]

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 
 import akka.Done
+import akka.stream.scaladsl.Source
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -273,6 +274,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       val groupRepo = mock[GroupRepository]
       val instanceTracker = mock[InstanceTracker]
       instanceTracker.setGoal(any, any, any).returns(Future.successful(Done))
+      instanceTracker.instanceUpdates returns Source.empty
       val driver = mock[SchedulerDriver]
       val killService = mock[KillService]
       val clock = new SettableClock()

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -3,10 +3,12 @@ package api
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
+import mesosphere.marathon.core.instance.update.InstancesSnapshot
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
@@ -154,9 +156,9 @@ class TaskKillerTest extends UnitTest {
   class Fixture {
     val tracker: InstanceTracker = mock[InstanceTracker]
     tracker.setGoal(any, any, any).returns(Future.successful(Done))
+    tracker.instanceUpdates.returns(Source.single(InstancesSnapshot(Nil) -> Source.empty))
     val killService: KillService = mock[KillService]
     val groupManager: GroupManager = mock[GroupManager]
-    killService.watchForKilledInstances(any)(any).returns(Future.successful(Done))
 
     val config: MarathonConf = mock[MarathonConf]
     when(config.zkTimeoutDuration).thenReturn(1.second)

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -3,6 +3,7 @@ package core.deployment.impl
 
 import akka.Done
 import akka.actor.ActorRef
+import akka.stream.scaladsl.Source
 import akka.testkit.TestProbe
 import akka.util.Timeout
 import mesosphere.AkkaUnitTest
@@ -39,6 +40,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
   class Fixture {
     val tracker: InstanceTracker = mock[InstanceTracker]
     tracker.setGoal(any, any, any).returns(Future.successful(Done))
+    tracker.instanceUpdates returns Source.empty
 
     val queue: LaunchQueue = mock[LaunchQueue]
     val killService = new KillServiceMock(system)

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -115,6 +115,9 @@ case class TestInstanceBuilder(instance: Instance, now: Timestamp = Timestamp.no
   def withReservation(volumeIds: Seq[LocalVolumeId]): TestInstanceBuilder =
     withReservation(volumeIds, reservationStateNew)
 
+  def withGoal(goal: Goal): TestInstanceBuilder =
+    copy(instance = instance.copy(state = instance.state.copy(goal = goal)))
+
   def withReservation(state: Reservation.State): TestInstanceBuilder =
     withReservation(Seq.empty, state)
 

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -377,7 +377,7 @@ object TestTaskBuilder extends StrictLogging {
       container: Option[MesosContainer] = None): Task = {
       import mesosphere.marathon.test.MarathonTestHelper.Implicits._
 
-      val taskId = Task.Id(instanceId, container)
+      val taskId = Task.TaskIdWithIncarnation(instanceId, container.map(_.name), 1)
       startingTask(taskId, appVersion, stagedAt)
         .withStatus((status: Task.Status) =>
           status.copy(

--- a/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/KillServiceMock.scala
@@ -3,15 +3,13 @@ package core.task
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.Materializer
-import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.MarathonEvent
 import mesosphere.marathon.core.instance.update.InstanceChangedEventsGenerator
 import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.task.Task.Id
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
-import mesosphere.marathon.test.Mockito
+import mesosphere.marathon.test.{Mockito, SettableClock}
 
 import scala.collection.mutable
 import scala.concurrent.Future
@@ -48,11 +46,5 @@ class KillServiceMock(system: ActorSystem) extends KillService with Mockito {
       killInstance(instance, reason)
     }
   }
-
-  /**
-    * Begins watching immediately for terminated instances. Future is completed when all instances are reported in a
-    * terminal condition.
-    */
-  override def watchForKilledInstances(instances: Seq[Instance])(implicit materializer: Materializer): Future[Done] = Future.successful(Done)
 }
 

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 
 import akka.Done
 import akka.actor.{ActorRef, PoisonPill, Terminated}
+import akka.stream.scaladsl.Source
 import akka.testkit.TestProbe
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.AkkaUnitTest
@@ -361,6 +362,7 @@ class KillServiceActorTest extends AkkaUnitTest with StrictLogging {
       holder
     }
     val instanceTracker: InstanceTracker = mock[InstanceTracker]
+    instanceTracker.instanceUpdates returns Source.empty
     val clock = new SettableClock()
     val metrics: Metrics = DummyMetrics
 

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
@@ -1,71 +1,102 @@
 package mesosphere.marathon
 package core.task.termination.impl
 
-import java.util.UUID
-
 import akka.Done
-import akka.stream.scaladsl.{Sink, Source}
-import akka.testkit.TestProbe
+import akka.stream.scaladsl.{Flow, Sink, Source}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.condition.Condition
+import mesosphere.marathon.core.instance.update.{InstanceDeleted, InstanceUpdated, InstancesSnapshot}
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
-import mesosphere.marathon.core.instance.Instance.PrefixInstance
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.PathId
 
-import scala.concurrent.duration._
-
 class KillStreamWatcherTest extends AkkaUnitTest {
+  val instancesTerminalFlow = Flow[Instance].map { i => InstanceUpdated(i.copy(state = i.state.copy(condition = Condition.Finished)), Some(i.state), Nil) }
+
+  val instancesDecommissionedFlow = Flow[Instance].map { i =>
+    InstanceDeleted(i, None, Nil)
+  }
   "killedInstanceFlow yields Done immediately when waiting on empty instance Ids" in {
-    val result = Source.empty.
-      via(KillStreamWatcher.killedInstanceFlow(Nil)).
-      runWith(Sink.head)
+    val emptyUpdates: InstanceTracker.InstanceUpdates = Source.single((InstancesSnapshot(Nil), Source.empty))
+    val result = KillStreamWatcher.watchForKilledInstances(emptyUpdates, Set.empty)
 
     result.futureValue shouldBe Done
   }
 
-  "killedInstanceFlow yields Done when all instance Ids are seen" in {
+  "killedInstanceFlow yields Set.empty when all instance Ids are seen" in {
 
-    val instanceIds = List("/a", "/b", "/c").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
-    val otherInstanceIds = List("/e", "/g", "/f").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
+    val instances = List("/a", "/b", "/c").map(appId => TestInstanceBuilder.newBuilder(PathId(appId)).addTaskRunning().instance)
+    val otherInstance = List("/e", "/g", "/f").map(appId => TestInstanceBuilder.newBuilder(PathId(appId)).addTaskRunning().instance)
 
-    val result = Source(otherInstanceIds ++ instanceIds).
-      via(KillStreamWatcher.killedInstanceFlow(instanceIds)).
-      runWith(Sink.head)
+    val instanceUpdates = Source.single(InstancesSnapshot(instances ++ otherInstance) -> Source(instances).via(instancesTerminalFlow))
 
-    result.futureValue shouldBe Done
+    val result = KillStreamWatcher.emitPendingTerminal(instanceUpdates, instances).runWith(Sink.last)
+
+    result.futureValue shouldBe Set.empty
   }
 
-  "killedInstanceFlow does not yield Done when not all instance Ids are seen" in {
-    val instanceIds = List("/a", "/b", "/c").map(appId => Instance.Id(PathId(appId), PrefixInstance, UUID.randomUUID()))
+  "emitPendingTerminal does not yield Set.empty when not all instance Ids are seen" in {
+    val instances = List("/a", "/b", "/c").map(appId => TestInstanceBuilder.newBuilder(PathId(appId)).addTaskRunning().instance)
 
-    val result = Source(instanceIds.tail).
-      via(KillStreamWatcher.killedInstanceFlow(instanceIds)).
-      runWith(Sink.seq)
+    val instanceUpdates = Source.single(InstancesSnapshot(instances) -> Source(instances.tail).via(instancesTerminalFlow))
 
-    result.futureValue shouldBe Nil
+    val result = KillStreamWatcher.emitPendingTerminal(instanceUpdates, instances).runWith(Sink.last)
+
+    result.futureValue.map(_.runSpecId) shouldBe Set(PathId("/a"))
   }
 
-  "KillStreamWatcher emits already terminated instances" in {
+  "KillStreamWatcher recognizes instances that are already terminal" in {
 
-    val empty = TestInstanceBuilder.emptyInstance(instanceId = Instance.Id.forRunSpec(PathId("/test")))
-    val unreachableInstance = empty.copy(state = empty.state.copy(condition = Condition.Killed))
+    val unreachableInstance = TestInstanceBuilder.newBuilder(PathId("/test")).addTaskUnreachable().instance
+    val instanceUpdates = Source.single(InstancesSnapshot(Seq(unreachableInstance)) -> Source.empty)
+    val result = KillStreamWatcher.emitPendingTerminal(instanceUpdates, Seq(unreachableInstance)).runWith(Sink.last)
 
-    val watcher = KillStreamWatcher.watchForKilledInstances(system.eventStream, List(unreachableInstance))
-
-    watcher.runWith(Sink.head).futureValue shouldEqual Done
+    result.futureValue shouldBe Set.empty
   }
 
-  "KillStreamWatcher doesn't emit anything if there are no changes" in {
+  "KillStreamWatcher emits the original instances if nothing is terminal" in {
+    val instances = List("/a", "/b", "/c").map(appId => TestInstanceBuilder.newBuilder(PathId(appId)).addTaskRunning().instance)
+    val instanceUpdates = Source.single(InstancesSnapshot(instances) -> Source.empty)
 
-    val probe = TestProbe("KillStreamWatcher")
+    val result = KillStreamWatcher.emitPendingTerminal(instanceUpdates, instances).runWith(Sink.seq)
 
-    val empty = TestInstanceBuilder.emptyInstance(instanceId = Instance.Id.forRunSpec(PathId("/test")))
-    val runnningInstance = empty.copy(state = empty.state.copy(condition = Condition.Running))
-
-    val watcher = KillStreamWatcher.watchForKilledInstances(system.eventStream, List(runnningInstance))
-
-    watcher.runWith(Sink.head).onComplete(_ => probe.ref ! Done)
-    probe.expectNoMessage(100.millis)
+    result.futureValue.map(_.map(_.runSpecId)) shouldBe List(Set(PathId("/a"), PathId("/b"), PathId("/c")))
   }
 
+  "KillStreamWatcher treats instances with taskIds with later incarnations as terminal" in {
+    val instanceWithIncarnation1 = TestInstanceBuilder.newBuilder(PathId("/a")).addTaskRunning().instance
+    val instanceWithIncarnation2 = instanceWithIncarnation1.copy(tasksMap = instanceWithIncarnation1.tasksMap.map {
+      case (taskId, task) =>
+        val nextTaskId = Task.Id.nextIncarnationFor(taskId)
+        nextTaskId -> task.copy(taskId = nextTaskId)
+    })
+    val instanceUpdates = Source.single(InstancesSnapshot(Seq(instanceWithIncarnation2)) -> Source.empty)
+
+    val result1 = KillStreamWatcher.emitPendingTerminal(instanceUpdates, Seq(instanceWithIncarnation1)).runWith(Sink.last)
+
+    result1.futureValue shouldBe Set.empty
+
+    val result2 = KillStreamWatcher.emitPendingTerminal(instanceUpdates, Seq(instanceWithIncarnation2)).runWith(Sink.last)
+
+    result2.futureValue shouldNot be(Set.empty)
+  }
+
+  "KillStreamWatcher does not emit instances as terminal if they're terminal, but not decommissioned and expunged" in {
+    val instanceWithIncarnation = TestInstanceBuilder.newBuilder(PathId("/a")).addTaskRunning().instance
+
+    val instanceUpdatesTerminalNonDecomissioned = Source.single(
+      InstancesSnapshot(Seq(instanceWithIncarnation)) -> Source.single(instanceWithIncarnation).via(instancesTerminalFlow))
+
+    val result1 = KillStreamWatcher.emitPendingDecomissioned(instanceUpdatesTerminalNonDecomissioned, Set(instanceWithIncarnation.instanceId)).runWith(Sink.last)
+
+    result1.futureValue.map(_.runSpecId) shouldBe Set(PathId("/a"))
+
+    val instanceUpdatesTerminalAndDecomissioned = Source.single(
+      InstancesSnapshot(Seq(instanceWithIncarnation)) -> Source.single(instanceWithIncarnation).via(instancesDecommissionedFlow))
+
+    val result2 = KillStreamWatcher.emitPendingDecomissioned(instanceUpdatesTerminalAndDecomissioned, Set(instanceWithIncarnation.instanceId)).runWith(Sink.last)
+
+    result2.futureValue should be(Set.empty)
+  }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
@@ -31,7 +31,7 @@ class KillStreamWatcherTest extends AkkaUnitTest {
     "completes immediately if provided an empty instance Ids" in {
       val emptyUpdates: InstanceTracker.InstanceUpdates = Source.single((InstancesSnapshot(Nil), sourceNever))
       val result = KillStreamWatcher
-        .watchForKilledInstances(emptyUpdates, Set.empty)
+        .watchForKilledTasks(emptyUpdates, Set.empty)
         .runWith(Sink.ignore)
         .futureValue
 
@@ -42,7 +42,7 @@ class KillStreamWatcherTest extends AkkaUnitTest {
       val unreachableInstance = TestInstanceBuilder.newBuilder(PathId("/test")).addTaskUnreachable().instance
       val instanceUpdates = Source.single(InstancesSnapshot(Seq(unreachableInstance)) -> sourceNever)
       val result = KillStreamWatcher
-        .watchForKilledInstances(instanceUpdates, Seq(unreachableInstance))
+        .watchForKilledTasks(instanceUpdates, Seq(unreachableInstance))
         .runWith(Sink.last)
         .futureValue
 
@@ -56,7 +56,7 @@ class KillStreamWatcherTest extends AkkaUnitTest {
       val instanceUpdates = Source.single(InstancesSnapshot(instances ++ otherInstance) -> Source(instances).via(instancesTerminalFlow))
 
       val result = KillStreamWatcher
-        .watchForKilledInstances(instanceUpdates, instances)
+        .watchForKilledTasks(instanceUpdates, instances)
         .runWith(Sink.last)
         .futureValue
 
@@ -68,7 +68,7 @@ class KillStreamWatcherTest extends AkkaUnitTest {
 
       val instanceUpdates = Source.single(InstancesSnapshot(instances) -> Source(instances.tail).via(instancesTerminalFlow))
 
-      val result = KillStreamWatcher.watchForKilledInstances(instanceUpdates, instances).runWith(Sink.last)
+      val result = KillStreamWatcher.watchForKilledTasks(instanceUpdates, instances).runWith(Sink.last)
 
       result.futureValue.map(_.runSpecId) shouldBe Set(PathId("/a"))
     }
@@ -77,7 +77,7 @@ class KillStreamWatcherTest extends AkkaUnitTest {
       val instances = List("/a", "/b", "/c").map(appId => TestInstanceBuilder.newBuilder(PathId(appId)).addTaskRunning().instance)
       val instanceUpdates = Source.single(InstancesSnapshot(instances) -> Source.empty)
 
-      val Seq(result) = KillStreamWatcher.watchForKilledInstances(instanceUpdates, instances).runWith(Sink.seq).futureValue
+      val Seq(result) = KillStreamWatcher.watchForKilledTasks(instanceUpdates, instances).runWith(Sink.seq).futureValue
 
       result.map(_.runSpecId) shouldBe Set(PathId("/a"), PathId("/b"), PathId("/c"))
     }
@@ -92,14 +92,14 @@ class KillStreamWatcherTest extends AkkaUnitTest {
       val instanceUpdates = Source.single(InstancesSnapshot(Seq(instanceWithIncarnation2)) -> Source.empty)
 
       val Seq(result1) = KillStreamWatcher
-        .watchForKilledInstances(instanceUpdates, Seq(instanceWithIncarnation1))
+        .watchForKilledTasks(instanceUpdates, Seq(instanceWithIncarnation1))
         .runWith(Sink.seq)
         .futureValue
 
       result1 shouldBe Set.empty
 
       val Seq(result2: Set[Instance.Id]) = KillStreamWatcher
-        .watchForKilledInstances(instanceUpdates, Seq(instanceWithIncarnation2))
+        .watchForKilledTasks(instanceUpdates, Seq(instanceWithIncarnation2))
         .runWith(Sink.seq)
         .futureValue
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -12,7 +12,6 @@ import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, CommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{PathId, Timestamp}
-import org.scalactic.source.Position
 import org.scalatest.Inside
 
 import scala.concurrent.duration._

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.typesafe.scalalogging.{Logger, StrictLogging}
 import mesosphere.marathon.Protos.Constraint
-import mesosphere.marathon.api.RestResource
 import mesosphere.marathon.core.pod.{HostNetwork, MesosContainer, PodDefinition}
 import mesosphere.marathon.integration.facades._
 import mesosphere.marathon.raml.{App, AppHealthCheck, AppHostVolume, AppPersistentVolume, AppResidency, AppVolume, Container, EngineType, Network, NetworkMode, PersistentVolumeInfo, PortDefinition, ReadMode, UnreachableDisabled, UpgradeStrategy}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -771,8 +771,8 @@ trait MarathonTest extends HealthCheckEndpoint with MarathonAppFixtures with Sca
 
   def waitForDeployment(change: RestResult[_], maxWait: FiniteDuration = patienceConfig.timeout.toMillis.millis): CallbackEvent = {
     require(change.success, s"Deployment request has not been successful. httpCode=${change.code} body=${change.entityString}")
-    val deploymentId = change.originalResponse.headers.find(_.name == RestResource.DeploymentHeader).getOrElse(throw new IllegalArgumentException("No deployment id found in Http Header"))
-    waitForDeploymentId(deploymentId.value, maxWait)
+    val deploymentId = change.deploymentId.getOrElse(throw new IllegalArgumentException("No deployment id found in Http Header"))
+    waitForDeploymentId(deploymentId, maxWait)
   }
 
   def waitForAppOfferReject(appId: PathId, offerRejectReason: String): Unit = {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/RestResult.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/RestResult.scala
@@ -3,7 +3,9 @@ package integration.setup
 
 import akka.http.scaladsl.model.HttpResponse
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.api.RestResource
 import play.api.libs.json.{JsValue, Json}
+
 import scala.reflect.ClassTag
 
 /**
@@ -40,6 +42,12 @@ case class RestResult[+T](valueGetter: () => T, originalResponse: HttpResponse, 
 
   /** Pretty print the original response entity (=body) as json. */
   lazy val entityPrettyJsonString: String = Json.prettyPrint(entityJson)
+
+  /**
+    * @return Deployment ID from headers, if any
+    */
+  def deploymentId: Option[String] =
+    originalResponse.headers.collectFirst { case header if header.name == RestResource.DeploymentHeader => header.value }
 }
 
 object RestResult {


### PR DESCRIPTION
This approach is race condition free; one does not need to
register the KillStreamWatcher before the kill requests are sent, as
kills will be detected if they'd already happened before the watcher
was registered. This is achieved by recognizing one the following states
as "terminal"

- Instance was removed from the instance tracker
- Instance has running tasks with Ids of later incarnation
- Instance is considered terminal (unreachable, killed, etc.)

Further, a mechanism was introduced to wait for instances to become
decomissioned. This simply waits for a moment in time where the
instance is no longer in the instanceTracker, either during the
initial snapshot or in subsequent updates.

JIRA Issues: MARATHON-8541