### PR TITLE
Chown Marathon after installation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,12 +192,12 @@ lazy val packagingSettings = Seq(
           |apt-get install --no-install-recommends -y mesos=${Dependency.V.MesosDebian} && \\
           |rm /usr/bin/systemctl && \\
           |apt-get clean && \\
-          |chown nobody:nogroup /marathon && \\
-          |chmod a+x /marathon/bin/marathon""".stripMargin)) ++
+          |chown nobody:nogroup /marathon""".stripMargin)) ++
       restCommands ++
       Seq(
         Cmd("ENV", "JAVA_HOME /docker-java-home"),
-        Cmd("RUN", s"""ln -sf /marathon/bin/marathon /marathon/bin/start""".stripMargin))
+        Cmd("RUN", s"""ln -sf /marathon/bin/marathon /marathon/bin/start && \\
+                      |chmod a+x /marathon/bin/marathon""".stripMargin))
   })
 
 lazy val `plugin-interface` = (project in file("plugin-interface"))


### PR DESCRIPTION
Summary:
The Docker build is broken because the permissions where changed before
the installation. This is correct in this diff.