### PR TITLE
Rename `$anon`  to `_app` for missing container.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -9,6 +9,7 @@ import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.plugin.validation.RunSpecValidator
 import mesosphere.marathon.raml._
 import mesosphere.marathon.state.{PathId, ResourceRole, RootGroup}
@@ -156,6 +157,7 @@ trait PodsValidation extends GeneralPurposeCombinators {
 
   def containerValidator(pod: Pod, enabledFeatures: Set[String], mesosMasterVersion: SemanticVersion): Validator[PodContainer] =
     validator[PodContainer] { container =>
+      container.name is notEqualTo(Task.Id.Names.anonymousContainer)
       container.resources is resourceValidator
       container.endpoints is every(endpointValidator(pod.networks))
       container.image is optional(imageValidator(enabledFeatures, pod.secrets))

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -263,8 +263,8 @@ object Task {
     * name. This is the container name specified in the containers section of the run spec.
     *
     * Examples:
-    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon"
-    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon"
+    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._app"
+    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._app"
     *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails"
     *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails"
     *
@@ -289,8 +289,8 @@ object Task {
     * The ids match [[Task.Id.TaskIdWithInstanceIdAndIncarnationRegex]] and include a launch attempt.
     *
     * Examples:
-    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon.1"
-    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon.3"
+    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._app.1"
+    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._app.3"
     *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails.2"
     *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails.42"
     *
@@ -312,7 +312,7 @@ object Task {
   object Id {
 
     object Names {
-      val anonymousContainer = "_anon" // presence of `_` is important since it's illegal for a real container name!
+      val anonymousContainer = "_app" // presence of `_` is important since it's illegal for a real container name!
     }
     // Regular expression for matching taskIds before instance-era
     private val LegacyTaskIdRegex = """^(.+)([\._])([^_\.]+)$""".r

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -263,8 +263,8 @@ object Task {
     * name. This is the container name specified in the containers section of the run spec.
     *
     * Examples:
-    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.$anon"
-    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.$anon"
+    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon"
+    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon"
     *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails"
     *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails"
     *
@@ -289,8 +289,8 @@ object Task {
     * The ids match [[Task.Id.TaskIdWithInstanceIdAndIncarnationRegex]] and include a launch attempt.
     *
     * Examples:
-    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.$anon.1"
-    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.$anon.3"
+    *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon.1"
+    *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon.3"
     *  - "myGroup_myApp.marathon-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails.2"
     *  - "myGroup_myApp.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.rails.42"
     *
@@ -312,15 +312,15 @@ object Task {
   object Id {
 
     object Names {
-      val anonymousContainer = "$anon" // presence of `$` is important since it's illegal for a real container name!
+      val anonymousContainer = "_anon" // presence of `$` is important since it's illegal for a real container name!
     }
     // Regular expression for matching taskIds before instance-era
     private val LegacyTaskIdRegex = """^(.+)([\._])([^_\.]+)$""".r
     private val ResidentTaskIdRegex = """^(.+)([\._])([^_\.]+)(\.)(\d+)$""".r
 
     // Regular expression for matching taskIds since instance-era
-    private val TaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)$""".r
-    private val TaskIdWithInstanceIdAndIncarnationRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^_\.]+)\.(\d+)$""".r
+    private val TaskIdWithInstanceIdRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^\.]+)$""".r
+    private val TaskIdWithInstanceIdAndIncarnationRegex = """^(.+)\.(instance-|marathon-)([^_\.]+)[\._]([^\.]+)\.(\d+)$""".r
 
     /**
       * Parse instance and task id from idString.

--- a/src/main/scala/mesosphere/marathon/core/task/Task.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/Task.scala
@@ -312,7 +312,7 @@ object Task {
   object Id {
 
     object Names {
-      val anonymousContainer = "_anon" // presence of `$` is important since it's illegal for a real container name!
+      val anonymousContainer = "_anon" // presence of `_` is important since it's illegal for a real container name!
     }
     // Regular expression for matching taskIds before instance-era
     private val LegacyTaskIdRegex = """^(.+)([\._])([^_\.]+)$""".r

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -25,7 +25,7 @@ class InstanceIdTest extends UnitTest with Inside {
       val appId = "/test/foo/bla/rest".toPath
       val instanceId = Instance.Id.forRunSpec(appId)
       val taskId = Task.Id(instanceId)
-      taskId.idString should be(instanceId.idString + ".$anon.1")
+      taskId.idString should be(instanceId.idString + "._anon.1")
     }
 
     "be converted to TaskIds with container name" in {
@@ -52,7 +52,7 @@ class InstanceIdTest extends UnitTest with Inside {
     "be converted from TaskIds without a container name" in {
       val appId = "/test/foo/bla/rest".toPath
       val uuid = UUID.fromString("b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6")
-      val parsedTaskId = Task.Id.parse("test_foo_bla_rest.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6.$anon")
+      val parsedTaskId = Task.Id.parse("test_foo_bla_rest.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon")
       parsedTaskId.runSpecId should be(appId)
       parsedTaskId.instanceId should be(Instance.Id(appId, PrefixInstance, uuid))
       inside(parsedTaskId) {

--- a/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/instance/InstanceIdTest.scala
@@ -25,7 +25,7 @@ class InstanceIdTest extends UnitTest with Inside {
       val appId = "/test/foo/bla/rest".toPath
       val instanceId = Instance.Id.forRunSpec(appId)
       val taskId = Task.Id(instanceId)
-      taskId.idString should be(instanceId.idString + "._anon.1")
+      taskId.idString should be(instanceId.idString + "._app.1")
     }
 
     "be converted to TaskIds with container name" in {
@@ -52,7 +52,7 @@ class InstanceIdTest extends UnitTest with Inside {
     "be converted from TaskIds without a container name" in {
       val appId = "/test/foo/bla/rest".toPath
       val uuid = UUID.fromString("b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6")
-      val parsedTaskId = Task.Id.parse("test_foo_bla_rest.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._anon")
+      val parsedTaskId = Task.Id.parse("test_foo_bla_rest.instance-b6ff5fa5-7714-11e7-a55c-5ecf1c4671f6._app")
       parsedTaskId.runSpecId should be(appId)
       parsedTaskId.instanceId should be(Instance.Id(appId, PrefixInstance, uuid))
       inside(parsedTaskId) {

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -35,13 +35,13 @@ class TaskIdTest extends UnitTest with Inside {
     }
 
     "TaskIds with encoded InstanceIds could be encoded" in {
-      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15.$anon").build)
+      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._anon").build)
       taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
       taskId.instanceId.idString should equal("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
     }
 
     "TaskIds with encoded InstanceIds could be encoded even with crucial path ids" in {
-      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15.$anon").build)
+      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._anon").build)
       taskId.runSpecId should equal("/test/foo.instance-/bla/rest".toRootPath)
       taskId.instanceId.idString should equal("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
     }

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -35,13 +35,13 @@ class TaskIdTest extends UnitTest with Inside {
     }
 
     "TaskIds with encoded InstanceIds could be encoded" in {
-      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._anon").build)
+      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._app").build)
       taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
       taskId.instanceId.idString should equal("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
     }
 
     "TaskIds with encoded InstanceIds could be encoded even with crucial path ids" in {
-      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._anon").build)
+      val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._app").build)
       taskId.runSpecId should equal("/test/foo.instance-/bla/rest".toRootPath)
       taskId.instanceId.idString should equal("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
     }


### PR DESCRIPTION
Summary:
Task Ids for Apps was created with `$anon` which was problematic requiring escaping of chars by universe components.   This patch switches to `_app` which does not require escaping.

This is backwards compatible since
* All ephemeral apps where created with `Task.Id.forRunSpec() => LegacyId`.
* All persistent apps use `Task.Id.forRunSpec() => LegacyId` for reservation.
* All persistent apps use `Task.Id.forResidentTask() => LegacyResidentId` for launching.
* All reservation labels use the instance id which does not include a container name.

Since `LegacyId` and `LegacyResidentId` are not using the anonymous container
name in their task ids `$anon` was not used in 1.7 and earlier.

JIRA issues:  MARATHON-8594

Co-authored-by: Karsten Jeschkies <k@jeschkies.xyz>
