### PR TITLE
Response asynchronously for all endpoints.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon
 package api
 
 import javax.servlet.http.HttpServletRequest
-import javax.ws.rs.core.Response
 import mesosphere.marathon.core.async.ExecutionContexts
 
 import mesosphere.marathon.plugin.auth._

--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -76,6 +76,18 @@ trait AuthResource extends RestResource {
       }
     }
 
+  def withAuthorizationF[A, B >: A](
+    action: AuthorizedAction[B],
+    maybeResource: Option[A],
+    ifNotExists: Response)(fn: A => Future[Response])(implicit identity: Identity): Future[Response] = {
+    maybeResource match {
+      case Some(resource) =>
+        checkAuthorization(action, resource)
+        fn(resource)
+      case None => Future.successful(ifNotExists)
+    }
+  }
+
   def withAuthorization[A, B >: A](
     action: AuthorizedAction[B],
     resource: A)(fn: => Response)(implicit identity: Identity): Response = {

--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -36,20 +36,6 @@ trait AuthResource extends RestResource {
   }
 
   /**
-    * Authenticate an HTTP request, synchronously.
-    *
-    * @param request The incoming HTTP request
-    * @param fn The work to perform with the identity. Not called if authentication fails.
-    *
-    * @return On success, a Jersey Response. On failure, throws a RejectionException.
-    */
-  def authenticated(request: HttpServletRequest)(fn: Identity => Response): Response = {
-    // TODO - just return the identity instead of using a callback
-    val identity = result(authenticatedAsync(request))
-    fn(identity)
-  }
-
-  /**
     * Using the configured authenticator plugin, synchronously assert that the action is authorized for the provided
     * identity.
     *

--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -63,10 +63,10 @@ trait AuthResource extends RestResource {
     *
     *
     */
-  def withAuthorization[A, B >: A](
+  def withAuthorization[A, B >: A, R](
     action: AuthorizedAction[B],
     maybeResource: Option[A],
-    ifNotExists: Response)(fn: A => Response)(implicit identity: Identity): Response =
+    ifNotExists: R)(fn: A => R)(implicit identity: Identity): R =
     {
       maybeResource match {
         case Some(resource) =>
@@ -76,21 +76,9 @@ trait AuthResource extends RestResource {
       }
     }
 
-  def withAuthorizationF[A, B >: A](
+  def withAuthorization[A, B >: A, R](
     action: AuthorizedAction[B],
-    maybeResource: Option[A],
-    ifNotExists: Response)(fn: A => Future[Response])(implicit identity: Identity): Future[Response] = {
-    maybeResource match {
-      case Some(resource) =>
-        checkAuthorization(action, resource)
-        fn(resource)
-      case None => Future.successful(ifNotExists)
-    }
-  }
-
-  def withAuthorization[A, B >: A](
-    action: AuthorizedAction[B],
-    resource: A)(fn: => Response)(implicit identity: Identity): Response = {
+    resource: A)(fn: => R)(implicit identity: Identity): R = {
     checkAuthorization(action, resource)
     fn
   }

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -16,7 +16,7 @@ import play.api.libs.json.JsonValidationError
 import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json._
 
-import scala.concurrent.{Await, Awaitable, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 trait RestResource extends JaxResource {

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -101,6 +101,16 @@ trait RestResource extends JaxResource {
       case ValidationSuccess => fn(t)
     }
   }
+
+  protected def withValidF[T](t: T)(fn: T => Future[Response])(implicit validator: Validator[T]): Future[Response] = {
+    // TODO - replace with Validation.validateOrThrow
+    validator(t) match {
+      case f: ValidationFailure =>
+        val entity = Json.toJson(f).toString
+        Future.successful(Response.status(StatusCodes.UnprocessableEntity.intValue).entity(entity).build())
+      case ValidationSuccess => fn(t)
+    }
+  }
 }
 
 object RestResource {

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -82,8 +82,6 @@ trait RestResource extends JaxResource {
   protected def jsonObjString(fields: (String, JsValueWrapper)*): String = Json.stringify(Json.obj(fields: _*))
   protected def jsonArrString(fields: JsValueWrapper*): String = Json.stringify(Json.arr(fields: _*))
 
-  protected def result[T](fn: Awaitable[T]): T = Await.result(fn, config.zkTimeoutDuration)
-
   /**
     * Checks if the implicit validator yields a valid result.
     * See [[validateOrThrow]], which is preferred to this.

--- a/src/main/scala/mesosphere/marathon/api/SystemResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/SystemResource.scala
@@ -21,7 +21,9 @@ import play.api.libs.json.Json
 import scala.concurrent.ExecutionContext
 import stream.Implicits._
 import com.wix.accord.dsl._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 
+import scala.async.Async.{await, async}
 import scala.concurrent.duration._
 
 /**
@@ -89,9 +91,12 @@ class SystemResource @Inject() (val config: MarathonConf, val metricsModule: Met
   @Path("metrics")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def metrics(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(ViewResource, SystemConfig) {
-      ok(jsonString(Raml.toRaml(metricsModule.snapshot())), MediaType.APPLICATION_JSON_TYPE)
+  def metrics(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      withAuthorization(ViewResource, SystemConfig) {
+        ok(jsonString(Raml.toRaml(metricsModule.snapshot())), MediaType.APPLICATION_JSON_TYPE)
+      }
     }
   }
 
@@ -99,9 +104,12 @@ class SystemResource @Inject() (val config: MarathonConf, val metricsModule: Met
   @Path("config")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def config(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(ViewResource, SystemConfig) {
-      ok(cfg.root().render(ConfigRenderOptions.defaults().setJson(true)))
+  def config(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      withAuthorization(ViewResource, SystemConfig) {
+        ok(cfg.root().render(ConfigRenderOptions.defaults().setJson(true)))
+      }
     }
   }
 
@@ -109,13 +117,16 @@ class SystemResource @Inject() (val config: MarathonConf, val metricsModule: Met
   @Path("logging")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def showLoggers(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(ViewResource, SystemConfig) {
-      LoggerFactory.getILoggerFactory match {
-        case lc: LoggerContext =>
-          ok(lc.getLoggerList.map { logger =>
-            logger.getName -> Option(logger.getLevel).map(_.levelStr).getOrElse(logger.getEffectiveLevel.levelStr + " (inherited)")
-          }.toMap)
+  def showLoggers(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      withAuthorization(ViewResource, SystemConfig) {
+        LoggerFactory.getILoggerFactory match {
+          case lc: LoggerContext =>
+            ok(lc.getLoggerList.map { logger =>
+              logger.getName -> Option(logger.getLevel).map(_.levelStr).getOrElse(logger.getEffectiveLevel.levelStr + " (inherited)")
+            }.toMap)
+        }
       }
     }
   }
@@ -124,28 +135,31 @@ class SystemResource @Inject() (val config: MarathonConf, val metricsModule: Met
   @Path("logging")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def changeLogger(body: Array[Byte], @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(UpdateResource, SystemConfig) {
-      withValid(Json.parse(body).as[LoggerChange]) { change =>
-        LoggerFactory.getILoggerFactory.getLogger(change.logger) match {
-          case logger: Logger =>
-            val level = Level.valueOf(change.level.value.toUpperCase)
+  def changeLogger(body: Array[Byte], @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      withAuthorization(UpdateResource, SystemConfig) {
+        withValid(Json.parse(body).as[LoggerChange]) { change =>
+          LoggerFactory.getILoggerFactory.getLogger(change.logger) match {
+            case logger: Logger =>
+              val level = Level.valueOf(change.level.value.toUpperCase)
 
-            // current level can be null, which means: use the parent level
-            // the current level should be preserved, no matter what the effective level is
-            val currentLevel = logger.getLevel
-            val currentEffectiveLevel = logger.getEffectiveLevel
-            logger.info(s"Set logger ${logger.getName} to $level current: $currentEffectiveLevel")
-            logger.setLevel(level)
+              // current level can be null, which means: use the parent level
+              // the current level should be preserved, no matter what the effective level is
+              val currentLevel = logger.getLevel
+              val currentEffectiveLevel = logger.getEffectiveLevel
+              logger.info(s"Set logger ${logger.getName} to $level current: $currentEffectiveLevel")
+              logger.setLevel(level)
 
-            // if a duration is given, we schedule a timer to reset to the current level
-            change.durationSeconds.foreach(duration => actorSystem.scheduler.scheduleOnce(duration.seconds, new Runnable {
-              override def run(): Unit = {
-                logger.info(s"Duration expired. Reset Logger ${logger.getName} back to $currentEffectiveLevel")
-                logger.setLevel(currentLevel)
-              }
-            }))
-            ok(change)
+              // if a duration is given, we schedule a timer to reset to the current level
+              change.durationSeconds.foreach(duration => actorSystem.scheduler.scheduleOnce(duration.seconds, new Runnable {
+                override def run(): Unit = {
+                  logger.info(s"Duration expired. Reset Logger ${logger.getName} back to $currentEffectiveLevel")
+                  logger.setLevel(currentLevel)
+                }
+              }))
+              ok(change)
+          }
         }
       }
     }
@@ -154,12 +168,15 @@ class SystemResource @Inject() (val config: MarathonConf, val metricsModule: Met
   @GET
   @Path("metrics/prometheus")
   @Produces(Array(MediaType.TEXT_PLAIN))
-  def metricsPrometheus(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(ViewResource, SystemConfig) {
-      if (!config.metricsPrometheusReporter()) {
-        notFound("Prometheus reporter is disabled")
-      } else {
-        ok(PrometheusReporter.report(metricsModule.snapshot()), MediaType.TEXT_PLAIN_TYPE)
+  def metricsPrometheus(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      withAuthorization(ViewResource, SystemConfig) {
+        if (!config.metricsPrometheusReporter()) {
+          notFound("Prometheus reporter is disabled")
+        } else {
+          ok(PrometheusReporter.report(metricsModule.snapshot()), MediaType.TEXT_PLAIN_TYPE)
+        }
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -53,7 +53,7 @@ class AppTasksResource @Inject() (
         case GroupTasks(gid) =>
           val groupPath = gid.toRootPath
           val maybeGroup = groupManager.group(groupPath)
-          await(withAuthorizationF(ViewGroup, maybeGroup, unknownGroup(groupPath)) { group =>
+          await(withAuthorization(ViewGroup, maybeGroup, Future.successful(unknownGroup(groupPath))) { group =>
             async {
               val tasks = await(runningTasks(group.transitiveAppIds, instancesBySpec)).toRaml
               ok(jsonObjString("tasks" -> tasks))

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -4,10 +4,12 @@ package api.v2
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType, Response}
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._
 import mesosphere.marathon.core.appinfo.EnrichedTask
+
 import scala.concurrent.ExecutionContext
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -21,9 +23,11 @@ import mesosphere.marathon.raml.Task._
 import mesosphere.marathon.raml.TaskConversion._
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.util.toRichFuture
 
 import scala.async.Async._
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 @Consumes(Array(MediaType.APPLICATION_JSON))
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -41,30 +45,32 @@ class AppTasksResource @Inject() (
   @GET
   def indexJson(
     @PathParam("appId") id: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val tasksResponse = async {
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       id match {
         case GroupTasks(gid) =>
           val groupPath = gid.toRootPath
           val maybeGroup = groupManager.group(groupPath)
           withAuthorization(ViewGroup, maybeGroup, unknownGroup(groupPath)) { group =>
-            ok(jsonObjString("tasks" -> runningTasks(group.transitiveAppIds, instancesBySpec).toRaml))
+            val tasks = await(runningTasks(group.transitiveAppIds, instancesBySpec)).toRaml
+            ok(jsonObjString("tasks" -> tasks))
           }
         case _ =>
           val appId = id.toRootPath
           val maybeApp = groupManager.app(appId)
+          val tasks = await(runningTasks(Set(appId), instancesBySpec)).toRaml
           withAuthorization(ViewRunSpec, maybeApp, unknownApp(appId)) { _ =>
-            ok(jsonObjString("tasks" -> runningTasks(Set(appId), instancesBySpec).toRaml))
+            ok(jsonObjString("tasks" -> tasks))
           }
       }
     }
-    result(tasksResponse)
   }
 
-  def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Vector[EnrichedTask] = {
+  def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Future[Vector[EnrichedTask]] = async {
     appIds.withFilter(instancesBySpec.hasSpecInstances).flatMap { id =>
-      val health = result(healthCheckManager.statuses(id))
+      val health = await(healthCheckManager.statuses(id))
       instancesBySpec.specInstances(id).flatMap { i =>
         EnrichedTask.fromInstance(i, healthCheckResults = health.getOrElse(i.instanceId, Nil))
       }
@@ -75,14 +81,15 @@ class AppTasksResource @Inject() (
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   def indexTxt(
     @PathParam("appId") appId: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val id = appId.toRootPath
-    result(async {
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val id = appId.toRootPath
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
         ok(EndpointsHelper.appsToEndpointString(ListTasks(instancesBySpec, Seq(app))))
       }
-    })
+    }
   }
 
   @DELETE
@@ -92,33 +99,33 @@ class AppTasksResource @Inject() (
     @QueryParam("scale")@DefaultValue("false") scale: Boolean = false,
     @QueryParam("force")@DefaultValue("false") force: Boolean = false,
     @QueryParam("wipe")@DefaultValue("false") wipe: Boolean = false,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val pathId = appId.toRootPath
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val pathId = appId.toRootPath
 
-    def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
-      Option(host).fold(appTasks) { hostname =>
-        appTasks.filter(_.hostname.contains(hostname) || hostname == "*")
-      }
-    }
-
-    if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
-
-    if (scale) {
-      val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
-      deploymentResult(result(deploymentF))
-    } else {
-      val response: Future[Response] = async {
-        val instances = await(taskKiller.kill(pathId, findToKill, wipe))
-        val healthStatuses = await(healthCheckManager.statuses(pathId))
-        val enrichedTasks: Seq[EnrichedTask] = instances.flatMap { i =>
-          EnrichedTask.singleFromInstance(i, healthCheckResults = healthStatuses.getOrElse(i.instanceId, Nil))
+      def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
+        Option(host).fold(appTasks) { hostname =>
+          appTasks.filter(_.hostname.contains(hostname) || hostname == "*")
         }
-        ok(jsonObjString("tasks" -> enrichedTasks.toRaml))
-      }.recover {
-        case PathNotFoundException(appId, version) => unknownApp(appId, version)
       }
 
-      result(response)
+      if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
+
+      if (scale) {
+        val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
+        deploymentResult(await(deploymentF))
+      } else {
+        await(taskKiller.kill(pathId, findToKill, wipe).asTry) match {
+          case Success(instances) =>
+            val healthStatuses = await(healthCheckManager.statuses(pathId))
+            val enrichedTasks: Seq[EnrichedTask] = instances.flatMap { i =>
+              EnrichedTask.singleFromInstance(i, healthCheckResults = healthStatuses.getOrElse(i.instanceId, Nil))
+            }
+            ok(jsonObjString("tasks" -> enrichedTasks.toRaml))
+          case Failure(PathNotFoundException(appId, version)) => unknownApp(appId, version)
+        }
+      }
     }
   }
 
@@ -130,40 +137,41 @@ class AppTasksResource @Inject() (
     @QueryParam("scale")@DefaultValue("false") scale: Boolean = false,
     @QueryParam("force")@DefaultValue("false") force: Boolean = false,
     @QueryParam("wipe")@DefaultValue("false") wipe: Boolean = false,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val pathId = appId.toRootPath
-    def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
-      try {
-        val instanceId = Task.Id.parse(id).instanceId
-        appTasks.filter(_.instanceId == instanceId)
-      } catch {
-        // the id can not be translated to an instanceId
-        case _: MatchError => Seq.empty
-      }
-    }
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val pathId = appId.toRootPath
 
-    if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
-
-    if (scale) {
-      val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
-      deploymentResult(result(deploymentF))
-    } else {
-      val response: Future[Response] = async {
-        val instances = await(taskKiller.kill(pathId, findToKill, wipe))
-        val healthStatuses = await(healthCheckManager.statuses(pathId))
-        instances.headOption match {
-          case None =>
-            unknownTask(id)
-          case Some(i) =>
-            val killedTask = EnrichedTask.singleFromInstance(i).get
-            val enrichedTask = killedTask.copy(healthCheckResults = healthStatuses.getOrElse(i.instanceId, Nil))
-            ok(jsonObjString("task" -> enrichedTask.toRaml))
+      def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
+        try {
+          val instanceId = Task.Id.parse(id).instanceId
+          appTasks.filter(_.instanceId == instanceId)
+        } catch {
+          // the id can not be translated to an instanceId
+          case _: MatchError => Seq.empty
         }
-      }.recover {
-        case PathNotFoundException(appId, version) => unknownApp(appId, version)
       }
 
-      result(response)
+      if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
+
+      if (scale) {
+        val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
+        deploymentResult(await(deploymentF))
+      } else {
+        await(taskKiller.kill(pathId, findToKill, wipe).asTry) match {
+          case Success(instances) =>
+            val healthStatuses = await(healthCheckManager.statuses(pathId))
+            instances.headOption match {
+              case None =>
+                unknownTask(id)
+              case Some(i) =>
+                val killedTask = EnrichedTask.singleFromInstance(i).get
+                val enrichedTask = killedTask.copy(healthCheckResults = healthStatuses.getOrElse(i.instanceId, Nil))
+                ok(jsonObjString("task" -> enrichedTask.toRaml))
+            }
+          case Failure(PathNotFoundException(appId, version)) => unknownApp(appId, version)
+        }
+      }
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -78,7 +78,7 @@ class AppTasksResource @Inject() (
           EnrichedTask.fromInstance(i, healthCheckResults = health.getOrElse(i.instanceId, Nil))
         }
       }
-    }).map(_.flatten.toVector)
+    }).map(_.iterator.flatten.toVector)
   }
 
   @GET

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -3,14 +3,16 @@ package api.v2
 
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{Context, MediaType, Response}
-
+import javax.ws.rs.container.{AsyncResponse, Suspended}
+import javax.ws.rs.core.{Context, MediaType}
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.AuthResource
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, ViewRunSpec}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.Timestamp
+
+import scala.async.Async.{await, async}
 import scala.concurrent.ExecutionContext
 
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -25,10 +27,14 @@ class AppVersionsResource(
   @GET
   def index(
     @PathParam("appId") appId: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val id = appId.toRootPath
-    withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { _ =>
-      ok(jsonObjString("versions" -> service.listAppVersions(id)))
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val id = appId.toRootPath
+      withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { _ =>
+        ok(jsonObjString("versions" -> service.listAppVersions(id)))
+      }
     }
   }
 
@@ -37,11 +43,15 @@ class AppVersionsResource(
   def show(
     @PathParam("appId") appId: String,
     @PathParam("version") version: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val id = appId.toRootPath
-    val timestamp = Timestamp(version)
-    withAuthorization(ViewRunSpec, service.getApp(id, timestamp), unknownApp(id, Some(timestamp))) { app =>
-      ok(jsonString(app))
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val id = appId.toRootPath
+      val timestamp = Timestamp(version)
+      withAuthorization(ViewRunSpec, service.getApp(id, timestamp), unknownApp(id, Some(timestamp))) { app =>
+        ok(jsonString(app))
+      }
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -66,13 +66,17 @@ class AppsResource @Inject() (
     @QueryParam("id") id: String,
     @QueryParam("label") label: String,
     @QueryParam("embed") embed: java.util.Set[String],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val selector = selectAuthorized(search(Option(cmd), Option(id), Option(label)))
-    // additional embeds are deprecated!
-    val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) +
-      AppInfo.Embed.Counts + AppInfo.Embed.Deployments
-    val mapped = result(appInfoService.selectAppsBy(selector, resolvedEmbed))
-    Response.ok(jsonObjString("apps" -> mapped)).build()
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val selector = selectAuthorized(search(Option(cmd), Option(id), Option(label)))
+      // additional embeds are deprecated!
+      val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) +
+        AppInfo.Embed.Counts + AppInfo.Embed.Deployments
+      val mapped = await(appInfoService.selectAppsBy(selector, resolvedEmbed))
+      Response.ok(jsonObjString("apps" -> mapped)).build()
+    }
   }
 
   @POST
@@ -119,35 +123,35 @@ class AppsResource @Inject() (
   def show(
     @PathParam("id") id: String,
     @QueryParam("embed") embed: java.util.Set[String],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) ++ Set(
-      // deprecated. For compatibility.
-      AppInfo.Embed.Counts, AppInfo.Embed.Tasks, AppInfo.Embed.LastTaskFailure, AppInfo.Embed.Deployments
-    )
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) ++ Set(
+        // deprecated. For compatibility.
+        AppInfo.Embed.Counts, AppInfo.Embed.Tasks, AppInfo.Embed.LastTaskFailure, AppInfo.Embed.Deployments
+      )
 
-    def transitiveApps(groupId: PathId): Response = {
-      groupManager.group(groupId) match {
-        case Some(group) =>
-          checkAuthorization(ViewGroup, group)
-          val appsWithTasks = result(appInfoService.selectAppsInGroup(groupId, authzSelector, resolvedEmbed))
-          ok(jsonObjString("*" -> appsWithTasks))
-        case None =>
-          unknownGroup(groupId)
+      id match {
+        case ListApps(gid) =>
+          val groupId = gid.toRootPath
+          groupManager.group(groupId) match {
+            case Some(group) =>
+              checkAuthorization(ViewGroup, group)
+              val appsWithTasks = await(appInfoService.selectAppsInGroup(groupId, authzSelector, resolvedEmbed))
+              ok(jsonObjString("*" -> appsWithTasks))
+            case None =>
+              unknownGroup(groupId)
+          }
+        case _ =>
+          val appId = id.toRootPath
+          await(appInfoService.selectApp(appId, authzSelector, resolvedEmbed)) match {
+            case Some(appInfo) =>
+              checkAuthorization(ViewRunSpec, appInfo.app)
+              ok(jsonObjString("app" -> appInfo))
+            case None => unknownApp(appId)
+          }
       }
-    }
-
-    def app(appId: PathId): Response = {
-      result(appInfoService.selectApp(appId, authzSelector, resolvedEmbed)) match {
-        case Some(appInfo) =>
-          checkAuthorization(ViewRunSpec, appInfo.app)
-          ok(jsonObjString("app" -> appInfo))
-        case None => unknownApp(appId)
-      }
-    }
-
-    id match {
-      case ListApps(gid) => transitiveApps(gid.toRootPath)
-      case _ => app(id.toRootPath)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -108,7 +108,7 @@ class GroupsResource @Inject() (
         }
 
       def versionsResponse(groupId: PathId) = {
-        withAuthorizationF(ViewGroup, groupManager.group(groupId), unknownGroup(groupId)) { _ =>
+        withAuthorization(ViewGroup, groupManager.group(groupId), Future.successful(unknownGroup(groupId))) { _ =>
           groupManager.versions(groupId).runWith(Sink.seq).map(versions => ok(versions))
         }
       }

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -67,8 +67,10 @@ class GroupsResource @Inject() (
     * Get root group.
     */
   @GET
-  def root(@Context req: HttpServletRequest, @QueryParam("embed") embed: java.util.Set[String]): Response =
-    group("/", embed, req)
+  def root(
+    @Context req: HttpServletRequest,
+    @QueryParam("embed") embed: java.util.Set[String],
+    @Suspended asyncResponse: AsyncResponse): Unit = group("/", embed, req, asyncResponse)
 
   /**
     * Get a specific group, optionally with specific version
@@ -80,45 +82,47 @@ class GroupsResource @Inject() (
   def group(
     @PathParam("id") id: String,
     @QueryParam("embed") embed: java.util.Set[String],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    val embeds: Set[String] = if (embed.isEmpty) defaultEmbeds else embed
-    val (appEmbed, groupEmbed) = resolveAppGroup(embeds)
+      val embeds: Set[String] = if (embed.isEmpty) defaultEmbeds else embed
+      val (appEmbed, groupEmbed) = resolveAppGroup(embeds)
 
-    //format:off
-    def appsResponse(id: PathId) =
-      infoService.selectAppsInGroup(id, authorizationSelectors.appSelector, appEmbed).map(info => ok(info))
+      //format:off
+      def appsResponse(id: PathId) =
+        infoService.selectAppsInGroup(id, authorizationSelectors.appSelector, appEmbed).map(info => ok(info))
 
-    def groupResponse(id: PathId) =
-      infoService.selectGroup(id, authorizationSelectors, appEmbed, groupEmbed).map {
-        case Some(info) => ok(info)
-        case None if id.isRoot => ok(GroupInfo.empty)
-        case None => unknownGroup(id)
+      def groupResponse(id: PathId) =
+        infoService.selectGroup(id, authorizationSelectors, appEmbed, groupEmbed).map {
+          case Some(info) => ok(info)
+          case None if id.isRoot => ok(GroupInfo.empty)
+          case None => unknownGroup(id)
+        }
+
+      def groupVersionResponse(id: PathId, version: Timestamp) =
+        infoService.selectGroupVersion(id, version, authorizationSelectors, groupEmbed).map {
+          case Some(info) => ok(info)
+          case None => unknownGroup(id)
+        }
+
+      def versionsResponse(groupId: PathId) = {
+        withAuthorizationF(ViewGroup, groupManager.group(groupId), unknownGroup(groupId)) { _ =>
+          groupManager.versions(groupId).runWith(Sink.seq).map(versions => ok(versions))
+        }
       }
 
-    def groupVersionResponse(id: PathId, version: Timestamp) =
-      infoService.selectGroupVersion(id, version, authorizationSelectors, groupEmbed).map {
-        case Some(info) => ok(info)
-        case None => unknownGroup(id)
-      }
-
-    def versionsResponse(groupId: PathId) = {
-      withAuthorization(ViewGroup, groupManager.group(groupId), unknownGroup(groupId)) { _ =>
-        result(groupManager.versions(groupId).runWith(Sink.seq).map(versions => ok(versions)))
+      id match {
+        case ListApps(gid) => await(appsResponse(gid.toRootPath))
+        case ListRootApps() => await(appsResponse(PathId.empty))
+        case ListVersionsRE(gid) => await(versionsResponse(gid.toRootPath))
+        case ListRootVersionRE() => await(versionsResponse(PathId.empty))
+        case GetVersionRE(gid, version) => await(groupVersionResponse(gid.toRootPath, Timestamp(version)))
+        case GetRootVersionRE(version) => await(groupVersionResponse(PathId.empty, Timestamp(version)))
+        case _ => await(groupResponse(id.toRootPath))
       }
     }
-
-    val response: Future[Response] = id match {
-      case ListApps(gid) => appsResponse(gid.toRootPath)
-      case ListRootApps() => appsResponse(PathId.empty)
-      case ListVersionsRE(gid) => Future.successful(versionsResponse(gid.toRootPath))
-      case ListRootVersionRE() => Future.successful(versionsResponse(PathId.empty))
-      case GetVersionRE(gid, version) => groupVersionResponse(gid.toRootPath, Timestamp(version))
-      case GetRootVersionRE(version) => groupVersionResponse(PathId.empty, Timestamp(version))
-      case _ => groupResponse(id.toRootPath)
-    }
-
-    result(response)
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -3,9 +3,8 @@ package api.v2
 
 import akka.actor.Scheduler
 import javax.servlet.http.HttpServletRequest
-import javax.ws.rs.core.{Context, MediaType, Response}
+import javax.ws.rs.core.{Context, MediaType}
 import javax.ws.rs._
-
 import com.google.inject.Inject
 import mesosphere.marathon.HttpConf
 import mesosphere.marathon.api.{AuthResource, RestResource}
@@ -14,7 +13,10 @@ import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository
 import mesosphere.marathon.raml.RuntimeConfiguration
 import Validation._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import mesosphere.marathon.stream.UriIO
+
+import scala.async.Async.{async, await}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -34,12 +36,15 @@ class LeaderResource @Inject() (
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def index(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(ViewResource, AuthorizedResource.Leader) {
-      electionService.leaderHostPort match {
-        case None => notFound("There is no leader")
-        case Some(leader) =>
-          ok(jsonObjString("leader" -> leader))
+  def index(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      withAuthorization(ViewResource, AuthorizedResource.Leader) {
+        electionService.leaderHostPort match {
+          case None => notFound("There is no leader")
+          case Some(leader) =>
+            ok(jsonObjString("leader" -> leader))
+        }
       }
     }
   }
@@ -49,14 +54,19 @@ class LeaderResource @Inject() (
   def delete(
     @QueryParam("backup") backupNullable: String,
     @QueryParam("restore") restoreNullable: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(UpdateResource, AuthorizedResource.Leader) {
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      checkAuthorization(UpdateResource, AuthorizedResource.Leader)
       if (electionService.isLeader) {
         val backup = validateOrThrow(Option(backupNullable))(optional(UriIO.valid))
         val restore = validateOrThrow(Option(restoreNullable))(optional(UriIO.valid))
-        result(runtimeConfigRepo.store(RuntimeConfiguration(backup, restore)))
+        await(runtimeConfigRepo.store(RuntimeConfiguration(backup, restore)))
 
-        scheduler.scheduleOnce(LeaderResource.abdicationDelay) { electionService.abdicateLeadership() }
+        scheduler.scheduleOnce(LeaderResource.abdicationDelay) {
+          electionService.abdicateLeadership()
+        }
 
         ok(jsonObjString("message" -> "Leadership abdicated"))
       } else {

--- a/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
@@ -4,8 +4,8 @@ package api.v2
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType, Response}
-
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api._
@@ -13,6 +13,8 @@ import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.plugin.auth.AuthorizedResource.Plugins
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpRequestHandler
+
+import scala.async.Async.{await, async}
 import scala.concurrent.ExecutionContext
 
 @Path("v2/plugins")
@@ -32,72 +34,88 @@ class PluginsResource @Inject() (
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def plugins(@Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+  def plugins(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(ViewResource, Plugins) {
         ok(jsonString(definitions))
       }
     }
+  }
 
   @GET
   @Path("""{pluginId}/{path:.+}""")
   def get(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(ViewResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @HEAD
   @Path("""{pluginId}/{path:.+}""")
   def head(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(ViewResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @PUT
   @Path("""{pluginId}/{path:.+}""")
   def put(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(UpdateResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @POST
   @Path("""{pluginId}/{path:.+}""")
   def post(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(CreateResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @DELETE
   @Path("""{pluginId}/{path:.+}""")
   def delete(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(DeleteResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   private[this] def handleRequest(pluginId: String, path: String, req: HttpServletRequest): Response = {
     pluginIdToHandler.get(pluginId).map { handler =>

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -83,8 +83,11 @@ class PodsResource @Inject() (
     * @return HTTP OK if pods are supported
     */
   @HEAD
-  def capability(@Context req: HttpServletRequest): Response = authenticated(req) { _ =>
-    ok()
+  def capability(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      ok()
+    }
   }
 
   @POST
@@ -149,22 +152,29 @@ class PodsResource @Inject() (
   }
 
   @GET
-  def findAll(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val pods = podSystem.findAll(isAuthorized(ViewRunSpec, _))
-    ok(Json.stringify(Json.toJson(pods.map(Raml.toRaml(_)))))
+  def findAll(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val pods = podSystem.findAll(isAuthorized(ViewRunSpec, _))
+      ok(Json.stringify(Json.toJson(pods.map(Raml.toRaml(_)))))
+    }
   }
 
   @GET @Path("""{id:.+}""")
   def find(
     @PathParam("id") id: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    import PathId._
+      import PathId._
 
-    withValid(id.toRootPath) { id =>
-      podSystem.find(id).fold(notFound(s"""{"message": "pod with $id does not exist"}""")) { pod =>
-        withAuthorization(ViewRunSpec, pod) {
-          ok(marshal(pod))
+      withValid(id.toRootPath) { id =>
+        podSystem.find(id).fold(notFound(s"""{"message": "pod with $id does not exist"}""")) { pod =>
+          withAuthorization(ViewRunSpec, pod) {
+            ok(marshal(pod))
+          }
         }
       }
     }
@@ -203,14 +213,18 @@ class PodsResource @Inject() (
   @Path("""{id:.+}::status""")
   def status(
     @PathParam("id") id: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    import PathId._
+      import PathId._
 
-    withValid(id.toRootPath) { id =>
-      val maybeStatus = podStatusService.selectPodStatus(id, authzSelector)
-      result(maybeStatus).fold(notFound(id)) { status =>
-        ok(Json.stringify(Json.toJson(status)))
+      withValid(id.toRootPath) { id =>
+        val maybeStatus = podStatusService.selectPodStatus(id, authzSelector)
+        await(maybeStatus).fold(notFound(id)) { status =>
+          ok(Json.stringify(Json.toJson(status)))
+        }
       }
     }
   }
@@ -219,14 +233,18 @@ class PodsResource @Inject() (
   @Path("""{id:.+}::versions""")
   def versions(
     @PathParam("id") id: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    import PathId._
-    import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
-    withValid(id.toRootPath) { id =>
-      podSystem.find(id).fold(notFound(id)) { pod =>
-        withAuthorization(ViewRunSpec, pod) {
-          val versions = podSystem.versions(id).runWith(Sink.seq)
-          ok(Json.stringify(Json.toJson(result(versions))))
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      import PathId._
+      import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
+      withValid(id.toRootPath) { id =>
+        podSystem.find(id).fold(notFound(id)) { pod =>
+          withAuthorization(ViewRunSpec, pod) {
+            val versions = podSystem.versions(id).runWith(Sink.seq)
+            ok(Json.stringify(Json.toJson(await(versions))))
+          }
         }
       }
     }
@@ -235,13 +253,17 @@ class PodsResource @Inject() (
   @GET
   @Path("""{id:.+}::versions/{version}""")
   def version(@PathParam("id") id: String, @PathParam("version") versionString: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    import PathId._
-    val version = Timestamp(versionString)
-    withValid(id.toRootPath) { id =>
-      result(podSystem.version(id, version)).fold(notFound(id)) { pod =>
-        withAuthorization(ViewRunSpec, pod) {
-          ok(marshal(pod))
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      import PathId._
+      val version = Timestamp(versionString)
+      withValid(id.toRootPath) { id =>
+        await(podSystem.version(id, version)).fold(notFound(id)) { pod =>
+          withAuthorization(ViewRunSpec, pod) {
+            ok(marshal(pod))
+          }
         }
       }
     }
@@ -249,10 +271,13 @@ class PodsResource @Inject() (
 
   @GET
   @Path("::status")
-  def allStatus(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val ids = podSystem.ids()
-    val future = podStatusService.selectPodStatuses(ids, authzSelector)
-    ok(Json.stringify(Json.toJson(result(future))))
+  def allStatus(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val ids = podSystem.ids()
+      val future = podStatusService.selectPodStatuses(ids, authzSelector)
+      ok(Json.stringify(Json.toJson(await(future))))
+    }
   }
 
   @DELETE

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -3,13 +3,13 @@ package api.v2
 
 import java.time.Clock
 import java.net.URI
+
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.{Context, MediaType, Response}
-
 import akka.event.EventStream
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
@@ -29,6 +29,7 @@ import play.api.libs.json.Json
 import Normalization._
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.api.v2.Validation._
+
 import scala.concurrent.ExecutionContext
 import scala.async.Async._
 
@@ -220,12 +221,12 @@ class PodsResource @Inject() (
 
       import PathId._
 
-      withValid(id.toRootPath) { id =>
-        val maybeStatus = podStatusService.selectPodStatus(id, authzSelector)
-        await(maybeStatus).fold(notFound(id)) { status =>
-          ok(Json.stringify(Json.toJson(status)))
+      await(withValidF(id.toRootPath) { id =>
+        podStatusService.selectPodStatus(id, authzSelector).map {
+          case None => notFound(id)
+          case Some(status) => ok(Json.stringify(Json.toJson(status)))
         }
-      }
+      })
     }
   }
 
@@ -239,14 +240,16 @@ class PodsResource @Inject() (
       implicit val identity = await(authenticatedAsync(req))
       import PathId._
       import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
-      withValid(id.toRootPath) { id =>
-        podSystem.find(id).fold(notFound(id)) { pod =>
-          withAuthorization(ViewRunSpec, pod) {
-            val versions = podSystem.versions(id).runWith(Sink.seq)
-            ok(Json.stringify(Json.toJson(await(versions))))
+      await(withValidF(id.toRootPath) { id =>
+        async {
+          val versions = await(podSystem.versions(id).runWith(Sink.seq))
+          podSystem.find(id).fold(notFound(id)) { pod =>
+            withAuthorization(ViewRunSpec, pod) {
+              ok(Json.stringify(Json.toJson(versions)))
+            }
           }
         }
-      }
+      })
     }
   }
 
@@ -259,13 +262,15 @@ class PodsResource @Inject() (
       implicit val identity = await(authenticatedAsync(req))
       import PathId._
       val version = Timestamp(versionString)
-      withValid(id.toRootPath) { id =>
-        await(podSystem.version(id, version)).fold(notFound(id)) { pod =>
-          withAuthorization(ViewRunSpec, pod) {
-            ok(marshal(pod))
+      await(withValidF(id.toRootPath) { id =>
+        async {
+          await(podSystem.version(id, version)).fold(notFound(id)) { pod =>
+            withAuthorization(ViewRunSpec, pod) {
+              ok(marshal(pod))
+            }
           }
         }
-      }
+      })
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -2,11 +2,12 @@ package mesosphere.marathon
 package api.v2
 
 import java.util
+
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType, Response}
-
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api.{EndpointsHelper, TaskKiller, _}
 import mesosphere.marathon.core.appinfo.EnrichedTask
@@ -43,58 +44,63 @@ class TasksResource @Inject() (
   def indexJson(
     @QueryParam("status") status: String,
     @QueryParam("status[]") statuses: util.List[String],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    Option(status).map(statuses.add)
-    val conditionSet: Set[Condition] = statuses.flatMap(toTaskState)(collection.breakOut)
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      Option(status).map(statuses.add)
+      val conditionSet: Set[Condition] = statuses.flatMap(toTaskState)(collection.breakOut)
 
-    val futureEnrichedTasks = async {
-      val instancesBySpec = await(instanceTracker.instancesBySpec)
+      val futureEnrichedTasks = async {
+        val instancesBySpec = await(instanceTracker.instancesBySpec)
 
-      val appIds: Set[PathId] = instancesBySpec.allSpecIdsWithInstances
+        val appIds: Set[PathId] = instancesBySpec.allSpecIdsWithInstances
 
-      val appIdsToApps = groupManager.apps(appIds)
+        val appIdsToApps = groupManager.apps(appIds)
 
-      val appToPorts: Map[PathId, Seq[Int]] = appIdsToApps.map {
-        case (appId, app) => appId -> app.map(_.servicePorts).getOrElse(Nil)
+        val appToPorts: Map[PathId, Seq[Int]] = appIdsToApps.map {
+          case (appId, app) => appId -> app.map(_.servicePorts).getOrElse(Nil)
+        }
+
+        val health = await(
+          Future.sequence(appIds.map { appId =>
+            healthCheckManager.statuses(appId)
+          })).foldLeft(Map[Id, Seq[Health]]())(_ ++ _)
+
+        val enrichedTasks: Iterable[Iterable[EnrichedTask]] = for {
+          (appId, instances) <- instancesBySpec.instancesMap
+          instance <- instances.instances
+          app <- appIdsToApps(appId)
+          if (isAuthorized(ViewRunSpec, app) && (conditionSet.isEmpty || conditionSet(instance.state.condition)))
+        } yield {
+          EnrichedTask.fromInstance(
+            instance,
+            healthCheckResults = health.getOrElse(instance.instanceId, Nil),
+            servicePorts = appToPorts.getOrElse(appId, Nil)
+          )
+        }
+        enrichedTasks.flatten
       }
 
-      val health = await(
-        Future.sequence(appIds.map { appId =>
-          healthCheckManager.statuses(appId)
-        })).foldLeft(Map[Id, Seq[Health]]())(_ ++ _)
-
-      val enrichedTasks: Iterable[Iterable[EnrichedTask]] = for {
-        (appId, instances) <- instancesBySpec.instancesMap
-        instance <- instances.instances
-        app <- appIdsToApps(appId)
-        if (isAuthorized(ViewRunSpec, app) && (conditionSet.isEmpty || conditionSet(instance.state.condition)))
-      } yield {
-        EnrichedTask.fromInstance(
-          instance,
-          healthCheckResults = health.getOrElse(instance.instanceId, Nil),
-          servicePorts = appToPorts.getOrElse(appId, Nil)
-        )
-      }
-      enrichedTasks.flatten
+      val enrichedTasks: Iterable[EnrichedTask] = await(futureEnrichedTasks)
+      ok(jsonObjString(
+        "tasks" -> enrichedTasks.toIndexedSeq.toRaml
+      ))
     }
-
-    val enrichedTasks: Iterable[EnrichedTask] = result(futureEnrichedTasks)
-    ok(jsonObjString(
-      "tasks" -> enrichedTasks.toIndexedSeq.toRaml
-    ))
   }
 
   @GET
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
-  def indexTxt(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    result(async {
+  def indexTxt(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       val rootGroup = groupManager.rootGroup()
       val appsToEndpointString = EndpointsHelper.appsToEndpointString(
         ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
       )
       ok(appsToEndpointString)
-    })
+    }
   }
 
   @POST
@@ -106,38 +112,42 @@ class TasksResource @Inject() (
     @QueryParam("force")@DefaultValue("false") force: Boolean,
     @QueryParam("wipe")@DefaultValue("false") wipe: Boolean,
     body: Array[Byte],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
 
-    if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
+      if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
 
-    val taskIds = (Json.parse(body) \ "ids").as[Set[String]]
-    val tasksIdToAppId: Map[Instance.Id, PathId] = taskIds.map { id =>
-      try {
-        val taskId = Task.Id.parse(id)
-        taskId.instanceId -> taskId.instanceId.runSpecId
-      } catch { case e: MatchError => throw new BadRequestException(s"Invalid task id '$id'. [${e.getMessage}]") }
-    }(collection.breakOut)
+      val taskIds = (Json.parse(body) \ "ids").as[Set[String]]
+      val tasksIdToAppId: Map[Instance.Id, PathId] = taskIds.map { id =>
+        try {
+          val taskId = Task.Id.parse(id)
+          taskId.instanceId -> taskId.instanceId.runSpecId
+        } catch {
+          case e: MatchError => throw new BadRequestException(s"Invalid task id '$id'. [${e.getMessage}]")
+        }
+      }(collection.breakOut)
 
-    def scaleAppWithKill(toKill: Map[PathId, Seq[Instance]]): Future[Response] = async {
-      val killAndScale = await(taskKiller.killAndScale(toKill, force))
-      deploymentResult(killAndScale)
-    }
+      def scaleAppWithKill(toKill: Map[PathId, Seq[Instance]]): Future[Response] = async {
+        val killAndScale = await(taskKiller.killAndScale(toKill, force))
+        deploymentResult(killAndScale)
+      }
 
-    def doKillTasks(toKill: Map[PathId, Seq[Instance]]): Future[Response] = async {
-      val affectedApps = tasksIdToAppId.values.flatMap(appId => groupManager.app(appId))(collection.breakOut)
-      // FIXME (gkleiman): taskKiller.kill a few lines below also checks authorization, but we need to check ALL before
-      // starting to kill tasks
-      affectedApps.foreach(checkAuthorization(UpdateRunSpec, _))
-      val killedInstances = await(Future.sequence(toKill
-        .filter { case (appId, _) => affectedApps.exists(app => app.id == appId) }
-        .map {
-          case (appId, instances) => taskKiller.kill(appId, _ => instances, wipe)
-        })).flatten
-      val killedTasks = killedInstances.flatMap { i => EnrichedTask.fromInstance(i).map(_.toRaml) }
-      ok(jsonObjString("tasks" -> killedTasks))
-    }
+      def doKillTasks(toKill: Map[PathId, Seq[Instance]]): Future[Response] = async {
+        val affectedApps = tasksIdToAppId.values.flatMap(appId => groupManager.app(appId))(collection.breakOut)
+        // FIXME (gkleiman): taskKiller.kill a few lines below also checks authorization, but we need to check ALL before
+        // starting to kill tasks
+        affectedApps.foreach(checkAuthorization(UpdateRunSpec, _))
+        val killedInstances = await(Future.sequence(toKill
+          .filter { case (appId, _) => affectedApps.exists(app => app.id == appId) }
+          .map {
+            case (appId, instances) => taskKiller.kill(appId, _ => instances, wipe)
+          })).flatten
+        val killedTasks = killedInstances.flatMap { i => EnrichedTask.fromInstance(i).map(_.toRaml) }
+        ok(jsonObjString("tasks" -> killedTasks))
+      }
 
-    val futureResponse = async {
       val maybeInstances: Iterable[Option[Instance]] = await(Future.sequence(tasksIdToAppId.view
         .map { case (taskId, _) => instanceTracker.instancesBySpec.map(_.instance(taskId)) }))
       val tasksByAppId: Map[PathId, Seq[Instance]] = maybeInstances.flatten
@@ -148,7 +158,6 @@ class TasksResource @Inject() (
         else doKillTasks(tasksByAppId)
       await(response)
     }
-    result(futureResponse)
   }
 
   private def toTaskState(state: String): Option[Condition] = state.toLowerCase match {

--- a/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
@@ -26,12 +26,12 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       When("the index is fetched")
-      val index = syncRequest { appsVersionsResource.index("appId", req) }
+      val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one app version is fetched")
-      val show = syncRequest { appsVersionsResource.show("appId", "version", req) }
+      val show = asyncRequest { r => appsVersionsResource.show("appId", "version", req, r) }
       Then("we receive a NotAuthenticated response")
       show.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -44,7 +44,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
 
       groupManager.app("appId".toRootPath) returns Some(AppDefinition("appId".toRootPath))
       When("the index is fetched")
-      val index = syncRequest { appsVersionsResource.index("appId", req) }
+      val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a not authorized response")
       index.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -57,7 +57,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
 
       groupManager.app("appId".toRootPath) returns None
       When("the index is fetched")
-      val index = syncRequest { appsVersionsResource.index("appId", req) }
+      val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a 404")
       index.getStatus should be(404)
     }
@@ -71,7 +71,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val version = Timestamp.now()
       service.getApp("appId".toRootPath, version) returns Some(AppDefinition("appId".toRootPath))
       When("one app version is fetched")
-      val show = syncRequest { appsVersionsResource.show("appId", version.toString, req) }
+      val show = asyncRequest { r => appsVersionsResource.show("appId", version.toString, req, r) }
       Then("we receive a not authorized response")
       show.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -85,7 +85,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val version = Timestamp.now()
       service.getApp("appId".toRootPath, version) returns None
       When("one app version is fetched")
-      val show = syncRequest { appsVersionsResource.show("appId", version.toString, req) }
+      val show = asyncRequest { r => appsVersionsResource.show("appId", version.toString, req, r) }
       Then("we receive a not authorized response")
       show.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -1398,7 +1398,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       appInfoService.selectAppsBy(any, Matchers.eq(expectedEmbeds)) returns Future.successful(Seq(appInfo))
 
       When("The the index is fetched without any filters")
-      val response = appsResource.index(null, null, null, new java.util.HashSet(), auth.request)
+      val response = asyncRequest { r => appsResource.index(null, null, null, new java.util.HashSet(), auth.request, r) }
 
       Then("The response holds counts and deployments")
       val appJson = Json.parse(response.getEntity.asInstanceOf[String])
@@ -1417,7 +1417,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       When("The the index is fetched with last  task failure")
       val embeds = new java.util.HashSet[String]()
       embeds.add("apps.lastTaskFailure")
-      val response = appsResource.index(null, null, null, embeds, auth.request)
+      val response = asyncRequest { r => appsResource.index(null, null, null, embeds, auth.request, r) }
 
       Then("The response holds counts and task failure")
       val appJson = Json.parse(response.getEntity.asInstanceOf[String])
@@ -1465,8 +1465,8 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       groupManager.rootGroup() returns createRootGroup()
 
       When("we try to fetch the list of apps")
-      val index = syncRequest {
-        appsResource.index("", "", "", embed, req)
+      val index = asyncRequest { r =>
+        appsResource.index("", "", "", embed, req, r)
       }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(auth.NotAuthenticatedStatus)
@@ -1479,8 +1479,8 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       create.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to fetch an app")
-      val show = syncRequest {
-        appsResource.show("", embed, req)
+      val show = asyncRequest { r =>
+        appsResource.show("", embed, req, r)
       }
       Then("we receive a NotAuthenticated response")
       show.getStatus should be(auth.NotAuthenticatedStatus)
@@ -1534,8 +1534,8 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       create.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to fetch an app")
-      val show = syncRequest {
-        appsResource.show("*", embed, req)
+      val show = asyncRequest { r =>
+        appsResource.show("*", embed, req, r)
       }
       Then("we receive a NotAuthorized response")
       show.getStatus should be(auth.UnauthorizedStatus)

--- a/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
@@ -32,13 +32,13 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation with JerseyTes
       val deployment = DeploymentStepInfo(DeploymentPlan(createRootGroup(), targetGroup), DeploymentStep(Seq.empty), 1)
       service.listRunningDeployments() returns Future.successful(Seq(deployment))
 
-      When("the index is fetched")
-      val running = syncRequest { deploymentsResource.running(req) }
+      When("the i r =>ndex is fetched")
+      val running = asyncRequest { r => deploymentsResource.running(req, r) }
       Then("we receive a NotAuthenticated response")
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one app version is fetched")
-      val cancel = syncRequest { deploymentsResource.cancel(deployment.plan.id, false, req) }
+      val cancel = asyncRequest { r => deploymentsResource.cancel(deployment.plan.id, false, req, r) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -54,7 +54,7 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation with JerseyTes
       service.listRunningDeployments() returns Future.successful(Seq(deployment))
 
       When("one app version is fetched")
-      val cancel = syncRequest { deploymentsResource.cancel(deployment.plan.id, false, req) }
+      val cancel = asyncRequest { r => deploymentsResource.cancel(deployment.plan.id, false, req, r) }
       Then("we receive a not authorized response")
       cancel.getStatus should be(auth.UnauthorizedStatus)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -114,16 +114,16 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupManager.rootGroup() returns createRootGroup()
 
       When("the root is fetched from index")
-      val root = syncRequest {
-        groupsResource.root(req, embed)
+      val root = asyncRequest { r =>
+        groupsResource.root(req, embed, r)
       }
 
       Then("we receive a NotAuthenticated response")
       root.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("the group by id is fetched from create")
-      val rootGroup = syncRequest {
-        groupsResource.group("/foo/bla", embed, req)
+      val rootGroup = asyncRequest { r =>
+        groupsResource.group("/foo/bla", embed, req, r)
       }
       Then("we receive a NotAuthenticated response")
       rootGroup.getStatus should be(auth.NotAuthenticatedStatus)
@@ -229,7 +229,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupInfo.selectGroup(any, any, any, any) returns Future.successful(None)
 
       When("the root is fetched from index")
-      val root = groupsResource.root(req, embed)
+      val root = asyncRequest { r => groupsResource.root(req, embed, r) }
 
       Then("the request is successful")
       root.getStatus should be(200)
@@ -259,7 +259,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupManager.group(PathId.empty) returns Some(createGroup(PathId.empty))
 
       When("The versions are queried")
-      val rootVersionsResponse = groupsResource.group("versions", embed, auth.request)
+      val rootVersionsResponse = asyncRequest { r => groupsResource.group("versions", embed, auth.request, r) }
 
       Then("The versions are send as simple json array")
       rootVersionsResponse.getStatus should be (200)
@@ -274,7 +274,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupManager.group("/foo/bla/blub".toRootPath) returns Some(createGroup("/foo/bla/blub".toRootPath))
 
       When("The versions are queried")
-      val rootVersionsResponse = groupsResource.group("/foo/bla/blub/versions", embed, auth.request)
+      val rootVersionsResponse = asyncRequest { r => groupsResource.group("/foo/bla/blub/versions", embed, auth.request, r) }
 
       Then("The versions are send as simple json array")
       rootVersionsResponse.getStatus should be (200)

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -34,6 +34,7 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       val resource = f.infoResource()
       f.auth.authenticated = true
       f.auth.authorized = false
+      f.frameworkIdRepository.get returns Future.successful(Some(FrameworkId("dummy-uuid")))
 
       When("we try to fetch the info")
       val index = asyncRequest { r => resource.index(f.auth.request, r) }

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -22,7 +22,7 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       f.auth.authenticated = false
 
       When("we try to fetch the info")
-      val index = syncRequest { resource.index(f.auth.request) }
+      val index = asyncRequest { r => resource.index(f.auth.request, r) }
 
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.NotAuthenticatedStatus)
@@ -36,7 +36,7 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       f.auth.authorized = false
 
       When("we try to fetch the info")
-      val index = syncRequest { resource.index(f.auth.request) }
+      val index = asyncRequest { r => resource.index(f.auth.request, r) }
 
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.UnauthorizedStatus)
@@ -57,7 +57,7 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       val resource = f.infoResource()
 
       When("the info is fetched")
-      val response = syncRequest { resource.index(f.auth.request) }
+      val response = asyncRequest { r => resource.index(f.auth.request, r) }
 
       Then("there must not be the credentials in the Mesos ZK connection string")
       response.getStatus should be(200)

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -819,6 +819,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         "list no versions" in {
           val groupManager = mock[GroupManager]
           groupManager.pod(any).returns(None)
+          groupManager.podVersions(any).returns(Source.empty)
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
@@ -976,6 +977,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         podSystem.delete(any, any).returns(Future.successful(DeploymentPlan.empty))
         podSystem.ids().returns(Set.empty)
         podSystem.version(any, any).returns(Future.successful(Some(PodDefinition())))
+        podSystem.versions(any).returns(Source.empty)
         fixture.auth.authorized = authorized
         fixture.auth.authenticated = authenticated
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -72,7 +72,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       ))
 
       //when
-      val response = queueResource.index(auth.request, Set("lastUnusedOffers").asJava)
+      val response = asyncRequest { r => queueResource.index(auth.request, Set("lastUnusedOffers").asJava, r) }
 
       //then
       response.getStatus should be(200)
@@ -110,7 +110,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
         )
       ))
       //when
-      val response = queueResource.index(auth.request, Set.empty[String].asJava)
+      val response = asyncRequest { r => queueResource.index(auth.request, Set.empty[String].asJava, r) }
 
       //then
       response.getStatus should be(200)
@@ -129,7 +129,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty)
 
       //when
-      val response = queueResource.resetDelay("unknown", auth.request)
+      val response = asyncRequest { r => queueResource.resetDelay("unknown", auth.request, r) }
 
       //then
       response.getStatus should be(404)
@@ -143,7 +143,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       groupManager.runSpec(app.id) returns Some(app)
 
       //when
-      val response = queueResource.resetDelay("app", auth.request)
+      val response = asyncRequest { r => queueResource.resetDelay("app", auth.request, r) }
 
       //then
       response.getStatus should be(204)
@@ -156,12 +156,12 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       When("the index is fetched")
-      val index = syncRequest { queueResource.index(req, Set.empty[String].asJava) }
+      val index = asyncRequest { r => queueResource.index(req, Set.empty[String].asJava, r) }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one delay is reset")
-      val resetDelay = syncRequest { queueResource.resetDelay("appId", req) }
+      val resetDelay = asyncRequest { r => queueResource.resetDelay("appId", req, r) }
       Then("we receive a NotAuthenticated response")
       resetDelay.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -178,7 +178,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       instanceTracker.specInstances(any)(any) returns Future.successful(instances)
       groupManager.runSpec(app.id) returns Some(app)
 
-      val resetDelay = syncRequest { queueResource.resetDelay("app", req) }
+      val resetDelay = asyncRequest { r => queueResource.resetDelay("app", req, r) }
       Then("we receive a not authorized response")
       resetDelay.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -192,7 +192,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       When("one delay is reset")
       instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty)
 
-      val resetDelay = queueResource.resetDelay("appId", req)
+      val resetDelay = asyncRequest { r => queueResource.resetDelay("appId", req, r) }
       Then("we receive a not authorized response")
       resetDelay.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 package api.v2
 
-import javax.ws.rs.BadRequestException
-
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
@@ -206,12 +204,12 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
 
-      val exception = intercept[BadRequestException] {
-        asyncRequest { r =>
-          appsTaskResource.deleteOne(appId.toString, id.toString, scale = true, force = false, wipe = true, auth.request, r)
-        }
+      val response = asyncRequest { r =>
+        appsTaskResource.deleteOne(appId.toString, id.toString, scale = true, force = false, wipe = true, auth.request, r)
       }
-      exception.getMessage shouldEqual "You cannot use scale and wipe at the same time."
+
+      response.getStatus should be(400)
+      response.getEntity shouldEqual """{"message":"You cannot use scale and wipe at the same time."}"""
     }
 
     "deleteOne with wipe delegates to taskKiller with wipe value" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -69,7 +69,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       assert(app.servicePorts.size > instance.appTask.status.networkInfo.hostPorts.size)
 
       When("Getting the txt tasks index")
-      val response = syncRequest { taskResource.indexTxt(auth.request) }
+      val response = asyncRequest { r => taskResource.indexTxt(auth.request, r) }
 
       Then("The status should be 200")
       response.getStatus shouldEqual 200
@@ -83,7 +83,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager.apps(any) returns Map.empty
 
       When("Getting the tasks index")
-      val response = syncRequest { taskResource.indexJson("status", new java.util.ArrayList[String], auth.request) }
+      val response = asyncRequest { r =>
+        taskResource.indexJson("status", new java.util.ArrayList[String], auth.request, r)
+      }
 
       Then("The status should be 200")
       response.getStatus shouldEqual 200
@@ -110,7 +112,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager.app(app2) returns Some(AppDefinition(app2))
 
       When("we ask to kill both tasks")
-      val response = syncRequest { taskResource.killTasks(scale = false, force = false, wipe = false, body = bodyBytes, auth.request) }
+      val response = asyncRequest { r =>
+        taskResource.killTasks(scale = false, force = false, wipe = false, body = bodyBytes, auth.request, r)
+      }
 
       Then("The response should be OK")
       response.getStatus shouldEqual 200
@@ -143,7 +147,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager.app(any) returns None
 
       When("we ask to kill the pod container")
-      val response = syncRequest { taskResource.killTasks(scale = false, force = false, wipe = false, body = bodyBytes, auth.request) }
+      val response = asyncRequest { r =>
+        taskResource.killTasks(scale = false, force = false, wipe = false, body = bodyBytes, auth.request, r)
+      }
 
       Then("The response should be OK")
       response.getStatus shouldEqual 200
@@ -173,7 +179,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager.app(app2) returns Some(AppDefinition(app2))
 
       When("we ask to kill both tasks")
-      val response = syncRequest { taskResource.killTasks(scale = true, force = true, wipe = false, body = bodyBytes, auth.request) }
+      val response = asyncRequest { r =>
+        taskResource.killTasks(scale = true, force = true, wipe = false, body = bodyBytes, auth.request, r)
+      }
 
       Then("The response should be OK")
       response.getStatus shouldEqual 200
@@ -199,7 +207,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
       When("we ask to scale AND wipe")
       val exception = intercept[BadRequestException] {
-        taskResource.killTasks(scale = true, force = false, wipe = true, body = bodyBytes, auth.request)
+        asyncRequest { r => taskResource.killTasks(scale = true, force = false, wipe = true, body = bodyBytes, auth.request, r) }
       }
 
       Then("an exception should occur")
@@ -222,7 +230,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager.app(app1) returns Some(AppDefinition(app1))
 
       When("we send the request")
-      val response = syncRequest { taskResource.killTasks(scale = false, force = false, wipe = true, body = bodyBytes, auth.request) }
+      val response = asyncRequest { r =>
+        taskResource.killTasks(scale = false, force = false, wipe = true, body = bodyBytes, auth.request, r)
+      }
 
       Then("The response should be OK")
       response.getStatus shouldEqual 200
@@ -251,7 +261,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager.app(appId) returns Some(AppDefinition(appId))
 
       When("kill task is called")
-      val killTasks = syncRequest { taskResource.killTasks(scale = true, force = false, wipe = false, body, req) }
+      val killTasks = asyncRequest { r => taskResource.killTasks(scale = true, force = false, wipe = false, body, req, r) }
       Then("we receive a NotAuthenticated response")
       killTasks.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -273,7 +283,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager.app(appId) returns None
 
       When("kill task is called")
-      val killTasks = syncRequest { taskResource.killTasks(scale = true, force = false, wipe = false, body, req) }
+      val killTasks = asyncRequest { r => taskResource.killTasks(scale = true, force = false, wipe = false, body, req, r) }
       Then("we receive a NotAuthenticated response")
       killTasks.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -284,12 +294,12 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       val req = auth.request
 
       When("the index as json is fetched")
-      val running = syncRequest { taskResource.indexJson("status", Collections.emptyList(), req) }
+      val running = asyncRequest { r => taskResource.indexJson("status", Collections.emptyList(), req, r) }
       Then("we receive a NotAuthenticated response")
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one index as txt is fetched")
-      val cancel = syncRequest { taskResource.indexTxt(req) }
+      val cancel = asyncRequest { r => taskResource.indexTxt(req, r) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -329,7 +339,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("kill task is called")
-      val killTasks = syncRequest { taskResource.killTasks(scale = false, force = false, wipe = false, body, req) }
+      val killTasks = asyncRequest { r => taskResource.killTasks(scale = false, force = false, wipe = false, body, req, r) }
       Then("we receive a not authorized response")
       killTasks.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -344,7 +354,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
       When("we ask to kill those two tasks")
       val ex = intercept[BadRequestException] {
-        taskResource.killTasks(scale = false, force = false, wipe = false, body = bodyBytes, auth.request)
+        asyncRequest { r => taskResource.killTasks(scale = false, force = false, wipe = false, body = bodyBytes, auth.request, r) }
       }
 
       Then("An exception should be thrown that points to the invalid taskId")


### PR DESCRIPTION
Summary:
This removes `RestResource.result` so that all our API endpoints will be
asynchronous.

JIRA issues: MARATHON-8562