### PR TITLE
Fix `LaunchQueueActor` flake with `lazy`.

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
@@ -58,6 +58,7 @@ class LaunchQueueActorTest extends AkkaUnitTest with ImplicitSender {
       val app = AppDefinition(PathId("/foo"))
       val instance = TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance()
 
+      @volatile
       val instanceTracker = mock[InstanceTracker]
       instanceTracker.instancesBySpec().returns(Future.successful(InstanceTracker.InstancesBySpec.empty))
       val instanceUpdate = InstanceUpdated(instance, None, Seq.empty)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
@@ -58,7 +58,6 @@ class LaunchQueueActorTest extends AkkaUnitTest with ImplicitSender {
       val app = AppDefinition(PathId("/foo"))
       val instance = TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance()
 
-      @volatile
       val instanceTracker = mock[InstanceTracker]
       instanceTracker.instancesBySpec().returns(Future.successful(InstanceTracker.InstancesBySpec.empty))
       val instanceUpdate = InstanceUpdated(instance, None, Seq.empty)
@@ -66,7 +65,7 @@ class LaunchQueueActorTest extends AkkaUnitTest with ImplicitSender {
       groupManager.runSpec(app.id).returns(Some(app))
       val delayUpdates: Source[RateLimiter.DelayUpdate, NotUsed] =
         EnrichedSource.emptyCancellable.mapMaterializedValue { _ => NotUsed }
-      val launchQueue = system.actorOf(
+      lazy val launchQueue = system.actorOf(
         LaunchQueueActor.props(
           config, instanceTracker, groupManager, runSpecActorProps, delayUpdates))
 


### PR DESCRIPTION
Summary:
The mock is set *after* the `LaunchQueueActor` is started in another
thread. There is a tiny chance that the thread won't see any changes to
the mock. With this change we create the actor lazily so that it starts
*after* the mocks are set.

JIRA issues: DCOS_OSS-4898