### PR TITLE
Deprecate AppC in Marathon

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ## Changes to 1.8.xxx
 
+### AppC is now deprecated
+AppC is now deprecated and will be removed in Marathon 1.9
+
 ### Introducing Seccomp capabilities to Marathon Apps and Pods
 
 When running Marathon Apps or Pods it is possible now to configure the `LinuxInfo` in order to define [seccomp](http://man7.org/linux/man-pages/man2/seccomp.2.html) which provides the ability to define container execution in a secure computing state as defined by the profiles at the agent.
@@ -55,7 +58,7 @@ We removed deprecated Kamon based metrics from the code base (see the 1.7.xxx ch
 From now on, apps which uses ids which ends with "restart", "tasks", "versions" won't be valid anymore. Such apps already had broken behavior (for example it wasn't possible to use a `GET /v2/apps` endpoint with them), so we made that constraint more explicit. Existing apps with such names will continue working, however all operations on them (except deletion) will result in an error. Please take care of renaming them before upgrading Marathon.
 ### Standby marathon instances no longer proxy events
 We no longer allow a standby Marathon instance to proxy `/v2/events` from Marathon master. Previously it was possible to use `proxy_events` flag to force Marathon
-to proxy the response from `/v2/events`, now it's deprecated. 
+to proxy the response from `/v2/events`, now it's deprecated.
 
 ### save_tasks_to_launch_timeout was removed
 This option was deprecated since 1.5 and using that have no effect on Marathon. Marathon will no longer start with that option provided.
@@ -77,7 +80,7 @@ reconnect when the connection was dropped by Marathon.
 
 ### New metrics names (breaking change)
 
-To help make it easier for operators to monitor Marathon, substantial semantic improvements to metrics have been made. Old metric names were often unintuitive and unhelpfully exposed internal details of Marathon's code layout. A new naming convention has been adopted and consistently applied. 
+To help make it easier for operators to monitor Marathon, substantial semantic improvements to metrics have been made. Old metric names were often unintuitive and unhelpfully exposed internal details of Marathon's code layout. A new naming convention has been adopted and consistently applied.
 
 This is a breaking change. Operators that were using metric data from Marathon before will need to update their visualizations and alerts to reference the new metric names. The new metric names and descriptions can be found in [our metrics documentation page](https://mesosphere.github.io/marathon/docs/metrics.html).
 
@@ -85,7 +88,7 @@ The old metrics can be re-enabled if needed by passing the command-line argument
 
 ### Default for "kill_retry_timeout" was increased to 30 seconds
 
-Sending frequent kill requests to an agent can in certain cases lead to overloading the Docker daemon (if the tasks are docker containers run by the Docker containerizer). Thirty seconds seems to be a more sensible default here. 
+Sending frequent kill requests to an agent can in certain cases lead to overloading the Docker daemon (if the tasks are docker containers run by the Docker containerizer). Thirty seconds seems to be a more sensible default here.
 
 ### Marathon framework ID generation is now very conservative
 

--- a/docs/docs/native-docker.md
+++ b/docs/docs/native-docker.md
@@ -15,7 +15,7 @@ Marathon enables users to launch containers with container images using two diff
 
 # Universal Container Runtime
 
-The [Universal Container Runtime](http://mesos.apache.org/documentation/latest/container-image) (UCR) extends the Mesos containerizer to support provisioning [Docker](https://docker.com/) container images ([AppC](https://github.com/appc/spec) coming soon). This means that you can use both the Mesos containerizer and other container image types. You can still use the Docker container runtime directly ([instructions are below](#docker-containerizer)), but the Universal Container Runtime supports running Docker images without depending on the Docker Engine, which allows for better integration with Mesos.
+The [Universal Container Runtime](http://mesos.apache.org/documentation/latest/container-image) (UCR) extends the Mesos containerizer to support provisioning [Docker](https://docker.com/) container images ([AppC](https://github.com/appc/spec) which is deprecated in v1.8). This means that you can use both the Mesos containerizer and other container image types. You can still use the Docker container runtime directly ([instructions are below](#docker-containerizer)), but the Universal Container Runtime supports running Docker images without depending on the Docker Engine, which allows for better integration with Mesos.
 
 The following Marathon features _only_ work with the UCR:
 
@@ -27,7 +27,7 @@ The following Marathon features _only_ work with the UCR:
 
 To provision containers with the UCR, specify the container type `MESOS` and a the appropriate object in your application definition. Here, we specify a Docker container with the `docker` object.
 
-The UCR containerizer provides a `pullConfig` parameter with a `secret` field for [authentication with a private Docker registry]({{ site.baseurl }}/docs/native-docker-private-registry.html). 
+The UCR containerizer provides a `pullConfig` parameter with a `secret` field for [authentication with a private Docker registry]({{ site.baseurl }}/docs/native-docker-private-registry.html).
 
 `credential`, with a `principal` and an optional `secret` field to authenticate when downloading the Docker image.
 

--- a/docs/docs/rest-api/public/api/v2/types/appContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/appContainer.raml
@@ -178,6 +178,7 @@ types:
           The container will be pulled, regardless if it is already available
           on the local system
         default: false
+    (pragma.deprecated): Deprecated since Marathon v1.8 and will be removed in v1.9
   Container:
     type: object
     properties:

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -22,6 +22,13 @@ case class DeprecatedFeature(
   * as opposed to simply telling them it is an unknown deprecated feature.
   */
 object DeprecatedFeatures {
+
+  val appC = DeprecatedFeature(
+    "app_c",
+    description = "appC is not supported in Marathon, Please use either Docker or UCR (Mesos) containerizers",
+    softRemoveVersion = SemVer(1, 8, 0),
+    hardRemoveVersion = SemVer(1, 9, 0))
+
   /* Removed */
   val syncProxy = DeprecatedFeature(
     "sync_proxy",
@@ -53,7 +60,7 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 7, 0),
     hardRemoveVersion = SemVer(1, 8, 0))
 
-  def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics)
+  def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC)
 
   def description: String = {
     "  - " + all.map { df =>


### PR DESCRIPTION
Summary:
There is a bunch of code for testing, serialization, conversion and task building etc but I have
never see it used. It was created by coreos which is now owned by RedHat and as of late
2016 is no longer active https://github.com/appc/spec#-disclaimer-.

I confirmed with Jie (author of AppC isolator in Mesos) that AppC is dead to us.
This seems to be the more honorable way to remove code from Marathon.

JIRA issues:
