### PR TITLE
Make scale check work with goals + UnreachableInactive

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -395,10 +395,10 @@ class SchedulerActions(
 
     val targetCount = runSpec.instances
 
-    val ScalingProposition(instancesToKill, instancesToStart) = ScalingProposition.propose(
+    val ScalingProposition(instancesToDecommission, instancesToStart) = ScalingProposition.propose(
       instances, Seq.empty, killToMeetConstraints, targetCount, runSpec.killSelection, runSpec.id)
 
-    if (instancesToKill.nonEmpty) {
+    if (instancesToDecommission.nonEmpty) {
       logger.info(s"Adjusting goals for instances ${instances.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
       val instancesAreTerminal = KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)
       val changeGoalsFuture = instances.map { i =>
@@ -416,7 +416,7 @@ class SchedulerActions(
       await(launchQueue.add(runSpec, toStart))
     }
 
-    if (instancesToKill.isEmpty && instancesToStart == 0) {
+    if (instancesToDecommission.isEmpty && instancesToStart == 0) {
       logger.info(s"Already running ${runSpec.instances} instances of ${runSpec.id}. Not scaling.")
     }
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -388,8 +388,7 @@ class SchedulerActions(
     logger.debug("Scale for run spec {}", runSpec)
 
     val instances = await(instanceTracker.specInstances(runSpec.id))
-    val runningInstances = instances.filter(_.isActive)
-    val scheduledInstances = instances.filter(_.isScheduled)
+    val goalRunningInstances = instances.filter(_.state.goal == Goal.Running)
 
     def killToMeetConstraints(notSentencedAndRunning: Seq[Instance], toKillCount: Int) = {
       Constraints.selectInstancesToKill(runSpec, notSentencedAndRunning, toKillCount)
@@ -398,10 +397,10 @@ class SchedulerActions(
     val targetCount = runSpec.instances
 
     val ScalingProposition(instancesToKill, instancesToStart) = ScalingProposition.propose(
-      runningInstances, None, killToMeetConstraints, targetCount, runSpec.killSelection)
+      instances, None, killToMeetConstraints, targetCount, runSpec.killSelection)
 
     instancesToKill.foreach { instances: Seq[Instance] =>
-      logger.info(s"Scaling ${runSpec.id} from ${runningInstances.size} down to $targetCount instances")
+      logger.info(s"Scaling ${runSpec.id} from ${instances.size} down to $targetCount instances")
 
       async {
         await(launchQueue.purge(runSpec.id))
@@ -419,19 +418,10 @@ class SchedulerActions(
       }
     }
 
-    if (instancesToStart.isDefined) {
-      val toStart = instancesToStart.get
-
-      logger.info(s"Need to scale ${runSpec.id} from ${runningInstances.size} up to $targetCount instances")
-      val leftToLaunch = scheduledInstances.size
-      val toAdd = toStart - leftToLaunch
-
-      if (toAdd > 0) {
-        logger.info(s"Queueing $toAdd new instances for ${runSpec.id} to the already $leftToLaunch queued ones")
-        await(launchQueue.add(runSpec, toAdd))
-      } else {
-        logger.info(s"Already queued ${scheduledInstances.size} and started ${runningInstances.size} instances for ${runSpec.id}. Not scaling.")
-      }
+    val toStart = instancesToStart.getOrElse(0)
+    if (toStart > 0) {
+      logger.info(s"Need to scale ${runSpec.id} from ${goalRunningInstances.size} up to $targetCount instances")
+      await(launchQueue.add(runSpec, toStart))
     }
 
     if (instancesToKill.isEmpty && instancesToStart.isEmpty) {

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -396,7 +396,7 @@ class SchedulerActions(
     val targetCount = runSpec.instances
 
     val ScalingProposition(instancesToKill, instancesToStart) = ScalingProposition.propose(
-      instances, None, killToMeetConstraints, targetCount, runSpec.killSelection, runSpec.id)
+      instances, Seq.empty, killToMeetConstraints, targetCount, runSpec.killSelection, runSpec.id)
 
     if (instancesToKill.nonEmpty) {
       logger.info(s"Adjusting goals for instances ${instances.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
@@ -411,12 +411,12 @@ class SchedulerActions(
       Done
     }
 
-    val toStart = instancesToStart.getOrElse(0)
+    val toStart = instancesToStart
     if (toStart > 0) {
       await(launchQueue.add(runSpec, toStart))
     }
 
-    if (instancesToKill.isEmpty && instancesToStart.isEmpty) {
+    if (instancesToKill.isEmpty && instancesToStart == 0) {
       logger.info(s"Already running ${runSpec.instances} instances of ${runSpec.id}. Not scaling.")
     }
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -403,8 +403,6 @@ class SchedulerActions(
       logger.info(s"Scaling ${runSpec.id} from ${instances.size} down to $targetCount instances")
 
       async {
-        await(launchQueue.purge(runSpec.id))
-
         logger.info(s"Adjusting goals for instances ${instances.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
         val instancesAreTerminal = KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)
         val changeGoalsFuture = instances.map { i =>

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -399,9 +399,9 @@ class SchedulerActions(
       instances, Seq.empty, killToMeetConstraints, targetCount, runSpec.killSelection, runSpec.id)
 
     if (instancesToDecommission.nonEmpty) {
-      logger.info(s"Adjusting goals for instances ${instances.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
+      logger.info(s"Adjusting goals for instances ${instancesToDecommission.map(_.instanceId)} (${GoalChangeReason.OverCapacity})")
       val instancesAreTerminal = KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)
-      val changeGoalsFuture = instances.map { i =>
+      val changeGoalsFuture = instancesToDecommission.map { i =>
         if (i.hasReservation) instanceTracker.setGoal(i.instanceId, Goal.Stopped, GoalChangeReason.OverCapacity)
         else instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)
       }

--- a/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/DeploymentPlan.scala
@@ -47,11 +47,10 @@ case class StartApplication(runSpec: RunSpec) extends DeploymentAction {
 }
 
 // runnable spec is started, but the instance count should be changed
-// TODO: Why is there an Option[Seq[]]?!
 case class ScaleApplication(
     runSpec: RunSpec,
     scaleTo: Int,
-    sentencedToDeath: Option[Seq[Instance]] = None) extends DeploymentAction
+    sentencedToDeath: Seq[Instance] = Seq.empty) extends DeploymentAction
 
 // runnable spec is started, but shall be completely stopped
 case class StopApplication(runSpec: RunSpec) extends DeploymentAction
@@ -177,8 +176,7 @@ case class DeploymentPlan(
       case StartApplication(spec) => s"Start(${specString(spec)}, instances=0)"
       case StopApplication(spec) => s"Stop(${specString(spec)})"
       case ScaleApplication(spec, scale, toKill) =>
-        val killTasksString =
-          toKill.withFilter(_.nonEmpty).map(", killTasks=" + _.map(_.instanceId.idString).mkString(",")).getOrElse("")
+        val killTasksString = if (toKill.isEmpty) "" else ", killTasks=" + toKill.map(_.instanceId.idString).mkString(",")
         s"Scale(${specString(spec)}, instances=$scale$killTasksString)"
       case RestartApplication(app) => s"Restart(${specString(app)})"
     }
@@ -254,7 +252,7 @@ object DeploymentPlan {
 
           // Scale-only change.
           case Some(oldSpec) if oldSpec.isOnlyScaleChange(newSpec) || newSpec.isScaledToZero =>
-            Some(ScaleApplication(newSpec, newSpec.instances, toKill.get(newSpec.id)))
+            Some(ScaleApplication(newSpec, newSpec.instances, toKill.getOrElse(newSpec.id, Seq.empty)))
 
           // Update or restart an existing run spec.
           case Some(oldSpec) if oldSpec.needsRestart(newSpec) =>

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -21,6 +21,7 @@ object ScalingProposition extends StrictLogging {
 
     val instancesGoalRunning: Map[Instance.Id, Instance] = instances
       .filter(_.state.goal == Goal.Running)
+      .filter(_.state.condition != UnreachableInactive)
       .map(instance => instance.instanceId -> instance)(collection.breakOut)
     val toDecommissionMap: Map[Instance.Id, Instance] = toDecommission.map(instance => instance.instanceId -> instance)(collection.breakOut)
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -51,7 +51,7 @@ object ScalingProposition extends StrictLogging {
     }
     if (instancesToDecommission.nonEmpty) {
       logger.info(s"Going to decommission instances '${instancesToDecommission.map(_.instanceId).mkString(",")}'." +
-        s" We have ${instancesGoalRunning.size} and we need $scaleTo instances.")
+        s" of runspec $runSpecId. We have ${instancesGoalRunning.size} and we need $scaleTo instances.")
     }
 
     ScalingProposition(instancesToDecommission, numberOfInstancesToStart)

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.core.condition.Condition.UnreachableInactive
 import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.state.{KillSelection, PathId, Timestamp}
 
-case class ScalingProposition(tasksToKill: Option[Seq[Instance]], tasksToStart: Option[Int])
+case class ScalingProposition(tasksToKill: Seq[Instance], tasksToStart: Option[Int])
 
 object ScalingProposition extends StrictLogging {
 
@@ -42,16 +42,15 @@ object ScalingProposition extends StrictLogging {
     val orderedDecommissionCandidates =
       Seq(sentencedAndRunningMap.values, killToMeetConstraints, rest.sortWith(sortByConditionAndDate(killSelection))).flatten
 
-    val candidatesToDecommission = orderedDecommissionCandidates.take(decommissionCount)
-    val numberOfInstancesToStart = scaleTo - instances.size + decommissionCount
+    val instancesToDecommission = orderedDecommissionCandidates.take(decommissionCount)
+    val numberOfInstancesToStart = scaleTo - instancesGoalRunning.size + decommissionCount
 
-    val instancesToDecommission = if (candidatesToDecommission.nonEmpty) Some(candidatesToDecommission) else None
-    val instancesToStart = if (numberOfInstancesToStart > 0) {
+    val newInstancesToStart = if (numberOfInstancesToStart > 0) {
       logger.info(s"Need to scale $runSpecId from ${instancesGoalRunning.size} up to $scaleTo instances")
       Some(numberOfInstancesToStart)
     } else None
 
-    ScalingProposition(instancesToDecommission, instancesToStart)
+    ScalingProposition(instancesToDecommission, newInstancesToStart)
   }
 
   // TODO: this should evaluate a task's health as well

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -51,7 +51,7 @@ object ScalingProposition extends StrictLogging {
     }
     if (instancesToDecommission.nonEmpty) {
       logger.info(s"Going to decommission instances '${instancesToDecommission.map(_.instanceId).mkString(",")}'." +
-        s" We have $instancesGoalRunning and we need $scaleTo instances.")
+        s" We have ${instancesGoalRunning.size} and we need $scaleTo instances.")
     }
 
     ScalingProposition(instancesToDecommission, numberOfInstancesToStart)

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -2,7 +2,8 @@ package mesosphere.marathon
 package core.deployment
 
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.condition.Condition.UnreachableInactive
+import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.state.{KillSelection, Timestamp}
 
 case class ScalingProposition(tasksToKill: Option[Seq[Instance]], tasksToStart: Option[Int])
@@ -10,42 +11,42 @@ case class ScalingProposition(tasksToKill: Option[Seq[Instance]], tasksToStart: 
 object ScalingProposition {
 
   def propose(
-    runningTasks: Seq[Instance],
-    toKill: Option[Seq[Instance]],
+    instances: Seq[Instance],
+    toDecommission: Option[Seq[Instance]],
     meetConstraints: ((Seq[Instance], Int) => Seq[Instance]),
     scaleTo: Int,
     killSelection: KillSelection): ScalingProposition = {
 
-    val killingTaskCount = runningTasks.count(_.state.condition == Condition.Killing)
+    val instancesGoalRunning: Map[Instance.Id, Instance] = instances
+      .filter(_.state.goal == Goal.Running)
+      .map(instance => instance.instanceId -> instance)(collection.breakOut)
+    val toDecommissionMap: Map[Instance.Id, Instance] = toDecommission.getOrElse(Seq.empty).map(instance => instance.instanceId -> instance)(collection.breakOut)
 
-    val runningTaskMap = Instance.instancesById(runningTasks)
-    val toKillMap = Instance.instancesById(toKill.getOrElse(Seq.empty))
-
-    val (sentencedAndRunningMap, notSentencedAndRunningMap) = runningTaskMap partition {
-      case (k, v) =>
-        toKillMap.contains(k)
+    val (sentencedAndRunningMap, notSentencedAndRunningMap) = instancesGoalRunning partition {
+      case (instanceId, instance) =>
+        toDecommissionMap.contains(instanceId) || instance.state.condition == UnreachableInactive
     }
     // overall number of tasks that need to be killed
-    val killCount = math.max(runningTasks.size - killingTaskCount - scaleTo, sentencedAndRunningMap.size)
+    val decommissionCount = math.max(instances.size - scaleTo, sentencedAndRunningMap.size)
     // tasks that should be killed to meet constraints – pass notSentenced & consider the sentenced 'already killed'
     val killToMeetConstraints = meetConstraints(
       notSentencedAndRunningMap.values.to[Seq],
-      killCount - sentencedAndRunningMap.size
+      decommissionCount - sentencedAndRunningMap.size
     )
 
     // rest are tasks that are not sentenced and need not be killed to meet constraints
     val rest: Seq[Instance] = (notSentencedAndRunningMap -- killToMeetConstraints.map(_.instanceId)).values.to[Seq]
 
-    val ordered =
+    val orderedDecommissionCandidates =
       Seq(sentencedAndRunningMap.values, killToMeetConstraints, rest.sortWith(sortByConditionAndDate(killSelection))).flatten
 
-    val candidatesToKill = ordered.take(killCount)
-    val numberOfTasksToStart = scaleTo - runningTasks.size + killCount
+    val candidatesToDecommission = orderedDecommissionCandidates.take(decommissionCount)
+    val numberOfInstancesToStart = scaleTo - instances.size + decommissionCount
 
-    val tasksToKill = if (candidatesToKill.nonEmpty) Some(candidatesToKill) else None
-    val tasksToStart = if (numberOfTasksToStart > 0) Some(numberOfTasksToStart) else None
+    val instancesToDecommission = if (candidatesToDecommission.nonEmpty) Some(candidatesToDecommission) else None
+    val instancesToStart = if (numberOfInstancesToStart > 0) Some(numberOfInstancesToStart) else None
 
-    ScalingProposition(tasksToKill, tasksToStart)
+    ScalingProposition(instancesToDecommission, instancesToStart)
   }
 
   // TODO: this should evaluate a task's health as well

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -26,8 +26,8 @@ object ScalingProposition extends StrictLogging {
     val toDecommissionMap: Map[Instance.Id, Instance] = toDecommission.map(instance => instance.instanceId -> instance)(collection.breakOut)
 
     val (sentencedAndRunningMap, notSentencedAndRunningMap) = instancesGoalRunning partition {
-      case (instanceId, instance) =>
-        toDecommissionMap.contains(instanceId) || instance.state.condition == UnreachableInactive
+      case (instanceId, _) =>
+        toDecommissionMap.contains(instanceId)
     }
     // overall number of tasks that need to be killed
     val decommissionCount = math.max(instancesGoalRunning.size - scaleTo, sentencedAndRunningMap.size)

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -49,6 +49,9 @@ object ScalingProposition extends StrictLogging {
     if (numberOfInstancesToStart > 0) {
       logger.info(s"Need to scale $runSpecId from ${instancesGoalRunning.size} up to $scaleTo instances")
     }
+    if (instancesToDecommission.nonEmpty) {
+      logger.info(s"Going to decommission instances '${instances.map(_.instanceId).mkString(",")}'. We have $instancesGoalRunning and we need $scaleTo instances.")
+    }
 
     ScalingProposition(instancesToDecommission, numberOfInstancesToStart)
   }

--- a/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/ScalingProposition.scala
@@ -50,7 +50,8 @@ object ScalingProposition extends StrictLogging {
       logger.info(s"Need to scale $runSpecId from ${instancesGoalRunning.size} up to $scaleTo instances")
     }
     if (instancesToDecommission.nonEmpty) {
-      logger.info(s"Going to decommission instances '${instances.map(_.instanceId).mkString(",")}'. We have $instancesGoalRunning and we need $scaleTo instances.")
+      logger.info(s"Going to decommission instances '${instancesToDecommission.map(_.instanceId).mkString(",")}'." +
+        s" We have $instancesGoalRunning and we need $scaleTo instances.")
     }
 
     ScalingProposition(instancesToDecommission, numberOfInstancesToStart)

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -164,9 +164,8 @@ private class DeploymentActor(
 
     async {
       val instances = await(instanceTracker.specInstances(runnableSpec.id))
-      val runningInstances = instances.filter(_.state.condition.isActive)
       val ScalingProposition(instancesToKill, tasksToStart) = ScalingProposition.propose(
-        runningInstances, toKill, killToMeetConstraints, scaleTo, runnableSpec.killSelection)
+        instances, toKill, killToMeetConstraints, scaleTo, runnableSpec.killSelection)
 
       logger.debug("Kill tasks if needed")
       await(instancesToKill.fold(Future.successful(Done))(ik => killInstancesIfNeeded(ik).map(_ => Done)))

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -165,7 +165,7 @@ private class DeploymentActor(
     async {
       val instances = await(instanceTracker.specInstances(runnableSpec.id))
       val ScalingProposition(instancesToKill, tasksToStart) = ScalingProposition.propose(
-        instances, toKill, killToMeetConstraints, scaleTo, runnableSpec.killSelection)
+        instances, toKill, killToMeetConstraints, scaleTo, runnableSpec.killSelection, runnableSpec.id)
 
       logger.debug("Kill tasks if needed")
       await(instancesToKill.fold(Future.successful(Done))(ik => killInstancesIfNeeded(ik).map(_ => Done)))

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -187,7 +187,7 @@ private class DeploymentActor(
 
     val instances = await(instanceTracker.specInstances(runSpec.id))
 
-    logger.info(s"Killing all instances of ${runSpec.id}: ${instances.map(_.instanceId)}")
+    logger.info(s"Decommissioning all instances of ${runSpec.id}: ${instances.map(_.instanceId)}")
     val instancesAreTerminal = KillStreamWatcher.watchForDecommissionedInstances(
       instanceTracker.instanceUpdates, instances)
     await(Future.sequence(instances.map(i => instanceTracker.setGoal(i.instanceId, Goal.Decommissioned, GoalChangeReason.DeletingApp))))

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -168,7 +168,7 @@ private class DeploymentActor(
         instances, toKill, killToMeetConstraints, scaleTo, runnableSpec.killSelection, runnableSpec.id)
 
       logger.debug("Kill tasks if needed")
-      await(instancesToKill.fold(Future.successful(Done))(ik => killInstancesIfNeeded(ik).map(_ => Done)))
+      await(killInstancesIfNeeded(instancesToKill))
 
       def startInstancesIfNeeded: Future[Done] = {
         tasksToStart.fold(Future.successful(Done)) { tasksToStart =>

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -175,9 +175,6 @@ class SchedulerActionsTest extends AkkaUnitTest {
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
 
-      Then("the queue is purged")
-      verify(f.queue, times(1)).purge(app.id)
-
       And("the youngest STAGED tasks are killed")
       verify(f.instanceTracker, withinTimeout()).setGoal(staged_2.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)
       verify(f.instanceTracker, withinTimeout()).setGoal(staged_3.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)
@@ -213,9 +210,6 @@ class SchedulerActionsTest extends AkkaUnitTest {
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
 
-      Then("the queue is purged")
-      verify(f.queue, times(1)).purge(app.id)
-
       And("the youngest RUNNING tasks are killed")
       verify(f.instanceTracker, withinTimeout()).setGoal(running_7.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)
       verify(f.instanceTracker, withinTimeout()).setGoal(running_6.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)
@@ -249,14 +243,10 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance(stagedAt = 2L)
       )
 
-      f.queue.purge(app.id) returns Future.successful(Done)
       f.instanceTracker.specInstances(app.id) returns Future.successful(tasks)
 
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
-
-      Then("the queue is purged")
-      verify(f.queue, times(1)).purge(app.id)
 
       And("all STAGED tasks plus the youngest RUNNING tasks are killed")
       verify(f.instanceTracker, withinTimeout()).setGoal(staged_1.instanceId, Goal.Decommissioned, GoalChangeReason.OverCapacity)

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -391,7 +391,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
       Then("DeploymentSteps should include ScaleApplication w/ tasksToKill")
       plan.steps should not be empty
-      plan.steps.head.actions.head shouldEqual ScaleApplication(newAppA, 5, Some(Seq(instanceToKill)))
+      plan.steps.head.actions.head shouldEqual ScaleApplication(newAppA, 5, Seq(instanceToKill))
     }
 
     "Deployment plan allows valid updates for resident tasks" in {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
@@ -16,8 +16,8 @@ class ScalingPropositionTest extends UnitTest {
       val f = new Fixture
 
       val proposition = ScalingProposition.propose(
-        runningTasks = f.noTasks,
-        toKill = Some(f.noTasks),
+        instances = f.noTasks,
+        toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection
@@ -33,8 +33,8 @@ class ScalingPropositionTest extends UnitTest {
 
       val instance = TestInstanceBuilder.newBuilder(f.appId).addTaskStaged().getInstance()
       val proposition = ScalingProposition.propose(
-        runningTasks = Seq(instance),
-        toKill = Some(Seq(instance)),
+        instances = Seq(instance),
+        toDecommission = Some(Seq(instance)),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection
@@ -49,8 +49,8 @@ class ScalingPropositionTest extends UnitTest {
       val f = new Fixture
 
       val proposition = ScalingProposition.propose(
-        runningTasks = f.noTasks,
-        toKill = Some(f.noTasks),
+        instances = f.noTasks,
+        toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection
@@ -65,8 +65,8 @@ class ScalingPropositionTest extends UnitTest {
       val f = new Fixture
 
       val proposition = ScalingProposition.propose(
-        runningTasks = f.noTasks,
-        toKill = Some(f.noTasks),
+        instances = f.noTasks,
+        toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = -42,
         killSelection = KillSelection.DefaultKillSelection
@@ -81,8 +81,8 @@ class ScalingPropositionTest extends UnitTest {
       val f = new Fixture
 
       val proposition = ScalingProposition.propose(
-        runningTasks = f.noTasks,
-        toKill = Some(f.noTasks),
+        instances = f.noTasks,
+        toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 42,
         killSelection = KillSelection.DefaultKillSelection
@@ -97,8 +97,8 @@ class ScalingPropositionTest extends UnitTest {
       val f = new Fixture
 
       val proposition = ScalingProposition.propose(
-        runningTasks = Seq(f.createInstance(1), f.createInstance(2), f.createInstance(3)),
-        toKill = Some(f.noTasks),
+        instances = Seq(f.createInstance(1), f.createInstance(2), f.createInstance(3)),
+        toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 5,
         killSelection = KillSelection.DefaultKillSelection
@@ -116,8 +116,8 @@ class ScalingPropositionTest extends UnitTest {
 
       val runningTasks: Seq[Instance] = Seq(f.createInstance(1), f.createInstance(2), f.createInstance(3))
       val proposition = ScalingProposition.propose(
-        runningTasks = runningTasks,
-        toKill = Some(f.noTasks),
+        instances = runningTasks,
+        toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection
@@ -141,8 +141,8 @@ class ScalingPropositionTest extends UnitTest {
       val alreadyKilled: Instance = f.createInstance(42)
 
       val proposition = ScalingProposition.propose(
-        runningTasks = Seq(task_1, task_2, task_3),
-        toKill = Some(Seq(task_2, task_3, alreadyKilled)),
+        instances = Seq(task_1, task_2, task_3),
+        toDecommission = Some(Seq(task_2, task_3, alreadyKilled)),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 3,
         killSelection = KillSelection.DefaultKillSelection
@@ -167,8 +167,8 @@ class ScalingPropositionTest extends UnitTest {
       val alreadyKilled = f.createInstance(42)
 
       val proposition = ScalingProposition.propose(
-        runningTasks = Seq(instance_1, instance_2, instance_3, instance_4),
-        toKill = Some(Seq(alreadyKilled)),
+        instances = Seq(instance_1, instance_2, instance_3, instance_4),
+        toDecommission = Some(Seq(alreadyKilled)),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 3,
         killSelection = KillSelection.DefaultKillSelection
@@ -192,8 +192,8 @@ class ScalingPropositionTest extends UnitTest {
       val instance_4 = f.createInstance(4)
 
       val proposition = ScalingProposition.propose(
-        runningTasks = Seq(instance_1, instance_2, instance_3, instance_4),
-        toKill = Some(Seq(instance_2)),
+        instances = Seq(instance_1, instance_2, instance_3, instance_4),
+        toDecommission = Some(Seq(instance_2)),
         meetConstraints = f.killToMeetConstraints(instance_3),
         scaleTo = 1,
         killSelection = KillSelection.DefaultKillSelection

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
@@ -20,7 +20,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "lead to ScalingProposition(None, _)" in {
@@ -37,7 +38,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(Seq(instance)),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "lead to ScalingProposition(Some(_), _)" in {
@@ -53,7 +55,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "lead to ScalingProposition(_, None)" in {
@@ -69,7 +72,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = -42,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "lead to ScalingProposition(_, None)" in {
@@ -85,7 +89,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 42,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "lead to ScaleProposition(_ Some(_)" in {
@@ -101,7 +106,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 5,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
       "determine tasks to kill" in {
         proposition.tasksToKill shouldBe empty
@@ -120,7 +126,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(f.noTasks),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "determine tasks to kill" in {
@@ -145,7 +152,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(Seq(task_2, task_3, alreadyKilled)),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 3,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "determine tasks to kill" in {
@@ -171,7 +179,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(Seq(alreadyKilled)),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 3,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "determine tasks to kill" in {
@@ -196,7 +205,8 @@ class ScalingPropositionTest extends UnitTest {
         toDecommission = Some(Seq(instance_2)),
         meetConstraints = f.killToMeetConstraints(instance_3),
         scaleTo = 1,
-        killSelection = KillSelection.DefaultKillSelection
+        killSelection = KillSelection.DefaultKillSelection,
+        f.appId
       )
 
       "determine tasks to kill" in {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
@@ -131,8 +131,8 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill shouldBe defined
-        proposition.tasksToKill.get shouldEqual runningTasks.reverse
+        proposition.tasksToKill.nonEmpty shouldBe true
+        proposition.tasksToKill shouldEqual runningTasks.reverse
       }
       "determine no tasks to start" in {
         proposition.tasksToStart shouldBe empty
@@ -157,8 +157,8 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill shouldBe defined
-        proposition.tasksToKill.get shouldEqual Seq(task_2, task_3)
+        proposition.tasksToKill.nonEmpty shouldBe true
+        proposition.tasksToKill shouldEqual Seq(task_2, task_3)
       }
       "determine tasks to start" in {
         proposition.tasksToStart shouldBe Some(2)
@@ -184,8 +184,8 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill shouldBe defined
-        proposition.tasksToKill.get shouldEqual Seq(instance_4)
+        proposition.tasksToKill.nonEmpty shouldBe true
+        proposition.tasksToKill shouldEqual Seq(instance_4)
       }
       "determine no tasks to start" in {
         proposition.tasksToStart shouldBe empty
@@ -210,8 +210,8 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill shouldBe defined
-        proposition.tasksToKill.get shouldEqual Seq(instance_2, instance_3, instance_4)
+        proposition.tasksToKill.nonEmpty shouldBe true
+        proposition.tasksToKill shouldEqual Seq(instance_2, instance_3, instance_4)
       }
       "determine no tasks to start" in {
         proposition.tasksToStart shouldBe empty

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/ScalingPropositionTest.scala
@@ -17,7 +17,7 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = f.noTasks,
-        toDecommission = Some(f.noTasks),
+        toDecommission = f.noTasks,
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection,
@@ -25,7 +25,7 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "lead to ScalingProposition(None, _)" in {
-        proposition.tasksToKill shouldBe empty
+        proposition.toDecommission shouldBe empty
       }
     }
 
@@ -35,15 +35,15 @@ class ScalingPropositionTest extends UnitTest {
       val instance = TestInstanceBuilder.newBuilder(f.appId).addTaskStaged().getInstance()
       val proposition = ScalingProposition.propose(
         instances = Seq(instance),
-        toDecommission = Some(Seq(instance)),
+        toDecommission = Seq(instance),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection,
         f.appId
       )
 
-      "lead to ScalingProposition(Some(_), _)" in {
-        proposition.tasksToKill shouldBe Some(Seq(instance))
+      "lead to ScalingProposition list of instances to decommission" in {
+        proposition.toDecommission shouldBe Seq(instance)
       }
     }
 
@@ -52,7 +52,7 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = f.noTasks,
-        toDecommission = Some(f.noTasks),
+        toDecommission = f.noTasks,
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection,
@@ -60,7 +60,7 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "lead to ScalingProposition(_, None)" in {
-        proposition.tasksToStart shouldBe empty
+        proposition.toStart shouldBe 0
       }
     }
 
@@ -69,7 +69,7 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = f.noTasks,
-        toDecommission = Some(f.noTasks),
+        toDecommission = f.noTasks,
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = -42,
         killSelection = KillSelection.DefaultKillSelection,
@@ -77,7 +77,7 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "lead to ScalingProposition(_, None)" in {
-        proposition.tasksToStart shouldBe empty
+        proposition.toStart shouldBe 0
       }
     }
 
@@ -86,15 +86,15 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = f.noTasks,
-        toDecommission = Some(f.noTasks),
+        toDecommission = f.noTasks,
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 42,
         killSelection = KillSelection.DefaultKillSelection,
         f.appId
       )
 
-      "lead to ScaleProposition(_ Some(_)" in {
-        proposition.tasksToStart shouldBe Some(42)
+      "lead to ScalePropositionof 42" in {
+        proposition.toStart shouldBe 42
       }
     }
 
@@ -103,17 +103,17 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = Seq(f.createInstance(1), f.createInstance(2), f.createInstance(3)),
-        toDecommission = Some(f.noTasks),
+        toDecommission = f.noTasks,
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 5,
         killSelection = KillSelection.DefaultKillSelection,
         f.appId
       )
       "determine tasks to kill" in {
-        proposition.tasksToKill shouldBe empty
+        proposition.toDecommission shouldBe empty
       }
       "determine tasks to start" in {
-        proposition.tasksToStart shouldBe Some(2)
+        proposition.toStart shouldBe 2
       }
     }
 
@@ -123,7 +123,7 @@ class ScalingPropositionTest extends UnitTest {
       val runningTasks: Seq[Instance] = Seq(f.createInstance(1), f.createInstance(2), f.createInstance(3))
       val proposition = ScalingProposition.propose(
         instances = runningTasks,
-        toDecommission = Some(f.noTasks),
+        toDecommission = f.noTasks,
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 0,
         killSelection = KillSelection.DefaultKillSelection,
@@ -131,11 +131,11 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill.nonEmpty shouldBe true
-        proposition.tasksToKill shouldEqual runningTasks.reverse
+        proposition.toDecommission.nonEmpty shouldBe true
+        proposition.toDecommission shouldEqual runningTasks.reverse
       }
       "determine no tasks to start" in {
-        proposition.tasksToStart shouldBe empty
+        proposition.toStart shouldBe 0
       }
     }
 
@@ -149,7 +149,7 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = Seq(task_1, task_2, task_3),
-        toDecommission = Some(Seq(task_2, task_3, alreadyKilled)),
+        toDecommission = Seq(task_2, task_3, alreadyKilled),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 3,
         killSelection = KillSelection.DefaultKillSelection,
@@ -157,11 +157,11 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill.nonEmpty shouldBe true
-        proposition.tasksToKill shouldEqual Seq(task_2, task_3)
+        proposition.toDecommission.nonEmpty shouldBe true
+        proposition.toDecommission shouldEqual Seq(task_2, task_3)
       }
       "determine tasks to start" in {
-        proposition.tasksToStart shouldBe Some(2)
+        proposition.toStart shouldBe 2
       }
     }
 
@@ -176,7 +176,7 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = Seq(instance_1, instance_2, instance_3, instance_4),
-        toDecommission = Some(Seq(alreadyKilled)),
+        toDecommission = Seq(alreadyKilled),
         meetConstraints = f.noConstraintsToMeet,
         scaleTo = 3,
         killSelection = KillSelection.DefaultKillSelection,
@@ -184,11 +184,11 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill.nonEmpty shouldBe true
-        proposition.tasksToKill shouldEqual Seq(instance_4)
+        proposition.toDecommission.nonEmpty shouldBe true
+        proposition.toDecommission shouldEqual Seq(instance_4)
       }
       "determine no tasks to start" in {
-        proposition.tasksToStart shouldBe empty
+        proposition.toStart shouldBe 0
       }
     }
 
@@ -202,7 +202,7 @@ class ScalingPropositionTest extends UnitTest {
 
       val proposition = ScalingProposition.propose(
         instances = Seq(instance_1, instance_2, instance_3, instance_4),
-        toDecommission = Some(Seq(instance_2)),
+        toDecommission = Seq(instance_2),
         meetConstraints = f.killToMeetConstraints(instance_3),
         scaleTo = 1,
         killSelection = KillSelection.DefaultKillSelection,
@@ -210,11 +210,11 @@ class ScalingPropositionTest extends UnitTest {
       )
 
       "determine tasks to kill" in {
-        proposition.tasksToKill.nonEmpty shouldBe true
-        proposition.tasksToKill shouldEqual Seq(instance_2, instance_3, instance_4)
+        proposition.toDecommission.nonEmpty shouldBe true
+        proposition.toDecommission shouldEqual Seq(instance_2, instance_3, instance_4)
       }
       "determine no tasks to start" in {
-        proposition.tasksToStart shouldBe empty
+        proposition.toStart shouldBe 0
       }
     }
   }


### PR DESCRIPTION
Summary:
Scale check was still heavily working with conditions. Right now when we have `Goal = Running`, there is no need to scale up, because the scheduler will take care of restarting the instance.

JIRA issues: MARATHON-8554
