### PR TITLE
Response asynchronously for all endpoints. (#6793)

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/AuthResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/AuthResource.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon
 package api
 
 import javax.servlet.http.HttpServletRequest
-import javax.ws.rs.core.Response
 import mesosphere.marathon.core.async.ExecutionContexts
 
 import mesosphere.marathon.plugin.auth._
@@ -36,20 +35,6 @@ trait AuthResource extends RestResource {
   }
 
   /**
-    * Authenticate an HTTP request, synchronously.
-    *
-    * @param request The incoming HTTP request
-    * @param fn The work to perform with the identity. Not called if authentication fails.
-    *
-    * @return On success, a Jersey Response. On failure, throws a RejectionException.
-    */
-  def authenticated(request: HttpServletRequest)(fn: Identity => Response): Response = {
-    // TODO - just return the identity instead of using a callback
-    val identity = result(authenticatedAsync(request))
-    fn(identity)
-  }
-
-  /**
     * Using the configured authenticator plugin, synchronously assert that the action is authorized for the provided
     * identity.
     *
@@ -77,10 +62,10 @@ trait AuthResource extends RestResource {
     *
     *
     */
-  def withAuthorization[A, B >: A](
+  def withAuthorization[A, B >: A, R](
     action: AuthorizedAction[B],
     maybeResource: Option[A],
-    ifNotExists: Response)(fn: A => Response)(implicit identity: Identity): Response =
+    ifNotExists: R)(fn: A => R)(implicit identity: Identity): R =
     {
       maybeResource match {
         case Some(resource) =>
@@ -90,9 +75,9 @@ trait AuthResource extends RestResource {
       }
     }
 
-  def withAuthorization[A, B >: A](
+  def withAuthorization[A, B >: A, R](
     action: AuthorizedAction[B],
-    resource: A)(fn: => Response)(implicit identity: Identity): Response = {
+    resource: A)(fn: => R)(implicit identity: Identity): R = {
     checkAuthorization(action, resource)
     fn
   }

--- a/src/main/scala/mesosphere/marathon/api/SystemResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/SystemResource.scala
@@ -91,6 +91,7 @@ class SystemResource @Inject() (val config: MarathonConf, cfg: Config)(implicit
   @Path("metrics")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
+  @SuppressWarnings(Array("all")) // async/await
   def metrics(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
@@ -104,6 +105,7 @@ class SystemResource @Inject() (val config: MarathonConf, cfg: Config)(implicit
   @Path("config")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
+  @SuppressWarnings(Array("all")) // async/await
   def config(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
@@ -117,6 +119,7 @@ class SystemResource @Inject() (val config: MarathonConf, cfg: Config)(implicit
   @Path("logging")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
+  @SuppressWarnings(Array("all")) // async/await
   def showLoggers(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
@@ -135,6 +138,7 @@ class SystemResource @Inject() (val config: MarathonConf, cfg: Config)(implicit
   @Path("logging")
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
+  @SuppressWarnings(Array("all")) // async/await
   def changeLogger(body: Array[Byte], @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -71,6 +71,7 @@ class AppTasksResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Future[Vector[EnrichedTask]] = {
     Future.sequence(appIds.withFilter(instancesBySpec.hasSpecInstances).map { id =>
       async {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -4,10 +4,12 @@ package api.v2
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{Context, MediaType, Response}
+import javax.ws.rs.container.{AsyncResponse, Suspended}
+import javax.ws.rs.core.{Context, MediaType}
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._
 import mesosphere.marathon.core.appinfo.EnrichedTask
+
 import scala.concurrent.ExecutionContext
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -21,9 +23,11 @@ import mesosphere.marathon.raml.Task._
 import mesosphere.marathon.raml.TaskConversion._
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.util.toRichFuture
 
 import scala.async.Async._
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 @Consumes(Array(MediaType.APPLICATION_JSON))
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -42,36 +46,42 @@ class AppTasksResource @Inject() (
   @SuppressWarnings(Array("all")) /* async/await */
   def indexJson(
     @PathParam("appId") id: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val tasksResponse = async {
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       id match {
         case GroupTasks(gid) =>
           val groupPath = gid.toRootPath
           val maybeGroup = groupManager.group(groupPath)
-          withAuthorization(ViewGroup, maybeGroup, unknownGroup(groupPath)) { group =>
-            ok(jsonObjString("tasks" -> runningTasks(group.transitiveAppIds, instancesBySpec).toRaml))
-          }
+          await(withAuthorization(ViewGroup, maybeGroup, Future.successful(unknownGroup(groupPath))) { group =>
+            async {
+              val tasks = await(runningTasks(group.transitiveAppIds, instancesBySpec)).toRaml
+              ok(jsonObjString("tasks" -> tasks))
+            }
+          })
         case _ =>
           val appId = id.toRootPath
           val maybeApp = groupManager.app(appId)
+          val tasks = await(runningTasks(Set(appId), instancesBySpec)).toRaml
           withAuthorization(ViewRunSpec, maybeApp, unknownApp(appId)) { _ =>
-            ok(jsonObjString("tasks" -> runningTasks(Set(appId), instancesBySpec).toRaml))
+            ok(jsonObjString("tasks" -> tasks))
           }
       }
     }
-    result(tasksResponse)
   }
 
-  def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Vector[EnrichedTask] = {
-    appIds.withFilter(instancesBySpec.hasSpecInstances).flatMap { id =>
-      val health = result(healthCheckManager.statuses(id))
-      instancesBySpec.specInstances(id).flatMap { instance =>
-        instance.tasksMap.values.map { task =>
-          EnrichedTask(instance, task, health.getOrElse(instance.instanceId, Nil))
+  def runningTasks(appIds: Iterable[PathId], instancesBySpec: InstancesBySpec): Future[Vector[EnrichedTask]] = {
+    Future.sequence(appIds.withFilter(instancesBySpec.hasSpecInstances).map { id =>
+      async {
+        val health = await(healthCheckManager.statuses(id))
+        instancesBySpec.specInstances(id).flatMap { instance =>
+          instance.tasksMap.values.map { task =>
+            EnrichedTask(instance, task, health.getOrElse(instance.instanceId, Nil))
+          }
         }
       }
-    }(collection.breakOut)
+    }).map(_.iterator.flatten.toVector)
   }
 
   @GET
@@ -79,14 +89,15 @@ class AppTasksResource @Inject() (
   @SuppressWarnings(Array("all")) /* async/await */
   def indexTxt(
     @PathParam("appId") appId: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val id = appId.toRootPath
-    result(async {
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val id = appId.toRootPath
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
         ok(EndpointsHelper.appsToEndpointString(ListTasks(instancesBySpec, Seq(app))))
       }
-    })
+    }
   }
 
   @DELETE
@@ -97,34 +108,34 @@ class AppTasksResource @Inject() (
     @QueryParam("scale")@DefaultValue("false") scale: Boolean = false,
     @QueryParam("force")@DefaultValue("false") force: Boolean = false,
     @QueryParam("wipe")@DefaultValue("false") wipe: Boolean = false,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val pathId = appId.toRootPath
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val pathId = appId.toRootPath
 
-    def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
-      Option(host).fold(appTasks) { hostname =>
-        appTasks.filter(_.agentInfo.host == hostname || hostname == "*")
-      }
-    }
-
-    if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
-
-    if (scale) {
-      val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
-      deploymentResult(result(deploymentF))
-    } else {
-      val response: Future[Response] = async {
-        val instances = await(taskKiller.kill(pathId, findToKill, wipe))
-        val healthStatuses = await(healthCheckManager.statuses(pathId))
-        val enrichedTasks: Seq[EnrichedTask] = instances.map { instance =>
-          val killedTask = instance.appTask
-          EnrichedTask(instance, killedTask, healthStatuses.getOrElse(instance.instanceId, Nil))
+      def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
+        Option(host).fold(appTasks) { hostname =>
+          appTasks.filter(_.agentInfo.host == hostname || hostname == "*")
         }
-        ok(jsonObjString("tasks" -> enrichedTasks.toRaml))
-      }.recover {
-        case PathNotFoundException(appId, version) => unknownApp(appId, version)
       }
 
-      result(response)
+      if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
+
+      if (scale) {
+        val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
+        deploymentResult(await(deploymentF))
+      } else {
+        await(taskKiller.kill(pathId, findToKill, wipe).asTry) match {
+          case Success(instances) =>
+            val healthStatuses = await(healthCheckManager.statuses(pathId))
+            val enrichedTasks: Seq[EnrichedTask] = instances.map { instance =>
+              val killedTask = instance.appTask
+              EnrichedTask(instance, killedTask, healthStatuses.getOrElse(instance.instanceId, Nil))
+            }
+            ok(jsonObjString("tasks" -> enrichedTasks.toRaml))
+          case Failure(PathNotFoundException(appId, version)) => unknownApp(appId, version)
+        }
+      }
     }
   }
 
@@ -137,40 +148,41 @@ class AppTasksResource @Inject() (
     @QueryParam("scale")@DefaultValue("false") scale: Boolean = false,
     @QueryParam("force")@DefaultValue("false") force: Boolean = false,
     @QueryParam("wipe")@DefaultValue("false") wipe: Boolean = false,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val pathId = appId.toRootPath
-    def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
-      try {
-        val instanceId = Task.Id(id).instanceId
-        appTasks.filter(_.instanceId == instanceId)
-      } catch {
-        // the id can not be translated to an instanceId
-        case _: MatchError => Seq.empty
-      }
-    }
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val pathId = appId.toRootPath
 
-    if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
-
-    if (scale) {
-      val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
-      deploymentResult(result(deploymentF))
-    } else {
-      val response: Future[Response] = async {
-        val instances = await(taskKiller.kill(pathId, findToKill, wipe))
-        val healthStatuses = await(healthCheckManager.statuses(pathId))
-        instances.headOption match {
-          case None =>
-            unknownTask(id)
-          case Some(instance) =>
-            val killedTask = instance.appTask
-            val enrichedTask = EnrichedTask(instance, killedTask, healthStatuses.getOrElse(instance.instanceId, Nil))
-            ok(jsonObjString("task" -> enrichedTask.toRaml))
+      def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
+        try {
+          val instanceId = Task.Id(id).instanceId
+          appTasks.filter(_.instanceId == instanceId)
+        } catch {
+          // the id can not be translated to an instanceId
+          case _: MatchError => Seq.empty
         }
-      }.recover {
-        case PathNotFoundException(appId, version) => unknownApp(appId, version)
       }
 
-      result(response)
+      if (scale && wipe) throw new BadRequestException("You cannot use scale and wipe at the same time.")
+
+      if (scale) {
+        val deploymentF = taskKiller.killAndScale(pathId, findToKill, force)
+        deploymentResult(await(deploymentF))
+      } else {
+        await(taskKiller.kill(pathId, findToKill, wipe).asTry) match {
+          case Success(instances) =>
+            val healthStatuses = await(healthCheckManager.statuses(pathId))
+            instances.headOption match {
+              case None =>
+                unknownTask(id)
+              case Some(instance) =>
+                val killedTask = instance.appTask
+                val enrichedTask = EnrichedTask(instance, killedTask, healthStatuses.getOrElse(instance.instanceId, Nil))
+                ok(jsonObjString("task" -> enrichedTask.toRaml))
+            }
+          case Failure(PathNotFoundException(appId, version)) => unknownApp(appId, version)
+        }
+      }
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -25,6 +25,7 @@ class AppVersionsResource(
     val config: MarathonConf)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   @GET
+  @SuppressWarnings(Array("all")) /* async/await */
   def index(
     @PathParam("appId") appId: String,
     @Context req: HttpServletRequest,
@@ -40,6 +41,7 @@ class AppVersionsResource(
 
   @GET
   @Path("{version}")
+  @SuppressWarnings(Array("all")) /* async/await */
   def show(
     @PathParam("appId") appId: String,
     @PathParam("version") version: String,

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -3,14 +3,16 @@ package api.v2
 
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{Context, MediaType, Response}
-
+import javax.ws.rs.container.{AsyncResponse, Suspended}
+import javax.ws.rs.core.{Context, MediaType}
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.AuthResource
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, ViewRunSpec}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.Timestamp
+
+import scala.async.Async.{await, async}
 import scala.concurrent.ExecutionContext
 
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -25,10 +27,14 @@ class AppVersionsResource(
   @GET
   def index(
     @PathParam("appId") appId: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val id = appId.toRootPath
-    withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { _ =>
-      ok(jsonObjString("versions" -> service.listAppVersions(id)))
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val id = appId.toRootPath
+      withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { _ =>
+        ok(jsonObjString("versions" -> service.listAppVersions(id)))
+      }
     }
   }
 
@@ -37,11 +43,15 @@ class AppVersionsResource(
   def show(
     @PathParam("appId") appId: String,
     @PathParam("version") version: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val id = appId.toRootPath
-    val timestamp = Timestamp(version)
-    withAuthorization(ViewRunSpec, service.getApp(id, timestamp), unknownApp(id, Some(timestamp))) { app =>
-      ok(jsonString(app))
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val id = appId.toRootPath
+      val timestamp = Timestamp(version)
+      withAuthorization(ViewRunSpec, service.getApp(id, timestamp), unknownApp(id, Some(timestamp))) { app =>
+        ok(jsonString(app))
+      }
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -66,13 +66,17 @@ class AppsResource @Inject() (
     @QueryParam("id") id: String,
     @QueryParam("label") label: String,
     @QueryParam("embed") embed: java.util.Set[String],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val selector = selectAuthorized(search(Option(cmd), Option(id), Option(label)))
-    // additional embeds are deprecated!
-    val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) +
-      AppInfo.Embed.Counts + AppInfo.Embed.Deployments
-    val mapped = result(appInfoService.selectAppsBy(selector, resolvedEmbed))
-    Response.ok(jsonObjString("apps" -> mapped)).build()
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val selector = selectAuthorized(search(Option(cmd), Option(id), Option(label)))
+      // additional embeds are deprecated!
+      val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) +
+        AppInfo.Embed.Counts + AppInfo.Embed.Deployments
+      val mapped = await(appInfoService.selectAppsBy(selector, resolvedEmbed))
+      Response.ok(jsonObjString("apps" -> mapped)).build()
+    }
   }
 
   @SuppressWarnings(Array("all")) /* async/await */
@@ -120,35 +124,35 @@ class AppsResource @Inject() (
   def show(
     @PathParam("id") id: String,
     @QueryParam("embed") embed: java.util.Set[String],
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) ++ Set(
-      // deprecated. For compatibility.
-      AppInfo.Embed.Counts, AppInfo.Embed.Tasks, AppInfo.Embed.LastTaskFailure, AppInfo.Embed.Deployments
-    )
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val resolvedEmbed = InfoEmbedResolver.resolveApp(embed) ++ Set(
+        // deprecated. For compatibility.
+        AppInfo.Embed.Counts, AppInfo.Embed.Tasks, AppInfo.Embed.LastTaskFailure, AppInfo.Embed.Deployments
+      )
 
-    def transitiveApps(groupId: PathId): Response = {
-      groupManager.group(groupId) match {
-        case Some(group) =>
-          checkAuthorization(ViewGroup, group)
-          val appsWithTasks = result(appInfoService.selectAppsInGroup(groupId, authzSelector, resolvedEmbed))
-          ok(jsonObjString("*" -> appsWithTasks))
-        case None =>
-          unknownGroup(groupId)
+      id match {
+        case ListApps(gid) =>
+          val groupId = gid.toRootPath
+          groupManager.group(groupId) match {
+            case Some(group) =>
+              checkAuthorization(ViewGroup, group)
+              val appsWithTasks = await(appInfoService.selectAppsInGroup(groupId, authzSelector, resolvedEmbed))
+              ok(jsonObjString("*" -> appsWithTasks))
+            case None =>
+              unknownGroup(groupId)
+          }
+        case _ =>
+          val appId = id.toRootPath
+          await(appInfoService.selectApp(appId, authzSelector, resolvedEmbed)) match {
+            case Some(appInfo) =>
+              checkAuthorization(ViewRunSpec, appInfo.app)
+              ok(jsonObjString("app" -> appInfo))
+            case None => unknownApp(appId)
+          }
       }
-    }
-
-    def app(appId: PathId): Response = {
-      result(appInfoService.selectApp(appId, authzSelector, resolvedEmbed)) match {
-        case Some(appInfo) =>
-          checkAuthorization(ViewRunSpec, appInfo.app)
-          ok(jsonObjString("app" -> appInfo))
-        case None => unknownApp(appId)
-      }
-    }
-
-    id match {
-      case ListApps(gid) => transitiveApps(gid.toRootPath)
-      case _ => app(id.toRootPath)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -60,6 +60,7 @@ class AppsResource @Inject() (
   private implicit val normalizeAppUpdate: Normalization[raml.AppUpdate] =
     appUpdateNormalization(normalizationConfig)(AppNormalization.withCanonizedIds())
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   def index(
     @QueryParam("cmd") cmd: String,
@@ -119,6 +120,7 @@ class AppsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Path("""{id:.+}""")
   def show(

--- a/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
@@ -30,6 +30,7 @@ class DeploymentsResource @Inject() (
   extends AuthResource
   with StrictLogging {
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   def running(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
@@ -40,6 +41,7 @@ class DeploymentsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Path("{id}")
   def cancel(

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -77,6 +77,7 @@ class GroupsResource @Inject() (
     * @param id the identifier of the group encoded as path
     * @return the group or the group versions.
     */
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Path("""{id:.+}""")
   def group(

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -90,6 +90,7 @@ class InfoResource @Inject() (
     "https_port" -> config.httpsPort.toOption
   )
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
   def index(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -34,6 +34,7 @@ class LeaderResource @Inject() (
     val scheduler: Scheduler)(implicit val executionContext: ExecutionContext)
   extends RestResource with AuthResource {
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
   def index(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
@@ -49,6 +50,7 @@ class LeaderResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Produces(Array(MediaType.APPLICATION_JSON))
   def delete(

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -3,9 +3,8 @@ package api.v2
 
 import akka.actor.Scheduler
 import javax.servlet.http.HttpServletRequest
-import javax.ws.rs.core.{Context, MediaType, Response}
+import javax.ws.rs.core.{Context, MediaType}
 import javax.ws.rs._
-
 import com.google.inject.Inject
 import mesosphere.marathon.HttpConf
 import mesosphere.marathon.api.{AuthResource, RestResource}
@@ -14,7 +13,10 @@ import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.storage.repository.RuntimeConfigurationRepository
 import mesosphere.marathon.raml.RuntimeConfiguration
 import Validation._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import mesosphere.marathon.stream.UriIO
+
+import scala.async.Async.{async, await}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -34,12 +36,15 @@ class LeaderResource @Inject() (
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def index(@Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(ViewResource, AuthorizedResource.Leader) {
-      electionService.leaderHostPort match {
-        case None => notFound("There is no leader")
-        case Some(leader) =>
-          ok(jsonObjString("leader" -> leader))
+  def index(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      withAuthorization(ViewResource, AuthorizedResource.Leader) {
+        electionService.leaderHostPort match {
+          case None => notFound("There is no leader")
+          case Some(leader) =>
+            ok(jsonObjString("leader" -> leader))
+        }
       }
     }
   }
@@ -49,14 +54,19 @@ class LeaderResource @Inject() (
   def delete(
     @QueryParam("backup") backupNullable: String,
     @QueryParam("restore") restoreNullable: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    withAuthorization(UpdateResource, AuthorizedResource.Leader) {
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      checkAuthorization(UpdateResource, AuthorizedResource.Leader)
       if (electionService.isLeader) {
         val backup = validateOrThrow(Option(backupNullable))(optional(UriIO.valid))
         val restore = validateOrThrow(Option(restoreNullable))(optional(UriIO.valid))
-        result(runtimeConfigRepo.store(RuntimeConfiguration(backup, restore)))
+        await(runtimeConfigRepo.store(RuntimeConfiguration(backup, restore)))
 
-        scheduler.scheduleOnce(LeaderResource.abdicationDelay) { electionService.abdicateLeadership() }
+        scheduler.scheduleOnce(LeaderResource.abdicationDelay) {
+          electionService.abdicateLeadership()
+        }
 
         ok(jsonObjString("message" -> "Leadership abdicated"))
       } else {

--- a/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
@@ -4,8 +4,8 @@ package api.v2
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
+import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType, Response}
-
 import mesosphere.marathon.MarathonConf
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api._
@@ -13,6 +13,8 @@ import mesosphere.marathon.core.plugin.PluginDefinitions
 import mesosphere.marathon.plugin.auth.AuthorizedResource.Plugins
 import mesosphere.marathon.plugin.auth._
 import mesosphere.marathon.plugin.http.HttpRequestHandler
+
+import scala.async.Async.{await, async}
 import scala.concurrent.ExecutionContext
 
 @Path("v2/plugins")
@@ -32,72 +34,88 @@ class PluginsResource @Inject() (
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def plugins(@Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+  def plugins(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(ViewResource, Plugins) {
         ok(jsonString(definitions))
       }
     }
+  }
 
   @GET
   @Path("""{pluginId}/{path:.+}""")
   def get(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(ViewResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @HEAD
   @Path("""{pluginId}/{path:.+}""")
   def head(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(ViewResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @PUT
   @Path("""{pluginId}/{path:.+}""")
   def put(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(UpdateResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @POST
   @Path("""{pluginId}/{path:.+}""")
   def post(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(CreateResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   @DELETE
   @Path("""{pluginId}/{path:.+}""")
   def delete(
     @PathParam("pluginId") pluginId: String,
     @PathParam("path") path: String,
-    @Context req: HttpServletRequest): Response =
-    authenticated(req) { implicit identity =>
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
       withAuthorization(DeleteResource, Plugins) {
         handleRequest(pluginId, path, req)
       }
     }
+  }
 
   private[this] def handleRequest(pluginId: String, path: String, req: HttpServletRequest): Response = {
     pluginIdToHandler.get(pluginId).map { handler =>

--- a/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PluginsResource.scala
@@ -32,6 +32,7 @@ class PluginsResource @Inject() (
     .withFilter(_.plugin == classOf[HttpRequestHandler].getName)
     .flatMap { d => requestHandlers.find(_.getClass.getName == d.implementation).map(d.id -> _) }(collection.breakOut)
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
   def plugins(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
@@ -43,6 +44,7 @@ class PluginsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Path("""{pluginId}/{path:.+}""")
   def get(
@@ -57,6 +59,7 @@ class PluginsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @HEAD
   @Path("""{pluginId}/{path:.+}""")
   def head(
@@ -72,6 +75,7 @@ class PluginsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @PUT
   @Path("""{pluginId}/{path:.+}""")
   def put(
@@ -87,6 +91,7 @@ class PluginsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @POST
   @Path("""{pluginId}/{path:.+}""")
   def post(
@@ -102,6 +107,7 @@ class PluginsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Path("""{pluginId}/{path:.+}""")
   def delete(

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -83,6 +83,7 @@ class PodsResource @Inject() (
     *
     * @return HTTP OK if pods are supported
     */
+  @SuppressWarnings(Array("all")) /* async/await */
   @HEAD
   def capability(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
@@ -154,6 +155,7 @@ class PodsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   def findAll(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
@@ -163,6 +165,7 @@ class PodsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET @Path("""{id:.+}""")
   def find(
     @PathParam("id") id: String,
@@ -213,6 +216,7 @@ class PodsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Path("""{id:.+}::status""")
   def status(
@@ -233,6 +237,7 @@ class PodsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Path("""{id:.+}::versions""")
   def versions(
@@ -256,6 +261,7 @@ class PodsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Path("""{id:.+}::versions/{version}""")
   def version(@PathParam("id") id: String, @PathParam("version") versionString: String,
@@ -277,9 +283,9 @@ class PodsResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Path("::status")
-  @SuppressWarnings(Array("OptionGet", "FilterOptionAndGet"))
   def allStatus(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -25,6 +25,7 @@ class QueueResource @Inject() (
     val authorizer: Authorizer,
     val config: MarathonConf)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
   def index(
@@ -40,6 +41,7 @@ class QueueResource @Inject() (
     }
   }
 
+  @SuppressWarnings(Array("all")) /* async/await */
   @DELETE
   @Path("""{appId:.+}/delay""")
   def resetDelay(

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -5,13 +5,15 @@ import java.time.Clock
 import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
-import javax.ws.rs.core.{Context, MediaType, Response}
-
+import javax.ws.rs.container.{AsyncResponse, Suspended}
+import javax.ws.rs.core.{Context, MediaType}
 import mesosphere.marathon.api.AuthResource
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.raml.Raml
 import mesosphere.marathon.state.PathId._
+
+import scala.async.Async.{await, async}
 import scala.concurrent.ExecutionContext
 
 @Path("v2/queue")
@@ -25,24 +27,34 @@ class QueueResource @Inject() (
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def index(@Context req: HttpServletRequest, @QueryParam("embed") embed: java.util.Set[String]): Response = authenticated(req) { implicit identity =>
-    val embedLastUnusedOffers = embed.contains(QueueResource.EmbedLastUnusedOffers)
-    val maybeStats = result(launchQueue.listWithStatistics)
-    val stats = maybeStats.filter(t => t.inProgress && isAuthorized(ViewRunSpec, t.runSpec))
-    ok(Raml.toRaml((stats, embedLastUnusedOffers, clock)))
+  def index(
+    @Context req: HttpServletRequest,
+    @QueryParam("embed") embed: java.util.Set[String],
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val embedLastUnusedOffers = embed.contains(QueueResource.EmbedLastUnusedOffers)
+      val maybeStats = await(launchQueue.listWithStatistics)
+      val stats = maybeStats.filter(t => t.inProgress && isAuthorized(ViewRunSpec, t.runSpec))
+      ok(Raml.toRaml((stats, embedLastUnusedOffers, clock)))
+    }
   }
 
   @DELETE
   @Path("""{appId:.+}/delay""")
   def resetDelay(
-    @PathParam("appId") id: String,
-    @Context req: HttpServletRequest): Response = authenticated(req) { implicit identity =>
-    val appId = id.toRootPath
-    val maybeApps = result(launchQueue.list)
-    val maybeApp = maybeApps.find(_.runSpec.id == appId).map(_.runSpec)
-    withAuthorization(UpdateRunSpec, maybeApp, notFound(s"Application $appId not found in tasks queue.")) { app =>
-      launchQueue.resetDelay(app)
-      noContent
+    @PathParam("runSpecId") id: String,
+    @Context req: HttpServletRequest,
+    @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+    async {
+      implicit val identity = await(authenticatedAsync(req))
+      val appId = id.toRootPath
+      val maybeApps = await(launchQueue.list)
+      val maybeApp = maybeApps.find(_.runSpec.id == appId).map(_.runSpec)
+      withAuthorization(UpdateRunSpec, maybeApp, notFound(s"Application $appId not found in tasks queue.")) { app =>
+        launchQueue.resetDelay(app)
+        noContent
+      }
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
@@ -95,7 +95,7 @@ class SystemResourceTest extends AkkaUnitTest with JerseyTest {
 
     "Get metrics" in new Fixture {
       When("The metrics are requested")
-      val response = resource.metrics(auth.request)
+      val response = asyncRequest { r => resource.metrics(auth.request, r) }
 
       Then("The metrics are sent")
       val metricsJson = Json.parse(response.getEntity.asInstanceOf[String])
@@ -111,17 +111,17 @@ class SystemResourceTest extends AkkaUnitTest with JerseyTest {
       auth.authenticated = false
 
       When("we try to fetch metrics")
-      val fetchedMetrics = syncRequest { resource.metrics(auth.request) }
+      val fetchedMetrics = asyncRequest { r => resource.metrics(auth.request, r) }
       Then("we receive a NotAuthenticated response")
       fetchedMetrics.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to get logging")
-      val showLoggers = syncRequest { resource.showLoggers(auth.request) }
+      val showLoggers = asyncRequest { r => resource.showLoggers(auth.request, r) }
       Then("we receive a NotAuthenticated response")
       showLoggers.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to change loggers")
-      val changeLogger = syncRequest { resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request) }
+      val changeLogger = asyncRequest { r => resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request, r) }
       Then("we receive a NotAuthenticated response")
       changeLogger.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -131,23 +131,23 @@ class SystemResourceTest extends AkkaUnitTest with JerseyTest {
       auth.authorized = false
 
       When("we try to fetch metrics")
-      val fetchedMetrics = syncRequest { resource.metrics(auth.request) }
+      val fetchedMetrics = asyncRequest { r => resource.metrics(auth.request, r) }
       Then("we receive a Unauthorized response")
       fetchedMetrics.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to get logging")
-      val showLoggers = syncRequest { resource.showLoggers(auth.request) }
+      val showLoggers = asyncRequest { r => resource.showLoggers(auth.request, r) }
       Then("we receive a Unauthorized response")
       showLoggers.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to change loggers")
-      val changeLogger = syncRequest { resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request) }
+      val changeLogger = asyncRequest { r => resource.changeLogger("""{ "level": "debug", "logger": "org" }""".getBytes, auth.request, r) }
       Then("we receive a Unauthorized response")
       changeLogger.getStatus should be(auth.UnauthorizedStatus)
     }
 
     "show all loggers will give a map of all loggers with level" in new Fixture {
-      val showLoggers = resource.showLoggers(auth.request)
+      val showLoggers = asyncRequest { r => resource.showLoggers(auth.request, r) }
       showLoggers.getStatus should be (200)
       val loggerMap = Json.parse(showLoggers.getEntity.asInstanceOf[String]).as[JsObject]
       loggerMap.values should not be empty
@@ -157,7 +157,7 @@ class SystemResourceTest extends AkkaUnitTest with JerseyTest {
 
     "change a logger via the api will update the log lebel" in new Fixture {
       When("We set the log level of not.used to trace")
-      resource.changeLogger("""{ "level": "trace", "logger": "not.used" }""".getBytes, auth.request)
+      asyncRequest { r => resource.changeLogger("""{ "level": "trace", "logger": "not.used" }""".getBytes, auth.request, r) }
       Then("The log level is set to trace")
       LoggerFactory.getILoggerFactory.getLogger("not.used").asInstanceOf[Logger].getLevel should be (Level.TRACE)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
@@ -26,12 +26,12 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       When("the index is fetched")
-      val index = syncRequest { appsVersionsResource.index("appId", req) }
+      val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one app version is fetched")
-      val show = syncRequest { appsVersionsResource.show("appId", "version", req) }
+      val show = asyncRequest { r => appsVersionsResource.show("appId", "version", req, r) }
       Then("we receive a NotAuthenticated response")
       show.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -44,7 +44,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
 
       groupManager.app("appId".toRootPath) returns Some(AppDefinition("appId".toRootPath))
       When("the index is fetched")
-      val index = syncRequest { appsVersionsResource.index("appId", req) }
+      val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a not authorized response")
       index.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -57,7 +57,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
 
       groupManager.app("appId".toRootPath) returns None
       When("the index is fetched")
-      val index = syncRequest { appsVersionsResource.index("appId", req) }
+      val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a 404")
       index.getStatus should be(404)
     }
@@ -71,7 +71,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val version = Timestamp.now()
       service.getApp("appId".toRootPath, version) returns Some(AppDefinition("appId".toRootPath))
       When("one app version is fetched")
-      val show = syncRequest { appsVersionsResource.show("appId", version.toString, req) }
+      val show = asyncRequest { r => appsVersionsResource.show("appId", version.toString, req, r) }
       Then("we receive a not authorized response")
       show.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -85,7 +85,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val version = Timestamp.now()
       service.getApp("appId".toRootPath, version) returns None
       When("one app version is fetched")
-      val show = syncRequest { appsVersionsResource.show("appId", version.toString, req) }
+      val show = asyncRequest { r => appsVersionsResource.show("appId", version.toString, req, r) }
       Then("we receive a not authorized response")
       show.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -1398,7 +1398,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       appInfoService.selectAppsBy(any, Matchers.eq(expectedEmbeds)) returns Future.successful(Seq(appInfo))
 
       When("The the index is fetched without any filters")
-      val response = appsResource.index(null, null, null, new java.util.HashSet(), auth.request)
+      val response = asyncRequest { r => appsResource.index(null, null, null, new java.util.HashSet(), auth.request, r) }
 
       Then("The response holds counts and deployments")
       val appJson = Json.parse(response.getEntity.asInstanceOf[String])
@@ -1417,7 +1417,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       When("The the index is fetched with last  task failure")
       val embeds = new java.util.HashSet[String]()
       embeds.add("apps.lastTaskFailure")
-      val response = appsResource.index(null, null, null, embeds, auth.request)
+      val response = asyncRequest { r => appsResource.index(null, null, null, embeds, auth.request, r) }
 
       Then("The response holds counts and task failure")
       val appJson = Json.parse(response.getEntity.asInstanceOf[String])
@@ -1465,8 +1465,8 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       groupManager.rootGroup() returns createRootGroup()
 
       When("we try to fetch the list of apps")
-      val index = syncRequest {
-        appsResource.index("", "", "", embed, req)
+      val index = asyncRequest { r =>
+        appsResource.index("", "", "", embed, req, r)
       }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(auth.NotAuthenticatedStatus)
@@ -1479,8 +1479,8 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       create.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("we try to fetch an app")
-      val show = syncRequest {
-        appsResource.show("", embed, req)
+      val show = asyncRequest { r =>
+        appsResource.show("", embed, req, r)
       }
       Then("we receive a NotAuthenticated response")
       show.getStatus should be(auth.NotAuthenticatedStatus)
@@ -1534,8 +1534,8 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       create.getStatus should be(auth.UnauthorizedStatus)
 
       When("we try to fetch an app")
-      val show = syncRequest {
-        appsResource.show("*", embed, req)
+      val show = asyncRequest { r =>
+        appsResource.show("*", embed, req, r)
       }
       Then("we receive a NotAuthorized response")
       show.getStatus should be(auth.UnauthorizedStatus)

--- a/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/DeploymentsResourceTest.scala
@@ -32,13 +32,13 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation with JerseyTes
       val deployment = DeploymentStepInfo(DeploymentPlan(createRootGroup(), targetGroup), DeploymentStep(Seq.empty), 1)
       service.listRunningDeployments() returns Future.successful(Seq(deployment))
 
-      When("the index is fetched")
-      val running = syncRequest { deploymentsResource.running(req) }
+      When("the i r =>ndex is fetched")
+      val running = asyncRequest { r => deploymentsResource.running(req, r) }
       Then("we receive a NotAuthenticated response")
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one app version is fetched")
-      val cancel = syncRequest { deploymentsResource.cancel(deployment.plan.id, false, req) }
+      val cancel = asyncRequest { r => deploymentsResource.cancel(deployment.plan.id, false, req, r) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -54,7 +54,7 @@ class DeploymentsResourceTest extends UnitTest with GroupCreation with JerseyTes
       service.listRunningDeployments() returns Future.successful(Seq(deployment))
 
       When("one app version is fetched")
-      val cancel = syncRequest { deploymentsResource.cancel(deployment.plan.id, false, req) }
+      val cancel = asyncRequest { r => deploymentsResource.cancel(deployment.plan.id, false, req, r) }
       Then("we receive a not authorized response")
       cancel.getStatus should be(auth.UnauthorizedStatus)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -113,16 +113,16 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupManager.rootGroup() returns createRootGroup()
 
       When("the root is fetched from index")
-      val root = syncRequest {
-        groupsResource.root(req, embed)
+      val root = asyncRequest { r =>
+        groupsResource.root(req, embed, r)
       }
 
       Then("we receive a NotAuthenticated response")
       root.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("the group by id is fetched from create")
-      val rootGroup = syncRequest {
-        groupsResource.group("/foo/bla", embed, req)
+      val rootGroup = asyncRequest { r =>
+        groupsResource.group("/foo/bla", embed, req, r)
       }
       Then("we receive a NotAuthenticated response")
       rootGroup.getStatus should be(auth.NotAuthenticatedStatus)
@@ -228,7 +228,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupInfo.selectGroup(any, any, any, any) returns Future.successful(None)
 
       When("the root is fetched from index")
-      val root = groupsResource.root(req, embed)
+      val root = asyncRequest { r => groupsResource.root(req, embed, r) }
 
       Then("the request is successful")
       root.getStatus should be(200)
@@ -258,7 +258,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupManager.group(PathId.empty) returns Some(createGroup(PathId.empty))
 
       When("The versions are queried")
-      val rootVersionsResponse = groupsResource.group("versions", embed, auth.request)
+      val rootVersionsResponse = asyncRequest { r => groupsResource.group("versions", embed, auth.request, r) }
 
       Then("The versions are send as simple json array")
       rootVersionsResponse.getStatus should be (200)
@@ -273,7 +273,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       groupManager.group("/foo/bla/blub".toRootPath) returns Some(createGroup("/foo/bla/blub".toRootPath))
 
       When("The versions are queried")
-      val rootVersionsResponse = groupsResource.group("/foo/bla/blub/versions", embed, auth.request)
+      val rootVersionsResponse = asyncRequest { r => groupsResource.group("/foo/bla/blub/versions", embed, auth.request, r) }
 
       Then("The versions are send as simple json array")
       rootVersionsResponse.getStatus should be (200)

--- a/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/InfoResourceTest.scala
@@ -22,7 +22,7 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       f.auth.authenticated = false
 
       When("we try to fetch the info")
-      val index = syncRequest { resource.index(f.auth.request) }
+      val index = asyncRequest { r => resource.index(f.auth.request, r) }
 
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.NotAuthenticatedStatus)
@@ -34,9 +34,10 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       val resource = f.infoResource()
       f.auth.authenticated = true
       f.auth.authorized = false
+      f.frameworkIdRepository.get returns Future.successful(Some(FrameworkId("dummy-uuid")))
 
       When("we try to fetch the info")
-      val index = syncRequest { resource.index(f.auth.request) }
+      val index = asyncRequest { r => resource.index(f.auth.request, r) }
 
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(f.auth.UnauthorizedStatus)
@@ -57,7 +58,7 @@ class InfoResourceTest extends UnitTest with JerseyTest {
       val resource = f.infoResource()
 
       When("the info is fetched")
-      val response = syncRequest { resource.index(f.auth.request) }
+      val response = asyncRequest { r => resource.index(f.auth.request, r) }
 
       Then("there must not be the credentials in the Mesos ZK connection string")
       response.getStatus should be(200)

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -115,7 +115,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
   "PodsResource" should {
     "support pods" in {
       val f = Fixture()
-      val response = f.podsResource.capability(f.auth.request)
+      val response = asyncRequest { r => f.podsResource.capability(f.auth.request, r) }
       response.getStatus should be(HttpServletResponse.SC_OK)
 
       val body = Option(response.getEntity.asInstanceOf[String])
@@ -555,7 +555,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       val f = Fixture()
 
       podSystem.find(any).returns(Option.empty[PodDefinition])
-      val response = f.podsResource.find("/mypod", f.auth.request)
+      val response = asyncRequest { r => f.podsResource.find("/mypod", f.auth.request, r) }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_NOT_FOUND)
@@ -570,7 +570,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       val f = Fixture()
 
       podSystem.findAll(any).returns(List(PodDefinition(), PodDefinition()))
-      val response = f.podsResource.findAll(f.auth.request)
+      val response = asyncRequest { r => f.podsResource.findAll(f.auth.request, r) }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
@@ -586,7 +586,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
       podStatusService.selectPodStatus(any, any).returns(Future(Some(PodStatus("mypod", Pod("mypod", containers = Seq.empty), PodState.Stable, statusSince = OffsetDateTime.now(), lastUpdated = OffsetDateTime.now(), lastChanged = OffsetDateTime.now()))))
 
-      val response = f.podsResource.status("/mypod", f.auth.request)
+      val response = asyncRequest { r => f.podsResource.status("/mypod", f.auth.request, r) }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
@@ -604,7 +604,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       podSystem.ids().returns(Set(PathId("mypod")))
       podStatusService.selectPodStatuses(any, any).returns(Future(Seq(PodStatus("mypod", Pod("mypod", containers = Seq.empty), PodState.Stable, statusSince = OffsetDateTime.now(), lastUpdated = OffsetDateTime.now(), lastChanged = OffsetDateTime.now()))))
 
-      val response = f.podsResource.allStatus(f.auth.request)
+      val response = asyncRequest { r => f.podsResource.allStatus(f.auth.request, r) }
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
@@ -819,10 +819,11 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         "list no versions" in {
           val groupManager = mock[GroupManager]
           groupManager.pod(any).returns(None)
+          groupManager.podVersions(any).returns(Source.empty)
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
-          val response = f.podsResource.versions("/id", f.auth.request)
+          val response = asyncRequest { r => f.podsResource.versions("/id", f.auth.request, r) }
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_NOT_FOUND)
           }
@@ -835,7 +836,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
-          val response = f.podsResource.version("/id", "2008-01-01T12:00:00.000Z", f.auth.request)
+          val response = asyncRequest { r => f.podsResource.version("/id", "2008-01-01T12:00:00.000Z", f.auth.request, r) }
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_NOT_FOUND)
             response.getEntity.toString should be ("{\"message\":\"Pod '/id' does not exist\"}")
@@ -854,7 +855,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
-          val response = f.podsResource.versions("/id", f.auth.request)
+          val response = asyncRequest { r => f.podsResource.versions("/id", f.auth.request, r) }
           withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_OK)
             val timestamps = Json.fromJson[Seq[Timestamp]](Json.parse(response.getEntity.asInstanceOf[String])).get
@@ -870,7 +871,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
           implicit val podManager = PodManagerImpl(groupManager)
           val f = Fixture()
 
-          val response = f.podsResource.version("/id", pod1.version.toString, f.auth.request)
+          val response = asyncRequest { r => f.podsResource.version("/id", pod1.version.toString, f.auth.request, r) }
           withClue(s"reponse body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_OK)
             val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.asInstanceOf[String])).get)
@@ -958,6 +959,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         podSystem.delete(any, any).returns(Future.successful(DeploymentPlan.empty))
         podSystem.ids().returns(Set.empty)
         podSystem.version(any, any).returns(Future.successful(Some(PodDefinition())))
+        podSystem.versions(any).returns(Source.empty)
         fixture.auth.authorized = authorized
         fixture.auth.authenticated = authenticated
       }
@@ -980,7 +982,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         }
 
         "find a pod" in {
-          val response = syncRequest { f.podsResource.find("mypod", f.auth.request) }
+          val response = asyncRequest { r => f.podsResource.find("mypod", f.auth.request, r) }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
@@ -992,12 +994,12 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         }
 
         "versions of a pod" in {
-          val response = syncRequest { f.podsResource.versions("mypod", f.auth.request) }
+          val response = asyncRequest { r => f.podsResource.versions("mypod", f.auth.request, r) }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
 
         "version of a pod" in {
-          val response = syncRequest { f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request) }
+          val response = asyncRequest { r => f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request, r) }
           response.getStatus should be(HttpServletResponse.SC_UNAUTHORIZED)
         }
       }
@@ -1020,7 +1022,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         }
 
         "find a pod" in {
-          val response = syncRequest { f.podsResource.find("mypod", f.auth.request) }
+          val response = asyncRequest { r => f.podsResource.find("mypod", f.auth.request, r) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
@@ -1032,17 +1034,17 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         }
 
         "status of a pod" in {
-          val response = syncRequest { f.podsResource.status("mypod", f.auth.request) }
+          val response = asyncRequest { r => f.podsResource.status("mypod", f.auth.request, r) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "versions of a pod" in {
-          val response = syncRequest { f.podsResource.versions("mypod", f.auth.request) }
+          val response = asyncRequest { r => f.podsResource.versions("mypod", f.auth.request, r) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
 
         "version of a pod" in {
-          val response = syncRequest { f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request) }
+          val response = asyncRequest { r => f.podsResource.version("mypod", Timestamp.now().toString, f.auth.request, r) }
           response.getStatus should be(HttpServletResponse.SC_FORBIDDEN)
         }
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -64,7 +64,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       ))
 
       //when
-      val response = queueResource.index(auth.request, Set("lastUnusedOffers").asJava)
+      val response = asyncRequest { r => queueResource.index(auth.request, Set("lastUnusedOffers").asJava, r) }
 
       //then
       response.getStatus should be(200)
@@ -102,7 +102,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
         )
       ))
       //when
-      val response = queueResource.index(auth.request, Set.empty[String].asJava)
+      val response = asyncRequest { r => queueResource.index(auth.request, Set.empty[String].asJava, r) }
 
       //then
       response.getStatus should be(200)
@@ -121,7 +121,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       queue.list returns Future.successful(Seq.empty)
 
       //when
-      val response = queueResource.resetDelay("unknown", auth.request)
+      val response = asyncRequest { r => queueResource.resetDelay("unknown", auth.request, r) }
 
       //then
       response.getStatus should be(404)
@@ -138,7 +138,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       ))
 
       //when
-      val response = queueResource.resetDelay("app", auth.request)
+      val response = asyncRequest { r => queueResource.resetDelay("app", auth.request, r) }
 
       //then
       response.getStatus should be(204)
@@ -151,12 +151,12 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       When("the index is fetched")
-      val index = syncRequest { queueResource.index(req, Set.empty[String].asJava) }
+      val index = asyncRequest { r => queueResource.index(req, Set.empty[String].asJava, r) }
       Then("we receive a NotAuthenticated response")
       index.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one delay is reset")
-      val resetDelay = syncRequest { queueResource.resetDelay("appId", req) }
+      val resetDelay = asyncRequest { r => queueResource.resetDelay("appId", req, r) }
       Then("we receive a NotAuthenticated response")
       resetDelay.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -173,7 +173,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
         backOffUntil = clock.now() + 100.seconds, startedAt = clock.now())
       queue.list returns Future.successful(Seq(taskCount))
 
-      val resetDelay = syncRequest { queueResource.resetDelay("appId", req) }
+      val resetDelay = asyncRequest { r => queueResource.resetDelay("appId", req, r) }
       Then("we receive a not authorized response")
       resetDelay.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -187,7 +187,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       When("one delay is reset")
       queue.list returns Future.successful(Seq.empty)
 
-      val resetDelay = queueResource.resetDelay("appId", req)
+      val resetDelay = asyncRequest { r => queueResource.resetDelay("appId", req, r) }
       Then("we receive a not authorized response")
       resetDelay.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -1,8 +1,6 @@
 package mesosphere.marathon
 package api.v2
 
-import akka.actor.ActorSystem
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
 import mesosphere.marathon.api.{JsonTestHelper, TaskKiller, TestAuthFixture}
 import mesosphere.marathon.test.JerseyTest

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -1,7 +1,8 @@
 package mesosphere.marathon
 package api.v2
 
-import javax.ws.rs.BadRequestException
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
 import mesosphere.marathon.api.{JsonTestHelper, TaskKiller, TestAuthFixture}
 import mesosphere.marathon.test.JerseyTest
@@ -83,7 +84,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.runSpec(appId) returns Some(AppDefinition(appId))
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
 
-      val response = appsTaskResource.deleteMany(appId.toString, host, scale = false, force = false, wipe = false, auth.request)
+      val response = asyncRequest { r =>
+        appsTaskResource.deleteMany(appId.toString, host, scale = false, force = false, wipe = false, auth.request, r)
+      }
       response.getStatus shouldEqual 200
 
       val expected =
@@ -127,7 +130,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val appId = "/my/app"
       val host = "host"
 
-      val response = syncRequest { appsTaskResource.deleteMany(appId, host, scale = true, force = false, wipe = true, auth.request) }
+      val response = asyncRequest { r =>
+        appsTaskResource.deleteMany(appId, host, scale = true, force = false, wipe = true, auth.request, r)
+      }
 
       response.getEntity().toString should include("You cannot use scale and wipe at the same time.")
     }
@@ -138,7 +143,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       healthCheckManager.statuses(appId.toRootPath) returns Future.successful(collection.immutable.Map.empty)
       taskKiller.kill(any, any, any)(any) returns Future.successful(Seq.empty[Instance])
 
-      val response = syncRequest { appsTaskResource.deleteMany(appId, host, scale = false, force = false, wipe = true, auth.request) }
+      val response = asyncRequest { r =>
+        appsTaskResource.deleteMany(appId, host, scale = false, force = false, wipe = true, auth.request, r)
+      }
       response.getStatus shouldEqual 200
       verify(taskKiller).kill(any, any, Matchers.eq(true))(any)
     }
@@ -156,9 +163,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.app(appId) returns Some(AppDefinition(appId))
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
 
-      val response = syncRequest {
+      val response = asyncRequest { r =>
         appsTaskResource.deleteOne(
-          appId.toString, instance1.instanceId.idString, scale = false, force = false, wipe = false, auth.request)
+          appId.toString, instance1.instanceId.idString, scale = false, force = false, wipe = false, auth.request, r)
       }
       response.getStatus shouldEqual 200
 
@@ -193,10 +200,12 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
 
-      val exception = intercept[BadRequestException] {
-        appsTaskResource.deleteOne(appId.toString, id.toString, scale = true, force = false, wipe = true, auth.request)
+      val response = asyncRequest { r =>
+        appsTaskResource.deleteOne(appId.toString, id.toString, scale = true, force = false, wipe = true, auth.request, r)
       }
-      exception.getMessage shouldEqual "You cannot use scale and wipe at the same time."
+
+      response.getStatus should be(400)
+      response.getEntity shouldEqual """{"message":"You cannot use scale and wipe at the same time."}"""
     }
 
     "deleteOne with wipe delegates to taskKiller with wipe value" in new Fixture {
@@ -212,9 +221,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.app(appId) returns Some(AppDefinition(appId))
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
 
-      val response = appsTaskResource.deleteOne(
-        appId.toString, instance1.instanceId.idString, scale = false, force = false, wipe = true, auth.request
-      )
+      val response = asyncRequest { r =>
+        appsTaskResource.deleteOne(appId.toString, instance1.instanceId.idString, scale = false, force = false, wipe = true, auth.request, r)
+      }
       response.getStatus shouldEqual 200
 
       val expected =
@@ -255,7 +264,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
       groupManager.app(appId) returns Some(AppDefinition(appId))
 
-      val response = appsTaskResource.indexJson("/my/app", auth.request)
+      val response = asyncRequest { r => appsTaskResource.indexJson("/my/app", auth.request, r) }
       response.getStatus shouldEqual 200
 
       val expected =
@@ -303,22 +312,26 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.rootGroup() returns createRootGroup()
 
       When("the indexJson is fetched")
-      val indexJson = syncRequest { appsTaskResource.indexJson("", req) }
+      val indexJson = asyncRequest { r => appsTaskResource.indexJson("", req, r) }
       Then("we receive a NotAuthenticated response")
       indexJson.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("the index as txt is fetched")
-      val indexTxt = syncRequest { appsTaskResource.indexTxt("", req) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", req, r) }
       Then("we receive a NotAuthenticated response")
       indexTxt.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("One task is deleted")
-      val deleteOne = syncRequest { appsTaskResource.deleteOne("appId", "taskId", false, false, false, req) }
+      val deleteOne = asyncRequest { r =>
+        appsTaskResource.deleteOne("appId", "taskId", false, false, false, req, r)
+      }
       Then("we receive a NotAuthenticated response")
       deleteOne.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("multiple tasks are deleted")
-      val deleteMany = syncRequest { appsTaskResource.deleteMany("appId", "host", false, false, false, req) }
+      val deleteMany = asyncRequest { r =>
+        appsTaskResource.deleteMany("appId", "host", false, false, false, req, r)
+      }
       Then("we receive a NotAuthenticated response")
       deleteMany.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -334,7 +347,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.app("/app".toRootPath) returns None
 
       When("the indexJson is fetched")
-      val indexJson = syncRequest { appsTaskResource.indexJson("/app", req) }
+      val indexJson = asyncRequest { r => appsTaskResource.indexJson("/app", req, r) }
       Then("we receive a 404")
       indexJson.getStatus should be(404)
     }
@@ -350,7 +363,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.app("/app".toRootPath) returns Some(AppDefinition("/app".toRootPath))
 
       When("the indexJson is fetched")
-      val indexJson = syncRequest { appsTaskResource.indexJson("/app", req) }
+      val indexJson = asyncRequest { r => appsTaskResource.indexJson("/app", req, r) }
       Then("we receive a not authorized response")
       indexJson.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -366,7 +379,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.group("/group".toRootPath) returns None
 
       When("the indexJson is fetched")
-      val indexJson = syncRequest { appsTaskResource.indexJson("/group/*", req) }
+      val indexJson = asyncRequest { r => appsTaskResource.indexJson("/group/*", req, r) }
       Then("we receive a 404")
       indexJson.getStatus should be(404)
     }
@@ -383,7 +396,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the indexJson is fetched")
-      val indexJson = syncRequest { appsTaskResource.indexJson("/group/*", req) }
+      val indexJson = asyncRequest { r => appsTaskResource.indexJson("/group/*", req, r) }
       Then("we receive a not authorized response")
       indexJson.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -399,7 +412,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = syncRequest { appsTaskResource.indexTxt("/app", req) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req, r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -415,7 +428,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = syncRequest { appsTaskResource.indexTxt("/app", req) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req, r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(404)
     }
@@ -432,7 +445,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("deleteOne is called")
-      val deleteOne = syncRequest { appsTaskResource.deleteOne("app", taskId.toString, false, false, false, req) }
+      val deleteOne = asyncRequest { r =>
+        appsTaskResource.deleteOne("app", taskId.toString, false, false, false, req, r)
+      }
       Then("we receive a not authorized response")
       deleteOne.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -449,7 +464,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("deleteOne is called")
-      val deleteOne = syncRequest { appsTaskResource.deleteOne("app", taskId.toString, false, false, false, req) }
+      val deleteOne = asyncRequest { r =>
+        appsTaskResource.deleteOne("app", taskId.toString, false, false, false, req, r)
+      }
       Then("we receive a not authorized response")
       deleteOne.getStatus should be(404)
     }
@@ -465,7 +482,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("deleteMany is called")
-      val deleteMany = syncRequest { appsTaskResource.deleteMany("app", "host", false, false, false, req) }
+      val deleteMany = asyncRequest { r =>
+        appsTaskResource.deleteMany("app", "host", false, false, false, req, r)
+      }
       Then("we receive a not authorized response")
       deleteMany.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -480,7 +499,9 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager.runSpec("/app".toRootPath) returns None
 
       When("deleteMany is called")
-      val deleteMany = syncRequest { appsTaskResource.deleteMany("app", "host", false, false, false, req) }
+      val deleteMany = asyncRequest { r =>
+        appsTaskResource.deleteMany("app", "host", false, false, false, req, r)
+      }
       Then("we receive a not authorized response")
       deleteMany.getStatus should be(404)
     }


### PR DESCRIPTION
Summary:
This removes `RestResource.result` so that all our API endpoints will be
asynchronous.

JIRA issues: MARATHON-8562