### PR TITLE
Force expunge all instances when removing a service

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -196,6 +196,9 @@ private class DeploymentActor(
     await(Future.sequence(instances.map(i => instanceTracker.setGoal(i.instanceId, Goal.Decommissioned))))
     await(killService.killInstances(instances, KillReason.DeletingApp))
 
+    // After killing all instances we expunge them from the state
+    await(Future.sequence(instances.map(i => instanceTracker.forceExpunge(i.instanceId))))
+
     launchQueue.resetDelay(runSpec)
 
     // The tasks will be removed from the InstanceTracker when their termination

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -327,6 +327,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       f.queue.purge(app.id) returns Future.successful(Done)
 
       instanceTracker.specInstances(mockito.Matchers.eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instance))
+      instanceTracker.forceExpunge(any) returns Future.successful(Done)
       system.eventStream.subscribe(probe.ref, classOf[UpgradeEvent])
 
       leadershipTransitionInput.offer(LeadershipTransition.ElectedAsLeaderAndReady)

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -129,6 +129,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       tracker.specInstances(Matchers.eq(app2.id))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
       tracker.specInstances(Matchers.eq(app3.id))(any[ExecutionContext]) returns Future.successful(Seq(instance3_1))
       tracker.specInstances(Matchers.eq(app4.id))(any[ExecutionContext]) returns Future.successful(Seq(instance4_1))
+      tracker.forceExpunge(any) returns Future.successful(Done)
 
       when(queue.add(same(app2New), any[Int])).thenAnswer(new Answer[Future[Done]] {
         def answer(invocation: InvocationOnMock): Future[Done] = {


### PR DESCRIPTION
Summary:
so far we rely on an `OfferMatcherReconciler` to expunge reserved persistent instances after the reservation was destroyed. However, in some cases (e.g. Agent was removed and the task is `TASK_UNKNOWN`) this will never happen, leading to Marathon leaking an instance. With this fix we force expunge instances after killing all tasks *if the app is being removed by the user*

JIRA: DCOS-49521