### PR TITLE
Fix racy deployment rollback

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -259,9 +259,7 @@ class MarathonSchedulerActor private (
 
   def deploymentFailed(plan: DeploymentPlan, reason: Throwable): Unit = {
     logger.error(s"Deployment ${plan.id}:${plan.version} of ${plan.targetIdsString} failed", reason)
-    Future.sequence(plan.affectedRunSpecIds.map(launchQueue.purge))
-      .recover { case NonFatal(error) => logger.warn(s"Error during async purge: planId=${plan.id} for ${plan.targetIdsString}", error); Done }
-      .foreach { _ => eventBus.publish(core.event.DeploymentFailed(plan.id, plan, reason = Some(reason.getMessage()))) }
+    eventBus.publish(core.event.DeploymentFailed(plan.id, plan, reason = Some(reason.getMessage())))
   }
 }
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerService.scala
@@ -112,7 +112,7 @@ class MarathonSchedulerService @Inject() (
   protected def newTimer() = new Timer("marathonSchedulerTimer")
 
   def deploy(plan: DeploymentPlan, force: Boolean = false): Future[Done] = {
-    logger.info(s"Deploy plan with force=$force:\n$plan ")
+    logger.debug(s"Forwarding new deployment plan with planId=${plan.id}, force=$force to the MarathonSchedulerActor")
     val future: Future[Any] = PromiseActor.askWithoutTimeout(system, schedulerActor, Deploy(plan, force))
     future.map {
       case DeploymentStarted(_) => Done

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -188,9 +188,6 @@ private class DeploymentActor(
     logger.debug(s"Stop runnable $runSpec")
     healthCheckManager.removeAllFor(runSpec.id)
 
-    // Purging launch queue
-    await(launchQueue.purge(runSpec.id))
-
     val instances = await(instanceTracker.specInstances(runSpec.id))
 
     logger.info(s"Killing all instances of ${runSpec.id}: ${instances.map(_.instanceId)}")

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -52,7 +52,7 @@ object InstanceUpdater extends StrictLogging {
           val updated: Instance = updatedInstance(instance, updatedTask, now)
           val events = eventsGenerator.events(updated, Some(updatedTask), now, previousState = Some(instance.state))
           if (shouldBeExpunged(updated)) {
-            logger.info("requesting to expunge instance {}, all tasks are terminal, instance has no reservation and is not Stopped", updated.instanceId)
+            logger.info("Requesting to expunge {}, all tasks are terminal, instance has no reservation and is not Stopped", updated.instanceId)
             InstanceUpdateEffect.Expunge(updated, events)
           } else {
             InstanceUpdateEffect.Update(updated, oldState = Some(instance), events)

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -374,7 +374,8 @@ private class TaskLauncherActor(
     */
   private[this] def launchAllowed(now: Timestamp, configRef: RunSpecConfigRef): Boolean = launchAllowedAt.get(configRef).exists(_ <= now)
   private[this] def shouldLaunchInstances(now: Timestamp): Boolean = {
-    logger.info(s"scheduledInstances: $scheduledInstances, backOffs: $launchAllowedAt")
+    if (scheduledInstances.nonEmpty || launchAllowedAt.nonEmpty)
+      logger.info(s"Found scheduled instances: ${scheduledInstances.map(_.instanceId).mkString(",")} and current back-off map: $launchAllowedAt")
     scheduledInstances.nonEmpty && scheduledVersions.exists { configRef => launchAllowed(now, configRef) }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -151,7 +151,7 @@ private[impl] class KillServiceActor(
     val killCount = config.killChunkSize - inFlight.size
     val toKillNow = instancesToKill.take(killCount)
 
-    logger.info(s"processing ${toKillNow.size} kills for ${toKillNow.keys}")
+    if (toKillNow.nonEmpty) logger.info(s"Processing ${toKillNow.size} kills for ${toKillNow.keys.mkString(",")}")
     toKillNow.foreach {
       case (instanceId, data) => processKill(data)
     }

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -279,7 +279,6 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       expectMsg(DeploymentStarted(plan))
 
-      verify(f.queue, timeout(1000)).purge(app.id)
       verify(f.queue, timeout(1000)).resetDelay(app.copy(instances = 0))
 
       system.eventStream.unsubscribe(probe.ref)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -12,12 +12,11 @@ import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, CommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol, UpgradeStrategy}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{PathId, Timestamp}
-import org.scalatest.Inside
 import org.scalactic.source.Position
 
 import scala.concurrent.duration._
 
-class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
+class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
   def appId(suffix: Option[String] = None): PathId = testBasePath / s"app-${suffix.getOrElse(UUID.randomUUID)}"
 
@@ -637,7 +636,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
 
       val waitingFor = Map[String, CallbackEvent => Boolean](
         elems =
-        "api_post_event" -> (_.info("appDefinition").asInstanceOf[Map[String, Any]]("id") == appIdPath.toString),
+          "api_post_event" -> (_.info("appDefinition").asInstanceOf[Map[String, Any]]("id") == appIdPath.toString),
         "group_change_success" -> (_.info("groupId").asInstanceOf[String] == appIdPath.parent.toString),
         "status_update_event" -> (_.info("appId") == appIdPath.toString),
         "status_update_event" -> (_.info("appId") == appIdPath.toString),

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -9,10 +9,11 @@ import mesosphere.marathon.api.RestResource
 import mesosphere.marathon.integration.facades.MarathonFacade._
 import mesosphere.marathon.integration.facades.{ITDeployment, ITEnrichedTask, ITQueueItem}
 import mesosphere.marathon.integration.setup._
-import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, CommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol}
+import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, CommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol, UpgradeStrategy}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{PathId, Timestamp}
 import org.scalatest.Inside
+import org.scalactic.source.Position
 
 import scala.concurrent.duration._
 
@@ -715,6 +716,41 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
 
       Then("the app should also be gone")
       marathon.app(id) should be(NotFound)
+    }
+
+    // Regression for MARATHON-8537
+    "manage yet another deployment rollback" in {
+      Given("an existing app")
+      val id: PathId = appId(Some("yet-another-deployment-rollback"))
+      val app = App(
+        id = id.toString,
+        cmd = Some("sleep 12345"),
+        instances = 2,
+        backoffFactor = 1d,
+        upgradeStrategy = Some(UpgradeStrategy(maximumOverCapacity = 0d, minimumHealthCapacity = 0d))
+      )
+      val created = marathon.createAppV2(app)
+      created shouldBe Created
+      waitForDeployment(created)
+
+      And("it is updated with an impossible constraint")
+      val updated = marathon.updateApp(id, AppUpdate(cpus = Some(1000d), cmd = Some("na"), instances = Some(1)))
+      updated shouldBe OK
+      val deploymentId = updated.originalResponse.headers.find(_.name == RestResource.DeploymentHeader).getOrElse(throw new IllegalArgumentException("No deployment id found in Http Header")).value()
+
+      Then("we wait for the first new instance to become scheduled")
+      // waitForEventWith("instance_changed_event", ev => ev.info("goal") == "Scheduled", s"event instance_changed_event with goal = Scheduled to arrive")
+      // But since we don't have this event now, we just simply try to wait for 5s which seems to work too ¯\_(ツ)_/¯
+      val start = System.currentTimeMillis()
+      eventually(System.currentTimeMillis() should be >= (start + 5000))(config = PatienceConfig(10.seconds, 100.millis), pos = Position.here)
+
+      And("cancel previous update")
+      val canceled = marathon.deleteDeployment(deploymentId)
+      canceled shouldBe OK
+
+      Then(s"rollback should be successful and ${app.instances} tasks running")
+      waitForDeployment(canceled)
+      waitForTasks(id, 2) //make sure, all the tasks have really started
     }
 
     "Docker info is not automagically created" in {


### PR DESCRIPTION
Summary:
recent instance's goal related refactorings introduced a race condition where decommissioning a _Scheduled_ instance would be unhandled by the `TaskReplaceActor` so that deployment would be stuck since not enough instance would be launched. This patch fixes this bug. A regression integration test was added. Additionally, we get rid of 2/3 `LaunchQueue.purge` calls that existed in and around deployments. These are not needed anymore.

Fixes: MARATHON-8537
Related: MARATHON-8223