### PR TITLE
Do not try to kill instance that has no tasks

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -106,7 +106,7 @@ private[impl] class KillServiceActor(
       (inFlight.contains(id) || instancesToKill.contains(id)) =>
       handleTerminal(id)
 
-    case InstanceChanged(id, _, _, _, instance) if instance.state.goal.isTerminal() =>
+    case InstanceChanged(id, _, _, _, instance) if instance.state.goal.isTerminal() && instance.tasksMap.nonEmpty =>
       if (instancesToKill.contains(id)) {
         logger.info(s"Ignoring goal change to ${instance.state.goal} for ${instance.state.goal} since the instance is already queued.")
       } else {


### PR DESCRIPTION
We won't try to kill instance with no tasks.

It's actually not breaking anything right now but it leads to log lines that might not make sense plus a double expunge called on that instance.