### PR TITLE
Reduce constraint IR to case classes.

### DIFF
--- a/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
@@ -149,7 +149,7 @@ object RamlTypeGenerator {
         Option(field).collect {
           case s: StringTypeDeclaration =>
             Seq(
-              Option(s.maxLength()).map(len => ConstraintT.MaxLength(len = len)),
+              Option(s.maxLength()).map(ConstraintT.MaxLength(_)),
               Option(s.minLength()).map(ConstraintT.MinLength(_)),
               Option(s.pattern()).map(ConstraintT.Pattern(_))
             ).flatten

--- a/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
@@ -149,7 +149,7 @@ object RamlTypeGenerator {
         Option(field).collect {
           case s: StringTypeDeclaration =>
             Seq(
-              Option(s.maxLength()).map(ConstraintT.MaxLength(_)),
+              Option(s.maxLength()).map(len => ConstraintT.MaxLength(len = len)),
               Option(s.minLength()).map(ConstraintT.MinLength(_)),
               Option(s.pattern()).map(ConstraintT.Pattern(_))
             ).flatten

--- a/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/FieldVisitor.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/FieldVisitor.scala
@@ -1,0 +1,68 @@
+package mesosphere.raml.backend.treehugger
+
+import mesosphere.raml.backend.{PlayPath, PlayReads, camelify, scalaFieldName, underscoreToCamel}
+import mesosphere.raml.ir.{ConstraintT, FieldT}
+import treehugger.forest._
+import definitions._
+import mesosphere.raml.ir.ConstraintT.BasicConstraint
+import treehuggerDSL._
+
+import scala.annotation.tailrec
+
+object FieldVisitor {
+
+  def playValidator(field: FieldT) =  {
+    def reads = validateConstraints(field.constraints)(PlayPath DOT "read" APPLYTYPE field.`type`)
+    def validate =
+      REF("json") DOT "\\" APPLY(LIT(field.rawName)) DOT "validate" APPLYTYPE field.`type` APPLY(reads)
+    def validateOpt =
+      REF("json") DOT "\\" APPLY(LIT(field.rawName)) DOT "validateOpt" APPLYTYPE field.`type` APPLY(reads)
+    def validateOptWithDefault(defaultValue: Tree) =
+      REF("json") DOT "\\" APPLY(LIT(field.rawName)) DOT "validateOpt" APPLYTYPE field.`type` APPLY(reads) DOT "map" APPLY (REF("_") DOT "getOrElse" APPLY defaultValue)
+
+    if (field.required && !field.forceOptional) {
+      validate
+    } else if (field.repeated && !field.forceOptional) {
+      validateOptWithDefault(field.`type` APPLY())
+    } else {
+      if (field.defaultValue.isDefined && !field.forceOptional) {
+        validateOptWithDefault(field.defaultValue.get)
+      } else {
+        validateOpt
+      }
+    }
+  }
+
+  def validateConstraints(c: Seq[ConstraintT[_]])(exp: Tree): Tree = {
+    if (c.isEmpty) {
+      exp
+    } else {
+      @tailrec
+      def buildChain(constraints: List[ConstraintT[_]], chain: Tree): Tree = constraints match {
+        case Nil => chain
+        case c :: rs => buildChain(rs, chain INFIX("keepAnd", validateConstraint(c)))
+      }
+
+      exp APPLY buildChain(c.tail.to[List], validateConstraint(c.head))
+    }
+  }
+
+  /** @return a code gen expression that represents a playJS reads validation */
+  def validateConstraint(c: ConstraintT[_]): Tree = c match {
+    case max @ ConstraintT.MaxLength(name, len, _) => REF(name) APPLYTYPE StringClass APPLY (max.constraintToValue(len))
+    case min @ ConstraintT.MinLength(len, _) => REF(min.name) APPLYTYPE StringClass APPLY (min.constraintToValue(len))
+    case p @ ConstraintT.Pattern(pattern, _) =>  REF(p.name) APPLY (p.constraintToValue(pattern))
+    case max @ ConstraintT.MaxItems(len, t, _) => REF(max.name) APPLYTYPE t APPLY(max.constraintToValue(len))
+    case min @ ConstraintT.MinItems(len, t, _) => REF(min.name) APPLYTYPE t APPLY(min.constraintToValue(len))
+    case max @ ConstraintT.Max(v, t, _) => REF(max.name) APPLYTYPE t APPLY(max.constraintToValue(v))
+    case min @ ConstraintT.Min(v, t, _) => REF(min.name) APPLYTYPE t APPLY(min.constraintToValue(v))
+    case keyPattern @ ConstraintT.KeyPattern(pattern, mapValType, _) =>  REF(keyPattern.name) APPLYTYPE mapValType APPLY (keyPattern.constraintToValue(pattern))
+  }
+
+  def limitField(constraint: ConstraintT[_], field: FieldT): Option[Tree] = {
+    constraint.withFieldLimit(field).limitField
+    val fieldName = scalaFieldName(underscoreToCamel(camelify(s"constraint_${f.rawName}_${name}".replace("-", "_"))))
+    val limit = (VAL(fieldName) := constraint.constraintToValue(constraint))
+    constraint.copyWith(Option(limit))
+  }
+}

--- a/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/FieldVisitor.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/FieldVisitor.scala
@@ -4,7 +4,6 @@ import mesosphere.raml.backend.{PlayPath, PlayReads, camelify, scalaFieldName, u
 import mesosphere.raml.ir.{ConstraintT, FieldT}
 import treehugger.forest._
 import definitions._
-import mesosphere.raml.ir.ConstraintT.BasicConstraint
 import treehuggerDSL._
 
 import scala.annotation.tailrec
@@ -49,20 +48,34 @@ object FieldVisitor {
 
   /** @return a code gen expression that represents a playJS reads validation */
   def validateConstraint(c: ConstraintT[_]): Tree = c match {
-    case max @ ConstraintT.MaxLength(name, len, _) => REF(name) APPLYTYPE StringClass APPLY (max.constraintToValue(len))
-    case min @ ConstraintT.MinLength(len, _) => REF(min.name) APPLYTYPE StringClass APPLY (min.constraintToValue(len))
-    case p @ ConstraintT.Pattern(pattern, _) =>  REF(p.name) APPLY (p.constraintToValue(pattern))
-    case max @ ConstraintT.MaxItems(len, t, _) => REF(max.name) APPLYTYPE t APPLY(max.constraintToValue(len))
-    case min @ ConstraintT.MinItems(len, t, _) => REF(min.name) APPLYTYPE t APPLY(min.constraintToValue(len))
-    case max @ ConstraintT.Max(v, t, _) => REF(max.name) APPLYTYPE t APPLY(max.constraintToValue(v))
-    case min @ ConstraintT.Min(v, t, _) => REF(min.name) APPLYTYPE t APPLY(min.constraintToValue(v))
-    case keyPattern @ ConstraintT.KeyPattern(pattern, mapValType, _) =>  REF(keyPattern.name) APPLYTYPE mapValType APPLY (keyPattern.constraintToValue(pattern))
+    case max @ ConstraintT.MaxLength(len) =>
+      REF(max.name) APPLYTYPE StringClass APPLY (constraintToValue(max, len))
+    case min @ ConstraintT.MinLength(len) =>
+      REF(min.name) APPLYTYPE StringClass APPLY (constraintToValue(min, len))
+    case p @ ConstraintT.Pattern(pattern) =>
+      REF(p.name) APPLY (constraintToValue(p, pattern))
+    case max @ ConstraintT.MaxItems(len, t) =>
+      REF(max.name) APPLYTYPE t APPLY(constraintToValue(max, len))
+    case min @ ConstraintT.MinItems(len, t) =>
+      REF(min.name) APPLYTYPE t APPLY(constraintToValue(min, len))
+    case max @ ConstraintT.Max(v, t) =>
+      REF(max.name) APPLYTYPE t APPLY(constraintToValue(max, v))
+    case min @ ConstraintT.Min(v, t) =>
+      REF(min.name) APPLYTYPE t APPLY(constraintToValue(min, v))
+    case keyPattern @ ConstraintT.KeyPattern(pattern, mapValType) =>
+      REF(keyPattern.name) APPLYTYPE mapValType APPLY (constraintToValue(keyPattern, pattern))
   }
 
-  def limitField(constraint: ConstraintT[_], field: FieldT): Option[Tree] = {
-    constraint.withFieldLimit(field).limitField
-    val fieldName = scalaFieldName(underscoreToCamel(camelify(s"constraint_${f.rawName}_${name}".replace("-", "_"))))
-    val limit = (VAL(fieldName) := constraint.constraintToValue(constraint))
-    constraint.copyWith(Option(limit))
+  def constraintToValue[C](c: ConstraintT[C], v: C): Tree = c match {
+    case ConstraintT.Pattern(pattern) =>  LIT(pattern) DOT "r"
+    case ConstraintT.KeyPattern(pattern, _) =>  LIT(pattern) DOT "r"
+    case _ => LIT(v) // decent assumption for built-ins, probably not much else
+  }
+
+  /** a code gen expression for a field that represents the constraint limit */
+  def limitField[C](constraint: ConstraintT[C], field: FieldT): Option[Tree] = {
+    val fieldName = scalaFieldName(underscoreToCamel(camelify(s"constraint_${field.rawName}_${constraint.name}".replace("-", "_"))))
+    val limit = (VAL(fieldName) := constraintToValue[C](constraint, constraint.constraint))
+    Option(limit)
   }
 }

--- a/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/ObjectVisitor.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/ObjectVisitor.scala
@@ -83,7 +83,7 @@ object ObjectVisitor {
           } else  Seq(DEF("reads", PLAY_JSON_RESULT(name)) withParams PARAM("json", PlayJsValue) := {
             BLOCK(
               actualFields.map { field =>
-                VAL(field.name) := field.playValidator
+                VAL(field.name) := FieldVisitor.playValidator(field)
               } ++ Seq(
                 VAL("_errors") := SEQ(actualFields.map(f => TUPLE(LIT(f.rawName), REF(f.name)))) DOT "collect" APPLY BLOCK(
                   CASE(REF(s"(field, e:$PlayJsError)")) ==> (REF("e") DOT "repath" APPLY (REF(PlayPath) DOT "\\" APPLY REF("field"))) DOT s"asInstanceOf[$PlayJsError]"),
@@ -153,7 +153,7 @@ object ObjectVisitor {
     val obj = if (childTypes.isEmpty || serializeOnly) {
       (OBJECTDEF(name)) := BLOCK(
         playFormat ++ defaultFields ++ defaultInstance ++ fields.flatMap { f =>
-          f.constraints.flatMap(_.withFieldLimit(f).limitField)
+          f.constraints.flatMap { constraint => FieldVisitor.limitField(constraint, f) }
         }
       )
     } else if (discriminator.isDefined) {

--- a/type-generator/src/main/scala/mesosphere/raml/ir/ConstraintT.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/ir/ConstraintT.scala
@@ -6,104 +6,57 @@ import definitions._
 import treehugger.forest
 import treehuggerDSL._
 
-import scala.annotation.tailrec
-
 sealed trait ConstraintT[C] { self =>
   val name: String
   val constraint: C
-  val constraintToValue: C => Tree = { (c: C) => LIT(c) } // decent assumption for built-ins, probably not much else
 
   /** false indicates custom, non-play constraint implementations that we've implemented as part of this generator */
   val builtIn: Boolean
-
-  /** a code gen expression for a field that represents the constraint limit */
-  val limitField: Option[Tree] = None
-
-  /** decorate this constraint with a `limitField` implementation */
-  def copyWith(lf: Option[Tree] = None): ConstraintT[C]
-
-  def withFieldLimit(f: FieldT): ConstraintT[C] = {
-    val fieldName = scalaFieldName(underscoreToCamel(camelify(s"constraint_${f.rawName}_${name}".replace("-", "_"))))
-    val limit = (VAL(fieldName) := constraintToValue(constraint))
-    copyWith(Option(limit))
-  }
 }
 
 object ConstraintT {
 
-  // built-in playJS validators
-
-  case class MaxLength(name: String = "maxLength", len: Integer, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[Integer] {
-    val constraint = len
+  case class MaxLength(constraint: Integer) extends ConstraintT[Integer] {
+    val name: String = "maxLength"
     val builtIn = true
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[Integer] = copy(limitField = lf)
   }
 
-  case class MinLength(len: Integer, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[Integer] {
+  case class MinLength(constraint: Integer) extends ConstraintT[Integer] {
     val name = "minLength"
-    val constraint = len
     val builtIn = true
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[Integer] = copy(limitField = lf)
   }
 
-  case class Pattern(p: String, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[String] {
+  case class Pattern(p: String) extends ConstraintT[String] {
     val name = "pattern"
     val constraint = p
     val builtIn = true
-    override val constraintToValue = { (c: String) => LIT(c) DOT "r" }
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[String] = copy(limitField = lf)
   }
 
-  case class MaxItems(len: Integer, t: Type, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[Integer] {
+  case class MaxItems(constraint: Integer, t: Type) extends ConstraintT[Integer] {
     val name = "maxLength"
-    val constraint = len
     val builtIn = true
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[Integer] = copy(limitField = lf)
   }
 
-  case class MinItems(len: Integer, t: Type, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[Integer] {
+  case class MinItems(constraint: Integer, t: Type) extends ConstraintT[Integer] {
     val name = "minLength"
-    val constraint = len
     val builtIn = true
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[Integer] = copy(limitField = lf)
   }
 
-  case class Max(v: Number, t: Type, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[Number] {
+  case class Max(constraint: Number, t: Type) extends ConstraintT[Number] {
     val name = "max"
-    val constraint = v
     val builtIn = true
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[Number] = copy(limitField = lf)
   }
 
-  case class Min(v: Number, t: Type, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[Number] {
+  case class Min(constraint: Number, t: Type) extends ConstraintT[Number] {
     val name = "min"
-    val constraint = v
     val builtIn = true
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[Number] = copy(limitField = lf)
   }
 
   // custom validator implementations follow
 
-  case class KeyPattern(p: String, mapValType: Type, override val limitField: Option[forest.Tree] = None) extends BasicConstraint[String] {
+  case class KeyPattern(constraint: String, mapValType: Type) extends ConstraintT[String] {
     val name = "keyPattern"
-    val constraint = p
     val builtIn = false
-    override val constraintToValue = { (c: String) => LIT(c) DOT "r" }
-
-    override def copyWith(lf: Option[Tree] = limitField): ConstraintT[String] = copy(limitField = lf)
-  }
-
-  trait BasicConstraint[C] extends ConstraintT[C] {
-    override val name: String
-    override val builtIn: Boolean
-    override val limitField: Option[Tree] = None
   }
 
   implicit class AllConstraints(val c: Seq[Seq[ConstraintT[_]]]) extends AnyVal {

--- a/type-generator/src/main/scala/mesosphere/raml/ir/FieldT.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/ir/FieldT.scala
@@ -74,26 +74,4 @@ case class FieldT(rawName: String, `type`: Type, comments: Seq[String], constrai
       }
     }
   }
-
-  val playValidator = {
-    def reads = constraints.validate(PlayPath DOT "read" APPLYTYPE `type`)
-    def validate =
-      REF("json") DOT "\\" APPLY(LIT(rawName)) DOT "validate" APPLYTYPE `type` APPLY(reads)
-    def validateOpt =
-      REF("json") DOT "\\" APPLY(LIT(rawName)) DOT "validateOpt" APPLYTYPE `type` APPLY(reads)
-    def validateOptWithDefault(defaultValue: Tree) =
-      REF("json") DOT "\\" APPLY(LIT(rawName)) DOT "validateOpt" APPLYTYPE `type` APPLY(reads) DOT "map" APPLY (REF("_") DOT "getOrElse" APPLY defaultValue)
-
-    if (required && !forceOptional) {
-      validate
-    } else if (repeated && !forceOptional) {
-      validateOptWithDefault(`type` APPLY())
-    } else {
-      if (defaultValue.isDefined && !forceOptional) {
-        validateOptWithDefault(defaultValue.get)
-      } else {
-        validateOpt
-      }
-    }
-  }
 }


### PR DESCRIPTION
Summary:
This moves the code generation for constraints into the treehugger backend.
The intermediate representation will just be simple case classes. This will enable
us to switch the code generation backend.