### PR TITLE
Decommission all instances on service removal

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -191,11 +191,10 @@ private class DeploymentActor(
     await(launchQueue.purge(runSpec.id))
 
     val instances = await(instanceTracker.specInstances(runSpec.id))
-    val launchedInstances = instances.filter(_.isActive)
 
-    logger.info(s"Killing all instances of ${runSpec.id}: ${launchedInstances.map(_.instanceId)}")
-    await(Future.sequence(launchedInstances.map(i => instanceTracker.setGoal(i.instanceId, Goal.Decommissioned))))
-    await(killService.killInstances(launchedInstances, KillReason.DeletingApp))
+    logger.info(s"Killing all instances of ${runSpec.id}: ${instances.map(_.instanceId)}")
+    await(Future.sequence(instances.map(i => instanceTracker.setGoal(i.instanceId, Goal.Decommissioned))))
+    await(killService.killInstances(instances, KillReason.DeletingApp))
 
     launchQueue.resetDelay(runSpec)
 


### PR DESCRIPTION
Summary:
This a fix for a problem that manifests itself rarely on the soak-cluster: sometimes a persistent app with an instance with `TASK_UNKNOWN` condition will be removed but the instance is leaked (stays in the state) which prevents the user from redeploying the app.

Fix:
- Decommission *all* instances (not that it matters in 1.7 but it improves logging) no matter whether they're `Active` or not
- Kill *all* instances (even inactive ones) and leave the details to the `KillStreamWatcher` - it knows how to deal with unknown/unreachable tasks

JIRA: DCOS-49521
