### PR TITLE
Deprecate Undefined gpu_scheduling_behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 The default GPU Scheduling Behavior has been changed to `restricted`, and `undefined` has been deprecated and will be removed in `1.9.x`. Operators with GPU clusters that are upgrading to Marathon 1.8.x should think carefully about their desired policy and set accordingly; as a general rule:
 
-* If Marathon is not GPU-enabled (`--enable_features=gpu_resources`), you don't need to do anything.
+* If Marathon is not GPU-enabled (`--enable_features gpu_resources`), you don't need to do anything.
 * If you are using GPUs, and most nodes have GPUs, set the `unrestricted`.
 * If you are using GPUs, and most nodes do not have GPUs, set to `restricted` (the default).
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 The default GPU Scheduling Behavior has been changed to `restricted`, and `undefined` has been deprecated and will be removed in `1.9.x`. Operators with GPU clusters that are upgrading to Marathon 1.8.x should think carefully about their desired policy and set accordingly; as a general rule:
 
-* If Marathon is not GPU-enabled (`--enable_features gpu_resources`), you don't need to do anything.
+* You only need to do configure `--gpu_scheduling_behavior` if Marathon is GPU enabled (`--enable_features gpu_resources`).
 * If you are using GPUs, and most nodes have GPUs, set the `unrestricted`.
 * If you are using GPUs, and most nodes do not have GPUs, set to `restricted` (the default).
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 ## Changes to 1.8.xxx
 
+### `--gpu_scheduling_behavior` default is now `restricted`; `undefined` is deprecated and will be removed
+
+The default GPU Scheduling Behavior has been changed to `restricted`, and `undefined` has been deprecated and will be removed in `1.9.x`. Operators with GPU clusters that are upgrading to Marathon 1.8.x should think carefully about their desired policy and set accordingly; as a general rule:
+
+* If Marathon is not GPU-enabled (`--enable_features=gpu_resources`), you don't need to do anything.
+* If you are using GPUs, and most nodes have GPUs, set the `unrestricted`.
+* If you are using GPUs, and most nodes do not have GPUs, set to `restricted` (the default).
+
+For more information on `gpu_scheduling_behavior`, please see [the docs](https://mesosphere.github.io/marathon/docs/preferential-gpu-scheduling.html)
+
 ### Upgrades only from Marathon 1.6+
 
 You can only upgrade to Marathon 1.8 from 1.6.x and 1.7.x. If you'd like to upgrade from an earlier version you should

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 The default GPU Scheduling Behavior has been changed to `restricted`, and `undefined` has been deprecated and will be removed in `1.9.x`. Operators with GPU clusters that are upgrading to Marathon 1.8.x should think carefully about their desired policy and set accordingly; as a general rule:
 
-* You only need to do configure `--gpu_scheduling_behavior` if Marathon is GPU enabled (`--enable_features gpu_resources`).
+* You only need to configure `--gpu_scheduling_behavior` if Marathon is GPU enabled (`--enable_features gpu_resources`).
 * If you are using GPUs, and most nodes have GPUs, set the `unrestricted`.
 * If you are using GPUs, and most nodes do not have GPUs, set to `restricted` (the default).
 

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -268,7 +268,7 @@ in your cluster. You should only need to reduce it if you use `--disable_revive_
 
 * `--decline_offer_duration` (Default: 120 seconds) The duration (milliseconds) for which to decline offers by default.
 
-* <span class="label label-default">v1.6.x</span> `--gpu_scheduling_behavior` (Default: undefined) Defines how offered GPU resources should be treated. Possible settings are `undefined`, `restricted` and `unrestricted`. Read more about [Preferential GPU scheduling](preferential-gpu-scheduling.html).
+* <span class="label label-default">v1.6.x</span> `--gpu_scheduling_behavior` (Default: restricted) Defines how offered GPU resources should be treated. Possible settings are `restricted` and `unrestricted`. Read more about [Preferential GPU scheduling](preferential-gpu-scheduling.html).
 
 
 ### Marathon after 0.8.2 (including) and before 0.11.0

--- a/docs/docs/preferential-gpu-scheduling.md
+++ b/docs/docs/preferential-gpu-scheduling.md
@@ -23,9 +23,8 @@ Marathon:
 
 - `--enable_features gpu_resources` - Tell Mesos that Marathon should be offered GPU resources. (See the [command-line docs](./command-line-flags.html)).
 - `--gpu_scheduling_behavior` - Defines how offered GPU resources should be treated. Possible settings:
-    - `unrestricted` (Default) - non-GPU tasks are launched irrespective of offers containing GPUs.
-    - `undefined` - The same as `unrestricted`, but logs a warning when a GPU resource containing offer is used for a non-GPU task.
-    - `restricted` - non-GPU tasks will decline offers containing GPUs. A decline reason of `DeclinedScareResources` is given.
+    - `unrestricted` - non-GPU tasks are launched irrespective of offers containing GPUs.
+    - `restricted` (Default) - non-GPU tasks will decline offers containing GPUs. A decline reason of `DeclinedScareResources` is given.
 
 ## Enumeration of Different Possible Cluster Scenarios
 

--- a/src/main/scala/mesosphere/marathon/GpuSchedulingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/GpuSchedulingBehavior.scala
@@ -6,12 +6,6 @@ sealed trait GpuSchedulingBehavior {
 object GpuSchedulingBehavior {
   case object Undefined extends GpuSchedulingBehavior {
     override def name = "undefined"
-    if (BuildInfo.version < SemVer(1, 9, 0))
-      "undefined"
-    else {
-      /* See MARATHON-8589 */
-      throw new NotImplementedError("Hi programmer! Please delete the definition Undefined and fix all resulting compile issues.")
-    }
   }
 
   case object Restricted extends GpuSchedulingBehavior {

--- a/src/main/scala/mesosphere/marathon/GpuSchedulingBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/GpuSchedulingBehavior.scala
@@ -1,7 +1,25 @@
 package mesosphere.marathon
 
+sealed trait GpuSchedulingBehavior {
+  def name: String
+}
 object GpuSchedulingBehavior {
-  final val Undefined: String = "undefined"
-  final val Restricted: String = "restricted"
-  final val Unrestricted: String = "unrestricted"
+  case object Undefined extends GpuSchedulingBehavior {
+    override def name = "undefined"
+    if (BuildInfo.version < SemVer(1, 9, 0))
+      "undefined"
+    else {
+      /* See MARATHON-8589 */
+      throw new NotImplementedError("Hi programmer! Please delete the definition Undefined and fix all resulting compile issues.")
+    }
+  }
+
+  case object Restricted extends GpuSchedulingBehavior {
+    override def name = "restricted"
+  }
+  case object Unrestricted extends GpuSchedulingBehavior {
+    override def name = "unrestricted"
+  }
+
+  def all = Seq(Undefined, Restricted, Unrestricted)
 }

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -304,7 +304,7 @@ trait MarathonConf
 
   lazy val gpuSchedulingBehavior = opt[GpuSchedulingBehavior](
     name = "gpu_scheduling_behavior",
-    descr = "Defines how offered GPU resources should be treated. Has no effect without --enable_features=gpu_resources. " +
+    descr = "Defines how offered GPU resources should be treated. Has no effect without --enable_features gpu_resources. " +
       s"Possible settings are ${GpuSchedulingBehavior.all.map(_.name).mkString(", ")}",
     noshort = true,
     default = Some(GpuSchedulingBehavior.Restricted)
@@ -358,8 +358,10 @@ object MarathonConf extends StrictLogging {
 
     override def parse(s: List[(String, List[String])]): Either[String, Option[GpuSchedulingBehavior]] = s match {
       case (_, schedulingBehaviorName :: Nil) :: Nil =>
-        GpuSchedulingBehavior.all.find(_.name == schedulingBehaviorName).map { b =>
-          Right(Some(b))
+        if ((schedulingBehaviorName == "undefined") && BuildInfo.version >= SemVer(1, 9, 0))
+          throw new NotImplementedError("'--gpu_scheduling_behavior undefined' has been removed. Please set either restricted or unrestricted.")
+        GpuSchedulingBehavior.all.find(_.name == schedulingBehaviorName).map { behavior =>
+          Right(Some(behavior))
         } getOrElse {
           Left(s"Setting $schedulingBehaviorName is invalid. Valid settings are ${GpuSchedulingBehavior.all.map(_.name).mkString(", ")}")
         }

--- a/src/main/scala/mesosphere/mesos/MatcherConf.scala
+++ b/src/main/scala/mesosphere/mesos/MatcherConf.scala
@@ -1,5 +1,6 @@
 package mesosphere.mesos
 
+import mesosphere.marathon.GpuSchedulingBehavior
 import org.rogach.scallop.ScallopOption
 
 import scala.concurrent.duration._
@@ -12,7 +13,7 @@ trait MatcherConf {
 
   def drainingTime: FiniteDuration = FiniteDuration(drainingSeconds(), SECONDS)
 
-  def gpuSchedulingBehavior: ScallopOption[String]
+  def gpuSchedulingBehavior: ScallopOption[GpuSchedulingBehavior]
 
   def maintenanceMode: ScallopOption[Boolean]
 }

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -249,8 +249,9 @@ object ResourceMatcher extends StrictLogging {
     }
 
     val checkGpuSchedulingBehaviour: Boolean = {
-      val applicationSpecificGpuBehavior = runSpec.labels.get("GPU_SCHEDULING_BEHAVIOR")
-        .filter(behavior => validBehaviors.contains(behavior))
+      val applicationSpecificGpuBehavior: Option[GpuSchedulingBehavior] = runSpec.labels.get("GPU_SCHEDULING_BEHAVIOR").flatMap { behaviorName =>
+        validBehaviors.find(_.name == behaviorName)
+      }
       val availableGPUs = groupedResources.getOrElse(Resource.GPUS, Nil).foldLeft(0.0)(_ + _.getScalar.getValue)
       val gpuResourcesAreWasted = availableGPUs > 0 && runSpec.resources.gpus == 0
       applicationSpecificGpuBehavior.getOrElse(conf.gpuSchedulingBehavior()) match {

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -1020,8 +1020,8 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
     }
 
-    "match any offer on gpu-enabled agent with a default gpu scheduling behavior" in {
-      val offer = MarathonTestHelper.makeBasicOffer(gpus = 4)
+    "decline GPU-containing offers for non-GPU apps with the default gpu scheduling behavior" in {
+      val gpuOffer = MarathonTestHelper.makeBasicOffer(gpus = 4)
         .build()
       val app = AppDefinition(
         id = "/test".toRootPath,
@@ -1035,8 +1035,8 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         portDefinitions = PortDefinitions(0, 0)
       )
 
-      val nonGpuResourceMatchResponse = ResourceMatcher.matchResources(
-        offer,
+      val nonGpuAppMatchResponse = ResourceMatcher.matchResources(
+        gpuOffer,
         app,
         knownInstances = Seq.empty,
         unreservedResourceSelector,
@@ -1044,10 +1044,10 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         Seq.empty
       )
 
-      nonGpuResourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
+      nonGpuAppMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
 
-      val gpuResourceMatchResponse = ResourceMatcher.matchResources(
-        offer,
+      val gpuAppMatchResponse = ResourceMatcher.matchResources(
+        gpuOffer,
         gpuApp,
         knownInstances = Seq.empty,
         unreservedResourceSelector,
@@ -1055,7 +1055,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         Seq.empty
       )
 
-      gpuResourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
+      gpuAppMatchResponse shouldBe a[ResourceMatchResponse.Match]
     }
 
     "match any offer on gpu-enabled agent with a undefined gpu scheduling behavior" in {


### PR DESCRIPTION
* New default is `restricted`
* Update changelog
* Replace strings for case object
* Prevent scheduler behavior Undefined from being used in Marathon 1.9 in the future

JIRA issues: MARATHON-8588