### PR TITLE
Speed up `v2/pods/::status`

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/appinfo/PodStatusService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/PodStatusService.scala
@@ -12,4 +12,9 @@ trait PodStatusService {
     * @return the status of the pod at the given path, if such a pod exists
     */
   def selectPodStatus(id: PathId, selector: PodSelector = Selector.all): Future[Option[PodStatus]]
+
+  /**
+    * @return the statuses of the pods at the given paths, if the pod exists
+    */
+  def selectPodStatuses(ids: Set[PathId], selector: PodSelector = Selector.all): Future[Seq[PodStatus]]
 }

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
@@ -30,6 +30,13 @@ private[appinfo] class DefaultInfoService(
       }
     }
 
+  override def selectPodStatuses(ids: Set[PathId], selector: PodSelector): Future[Seq[PodStatus]] = {
+    val baseData = newBaseData()
+
+    val pods = ids.toVector.flatMap(groupManager.pod(_)).filter(selector.matches)
+    resolvePodInfos(pods, baseData)
+  }
+
   override def selectApp(id: PathId, selector: AppSelector, embed: Set[AppInfo.Embed]): Future[Option[AppInfo]] = {
     logger.debug(s"queryForAppId $id")
     groupManager.app(id) match {

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -602,7 +602,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       val f = Fixture()
 
       podSystem.ids().returns(Set(PathId("mypod")))
-      podStatusService.selectPodStatus(any, any).returns(Future(Some(PodStatus("mypod", Pod("mypod", containers = Seq.empty), PodState.Stable, statusSince = OffsetDateTime.now(), lastUpdated = OffsetDateTime.now(), lastChanged = OffsetDateTime.now()))))
+      podStatusService.selectPodStatuses(any, any).returns(Future(Seq(PodStatus("mypod", Pod("mypod", containers = Seq.empty), PodState.Stable, statusSince = OffsetDateTime.now(), lastUpdated = OffsetDateTime.now(), lastChanged = OffsetDateTime.now()))))
 
       val response = f.podsResource.allStatus(f.auth.request)
 


### PR DESCRIPTION
Summary:
This replace the Akka stream with a simple `Future.sequence` and uses
the same `AppInfoBaseData` instance for each pod. This we utilize the
cached instances and not limit ourselves to eight parallel threads. To
not overload Marathon we use the fixed size thread pool from #5973.

However, even with #5973 we might allocate a lot of futures and
runnables.

For 100 pods with 1 instance each I got the following:

## Master
```
› wrk -c 10 -t 10 -d 2m http://localhost:8080/v2/pods/::status
Running 2m test @ http://localhost:8080/v2/pods/::status
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   136.52ms   44.93ms 859.05ms   93.64%
    Req/Sec     7.71      2.49    20.00     69.81%
  8918 requests in 2.00m, 1.34GB read
Requests/sec:     74.26
Transfer/sec:     11.45MB
```

## This change
```
Running 2m test @ http://localhost:8080/v2/pods/::status
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    62.27ms   23.24ms 220.39ms   70.17%
    Req/Sec    15.94      6.09    50.00     69.12%
  19345 requests in 2.00m, 2.91GB read
Requests/sec:    161.10
Transfer/sec:     24.85MB 
```

JIRA issues: MARATHON-8563