### PR TITLE
 Introduced global throttling for Marathon health checks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 ## Changes from 1.5.12 to 1.5.14
 
 ## Introduce global throttling to Marathon health checks
-Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here will overload Marathon leading to internal timeouts and unstable behavior.  
+Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.  
 
 ### Fixed Issues
 - [MARATHON-8596](https://jira.mesosphere.com/browse/MARATHON-8596) Introduced global throttling to Marathon health checks 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## Changes from 1.5.12 to 1.5.14
+
+## Introduce global throttling to Marathon health checks
+Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here will overload Marathon leading to internal timeouts and unstable behavior.  
+
+### Fixed Issues
+- [MARATHON-8596](https://jira.mesosphere.com/browse/MARATHON-8596) Introduced global throttling to Marathon health checks 
+
 ## Changes from 1.5.12 to 1.5.13
 
 ### Fixed Issues

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,12 @@
-## Changes from 1.5.12 to 1.5.14
+## Changes from 1.5.13 to 1.5.14
 
 ## Introduce global throttling to Marathon health checks
 Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.  
 
 ### Fixed Issues
-- [MARATHON-8596](https://jira.mesosphere.com/browse/MARATHON-8596) Introduced global throttling to Marathon health checks 
+- [MARATHON-8596](https://jira.mesosphere.com/browse/MARATHON-8596) Introduced global throttling to Marathon health checks
+- [MARATHON-8575](https://jira.mesosphere.com/browse/MARATHON-8575) Fixed a broken migration for app definitions with port mappings protocol "tcp,udp" which is no longer valid and should be "udp,tcp"
+- [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) Fixed a rare bug where a deployment was sometimes not immediately visible through the `v2/deployments` endpoint after creation
 
 ## Changes from 1.5.12 to 1.5.13
 

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -342,6 +342,14 @@ trait MarathonConf
     default = Some(GpuSchedulingBehavior.Undefined),
     validate = validateGpuSchedulingBehavior
   )
+
+  lazy val maxConcurrentMarathonHealthChecks = opt[Int](
+    name = "max_concurrent_marathon_health_checks",
+    descr = "Defines maximum number of concurrent *Marathon* health checks (HTTP/S and TCP). Note that setting a big value" +
+    "here will overload Marathon leading to internal timeouts and unstable behavior.",
+    noshort = true,
+    default = Some(256)
+  )
 }
 
 object MarathonConf extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -191,7 +191,7 @@ class CoreModuleImpl @Inject() (
 
   override lazy val healthModule: HealthModule = new HealthModule(
     actorSystem, taskTerminationModule.taskKillService, eventStream,
-    taskTrackerModule.instanceTracker, groupManagerModule.groupManager)(actorsModule.materializer)
+    taskTrackerModule.instanceTracker, groupManagerModule.groupManager, marathonConf)(actorsModule.materializer)
 
   // GROUP MANAGER
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
@@ -3,7 +3,7 @@ package core.health
 
 import akka.actor.ActorSystem
 import akka.event.EventStream
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.impl.MarathonHealthCheckManager
 import mesosphere.marathon.core.task.termination.KillService
@@ -17,11 +17,13 @@ class HealthModule(
     killService: KillService,
     eventBus: EventStream,
     taskTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) {
+    groupManager: GroupManager,
+    conf: MarathonConf)(implicit mat: ActorMaterializer) {
   lazy val healthCheckManager = new MarathonHealthCheckManager(
     actorSystem,
     killService,
     eventBus,
     taskTracker,
-    groupManager)
+    groupManager,
+    conf)
 }

--- a/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
@@ -23,3 +23,13 @@ case class Unhealthy(
   cause: String,
   time: Timestamp = Timestamp.now(),
   publishEvent: Boolean = true) extends HealthResult
+
+/**
+  * Representing an ignored HTTP response code (see [[MarathonHttpHealthCheck.ignoreHttp1xx]]. Will not update the
+  * health check state and not be published.
+  */
+case class Ignored(
+  instanceId: Instance.Id,
+  version: Timestamp,
+  time: Timestamp = Timestamp.now(),
+  publishEvent: Boolean = false) extends HealthResult

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -41,12 +41,10 @@ private[health] class HealthCheckActor(
         //Start health checking not after the default first health check
         val startAfter = math.min(marathonHealthCheck.interval.toMillis, HealthCheck.DefaultFirstHealthCheckAfter.toMillis).millis
 
+        logger.info(s"Starting health check for ${app.id} version ${app.version} and healthCheck $marathonHealthCheck in $startAfter ms")
+
         Source
           .tick(startAfter, marathonHealthCheck.interval, Tick)
-          .map { t =>
-            logger.info(s"HealthCheck tick for app ${app.id} version ${app.version} and healthCheck $marathonHealthCheck")
-            t
-          }
           .mapAsync(1)(_ => instanceTracker.specInstances(app.id))
           .map { instances =>
             purgeStatusOfDoneInstances(instances)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -1,10 +1,11 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.Done
-import akka.actor.{ Actor, ActorRef, Cancellable, Props }
+import akka.NotUsed
+import akka.actor.{ Actor, ActorRef, Props }
 import akka.event.EventStream
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
@@ -15,113 +16,78 @@ import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
 
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 
 private[health] class HealthCheckActor(
-    app: AppDefinition,
-    appHealthCheckActor: ActorRef,
-    killService: KillService,
-    healthCheck: HealthCheck,
-    instanceTracker: InstanceTracker,
-    eventBus: EventStream)(implicit mat: Materializer) extends Actor with StrictLogging {
+  app: AppDefinition,
+  appHealthCheckActor: ActorRef,
+  killService: KillService,
+  healthCheck: HealthCheck,
+  instanceTracker: InstanceTracker,
+  eventBus: EventStream,
+  healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer)
+    extends Actor with StrictLogging {
 
-  import HealthCheckWorker.HealthCheckJob
   import context.dispatcher
 
-  var nextScheduledCheck: Option[Cancellable] = None
-  var healthByInstanceId = Map.empty[Instance.Id, Health]
-
-  val workerProps: Props = Props(classOf[HealthCheckWorkerActor], mat)
+  var healthByInstanceId = TrieMap.empty[Instance.Id, Health]
 
   override def preStart(): Unit = {
-    logger.info(
-      "Starting health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
-    //Start health checking not after the default first health check
-    val start = math.min(healthCheck.interval.toMillis, HealthCheck.DefaultFirstHealthCheckAfter.toMillis).millis
-    scheduleNextHealthCheck(Some(start))
-  }
+    healthCheck match {
+      case marathonHealthCheck: MarathonHealthCheck =>
+        //Start health checking not after the default first health check
+        val startAfter = math.min(marathonHealthCheck.interval.toMillis, HealthCheck.DefaultFirstHealthCheckAfter.toMillis).millis
 
-  override def preRestart(reason: Throwable, message: Option[Any]): Unit =
-    logger.info(
-      "Restarting health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
+        Source
+          .tick(startAfter, marathonHealthCheck.interval, Tick)
+          .map { t =>
+            logger.info(s"HealthCheck tick for app ${app.id} version ${app.version} and healthCheck $marathonHealthCheck")
+            t
+          }
+          .mapAsync(1)(_ => instanceTracker.specInstances(app.id))
+          .map { instances =>
+            purgeStatusOfDoneInstances(instances)
+            instances.collect {
+              case instance if instance.runSpecVersion == app.version && instance.isRunning =>
+                logger.debug("Making a health check request for {}", instance.instanceId)
+                (app, instance, marathonHealthCheck, self)
+            }
+          }
+          .mapConcat(identity)
+          .watchTermination(){ (_, done) =>
+            done.onComplete {
+              case Success(_) =>
+                logger.info(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck was stopped")
+                self ! 'restart
 
-  override def postStop(): Unit = {
-    nextScheduledCheck.forall { _.cancel() }
-    logger.info(
-      "Stopped health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
-  }
-
-  def updateInstances(): Future[Done] = {
-    instanceTracker.specInstances(app.id).map { instances =>
-      self ! InstancesUpdate(version = app.version, instances = instances)
-      Done
-    }.recover {
-      case t =>
-        logger.error(s"An error has occurred: ${t.getMessage}", t)
-        Done
+              case Failure(ex) =>
+                logger.warn(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck crashed due to:", ex)
+                self ! 'restart
+            }
+          }
+          .runWith(healthCheckHub)
+      case _ => // Don't do anything for Mesos health checks
     }
   }
 
   def purgeStatusOfDoneInstances(instances: Seq[Instance]): Unit = {
-    logger.debug(
-      "Purging health status of inactive instances for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
+    logger.debug(s"Purging health status of inactive instances for app ${app.id} version ${app.version} and healthCheck ${healthCheck}")
+
     val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isLaunched).map(_.instanceId)(collection.breakOut)
     // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
     // Therefore we materialize it into a new map.
-    healthByInstanceId = healthByInstanceId.filterKeys(activeInstanceIds).iterator.toMap
+    activeInstanceIds.foreach { activeId =>
+      healthByInstanceId.remove(activeId)
+    }
 
-    val hcToPurge = instances.withFilter(!_.isActive).map(instance => {
+    val checksToPurge = instances.withFilter(!_.isActive).map(instance => {
       val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)
       (instanceKey, healthCheck)
     })
-    appHealthCheckActor ! PurgeHealthCheckStatuses(hcToPurge)
-  }
-
-  def scheduleNextHealthCheck(interval: Option[FiniteDuration] = None): Unit = healthCheck match {
-    case hc: MarathonHealthCheck =>
-      logger.debug(
-        "Scheduling next health check for app [{}] version [{}] and healthCheck [{}]",
-        app.id,
-        app.version,
-        hc
-      )
-      nextScheduledCheck = Some(
-        context.system.scheduler.scheduleOnce(interval.getOrElse(hc.interval)) {
-          self ! Tick
-        }
-      )
-    case _ => // Don't do anything for Mesos health checks
-  }
-
-  def dispatchJobs(instances: Seq[Instance]): Unit = healthCheck match {
-    case hc: MarathonHealthCheck =>
-      logger.debug("Dispatching health check jobs to workers")
-      instances.foreach { instance =>
-        if (instance.runSpecVersion == app.version && instance.isRunning) {
-          logger.debug("Dispatching health check job for {}", instance.instanceId)
-          val worker: ActorRef = context.actorOf(workerProps)
-          worker ! HealthCheckJob(app, instance, hc)
-        }
-      }
-    case _ => // Don't do anything for Mesos health checks
+    appHealthCheckActor ! PurgeHealthCheckStatuses(checksToPurge)
   }
 
   def checkConsecutiveFailures(instance: Instance, health: Health): Unit = {
@@ -175,9 +141,9 @@ private[health] class HealthCheckActor(
 
     val updatedHealth = result match {
       case Healthy(_, _, _, _) =>
-        Future(health.update(result))
+        Future.successful(health.update(result))
       case Unhealthy(_, _, _, _, _) =>
-        instanceTracker.instance(instanceId).map({
+        instanceTracker.instance(instanceId).map {
           case Some(instance) =>
             if (ignoreFailures(instance, health)) {
               // Don't update health
@@ -193,7 +159,9 @@ private[health] class HealthCheckActor(
           case None =>
             logger.error(s"Couldn't find instance $instanceId")
             health.update(result)
-        })
+        }
+      case _: Ignored =>
+        Future.successful(health) // Ignore and keep the old health
     }
     updatedHealth.onComplete {
       case Success(newHealth) => self ! InstanceHealth(result, health, newHealth)
@@ -222,25 +190,14 @@ private[health] class HealthCheckActor(
     case GetAppHealth =>
       sender() ! AppHealth(healthByInstanceId.values.to[Seq])
 
-    case Tick =>
-      updateInstances().andThen{ case _ => self ! ScheduleNextHealthCheck() }
-
-    case ScheduleNextHealthCheck(interval) =>
-      scheduleNextHealthCheck(interval)
-
-    case InstancesUpdate(version, instances) if version == app.version =>
-      purgeStatusOfDoneInstances(instances)
-      dispatchJobs(instances)
-
     case result: HealthResult if result.version == app.version =>
       handleHealthResult(result)
 
     case instanceHealth: InstanceHealth =>
       updateInstanceHealth(instanceHealth)
 
-    case result: HealthResult =>
-      logger.warn(s"Ignoring health result [$result] due to version mismatch.")
-
+    case 'restart =>
+      throw new RuntimeException("HealthCheckActor stream stopped, restarting")
   }
 }
 
@@ -251,7 +208,8 @@ object HealthCheckActor {
     killService: KillService,
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
-    eventBus: EventStream)(implicit mat: Materializer): Props = {
+    eventBus: EventStream,
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer): Props = {
 
     Props(new HealthCheckActor(
       app,
@@ -259,18 +217,17 @@ object HealthCheckActor {
       killService,
       healthCheck,
       instanceTracker,
-      eventBus))
+      eventBus,
+      healthCheckHub))
   }
 
   // self-sent every healthCheck.intervalSeconds
   case object Tick
   case class GetInstanceHealth(instanceId: Instance.Id)
   case object GetAppHealth
-  case class ScheduleNextHealthCheck(interval: Option[FiniteDuration] = None)
 
   case class AppHealth(health: Seq[Health])
 
   case class InstanceHealth(result: HealthResult, health: Health, newHealth: Health)
   case class InstancesUpdate(version: Timestamp, instances: Seq[Instance])
-
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorker.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorker.scala
@@ -3,87 +3,80 @@ package core.health.impl
 
 import java.net.{ InetSocketAddress, Socket }
 import java.security.cert.X509Certificate
-import javax.net.ssl.{ KeyManager, SSLContext, X509TrustManager }
 
-import akka.actor.{ Actor, ActorSystem, PoisonPill }
+import akka.actor.ActorSystem
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, headers }
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.{ ConnectionContext, Http }
+import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
-import akka.stream.{ ActorMaterializer, ActorMaterializerSettings, Materializer }
 import com.typesafe.scalalogging.StrictLogging
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import javax.net.ssl.{ KeyManager, SSLContext, X509TrustManager }
+import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
 import mesosphere.util.ThreadPoolContext
 
-import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success }
+import scala.util.{ Failure, Success, Try }
 
-class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with StrictLogging {
+object HealthCheckWorker extends StrictLogging {
 
-  import HealthCheckWorker._
-
-  private implicit val system = context.system
-  private implicit val scheduler = system.scheduler
-  import context.dispatcher // execution context for futures
-  private implicit val materializer = ActorMaterializer(ActorMaterializerSettings(system))
-
-  def receive: Receive = {
-    case HealthCheckJob(app, instance, check) =>
-      val replyTo = sender() // avoids closing over the volatile sender ref
-
-      doCheck(app, instance, check)
-        .andThen {
-          case Success(Some(result)) => replyTo ! result
-          case Success(None) => // ignore
-          case Failure(t) =>
-            logger.warn(s"Performing health check for app=${app.id} instance=${instance.instanceId} port=${check.port} failed with exception", t)
-            replyTo ! Unhealthy(
-              instance.instanceId,
-              instance.runSpecVersion,
-              s"${t.getClass.getSimpleName}: ${t.getMessage}"
-            )
-        }
-        .onComplete { _ => self ! PoisonPill }
+  implicit class RichFuture[T](f: Future[T])(implicit ec: ExecutionContext) {
+    def mapAll[U](pf: PartialFunction[Try[T], U]): Future[U] = {
+      val p = Promise[U]()
+      f.onComplete(r => p.complete(Try(pf(r))))
+      p.future
+    }
   }
 
-  def doCheck(
-    app: AppDefinition, instance: Instance, check: MarathonHealthCheck): Future[Option[HealthResult]] = {
+  def run(app: AppDefinition, instance: Instance, healthCheck: MarathonHealthCheck)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+    logger.debug("Dispatching health check job for {}", instance.instanceId)
+
+    implicit val system = mat.system
+    implicit val ex = mat.executionContext
+
+    check(app, instance, healthCheck)
+      .mapAll {
+        case Success(result) => result
+        case Failure(ex) =>
+          logger.warn(s"Performing health check for app=${app.id} instance=${instance.instanceId} port=${healthCheck.port} failed with exception", ex)
+          Unhealthy(
+            instance.instanceId,
+            instance.runSpecVersion,
+            s"${ex.getClass.getSimpleName}: ${ex.getMessage}"
+          )
+      }
+  }
+
+  def check(
+    app: AppDefinition,
+    instance: Instance,
+    healthCheck: MarathonHealthCheck)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
     // HealthChecks are only supported for legacy App instances with exactly one task
     val effectiveIpAddress = instance.appTask.status.networkInfo.effectiveIpAddress(app)
     effectiveIpAddress match {
       case Some(host) =>
-        val maybePort = check.effectivePort(app, instance)
-        (check, maybePort) match {
+        val maybePort = healthCheck.effectivePort(app, instance)
+        (healthCheck, maybePort) match {
           case (hc: MarathonHttpHealthCheck, Some(port)) =>
             hc.protocol match {
-              case Protos.HealthCheckDefinition.Protocol.HTTPS => https(instance, hc, host, port)
-              case Protos.HealthCheckDefinition.Protocol.HTTP => http(instance, hc, host, port)
-              case invalidProtocol: Protos.HealthCheckDefinition.Protocol =>
-                Future.failed {
-                  val message = s"Health check failed: HTTP health check contains invalid protocol: $invalidProtocol"
-                  logger.warn(message)
-                  new UnsupportedOperationException(message)
-                }
+              case Protocol.HTTPS => https(instance, hc, host, port)
+              case Protocol.HTTP => http(instance, hc, host, port)
+              case invalid =>
+                Future.failed (new UnsupportedOperationException(s"Health check failed: HTTP health check contains invalid protocol: $invalid"))
             }
           case (hc: MarathonTcpHealthCheck, Some(port)) => tcp(instance, hc, host, port)
-          case _ => Future.failed {
-            val message = "Health check failed: unable to get the task's effectivePort"
-            logger.warn(message)
-            new UnsupportedOperationException(message)
-          }
+          case _ => Future.failed(new UnsupportedOperationException("Health check failed: unable to get the task's effectivePort"))
         }
       case None =>
-        Future.failed {
-          val message = "Health check failed: unable to get the task's effective IP address"
-          logger.warn(message)
-          new UnsupportedOperationException(message)
-        }
+        Future.failed(new UnsupportedOperationException("Health check failed: unable to get the task's effective IP address"))
     }
   }
 
@@ -91,30 +84,32 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     instance: Instance,
     check: MarathonHttpHealthCheck,
     host: String,
-    port: Int): Future[Option[HealthResult]] = {
+    port: Int)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
+    implicit val ec = mat.executionContext
+
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"http://$host:$port$absolutePath"
     logger.debug(s"Checking the health of [$url] for instance=${instance.instanceId} via HTTP")
 
-    singleRequest(
-      RequestBuilding.Get(url),
-      check.timeout
-    ).map { response =>
+    singleRequest(RequestBuilding.Get(url), check.timeout)
+      .map { response =>
         response.discardEntityBytes() //forget about the body
         if (acceptableResponses.contains(response.status.intValue())) {
-          Some(Healthy(instance.instanceId, instance.runSpecVersion))
+          Healthy(instance.instanceId, instance.runSpecVersion)
         } else if (check.ignoreHttp1xx && (toIgnoreResponses.contains(response.status.intValue))) {
           logger.debug(s"Ignoring health check HTTP response ${response.status.intValue} for instance=${instance.instanceId}")
-          None
+          Ignored(instance.instanceId, instance.runSpecVersion)
         } else {
           logger.debug(s"Health check for instance=${instance.instanceId} responded with ${response.status}")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
+          Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString())
         }
-      }.recover {
+      }
+      .recover {
         case NonFatal(e) =>
           logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
+          Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage)
       }
   }
 
@@ -122,7 +117,8 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     instance: Instance,
     check: MarathonTcpHealthCheck,
     host: String,
-    port: Int): Future[Option[HealthResult]] = {
+    port: Int)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
     val address = s"$host:$port"
     val timeoutMillis = check.timeout.toMillis.toInt
     logger.debug(s"Checking the health of [$address] for instance=${instance.instanceId} via TCP")
@@ -134,7 +130,7 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
         socket.connect(address, timeoutMillis)
         socket.close()
       }
-      Some(Healthy(instance.instanceId, instance.runSpecVersion, Timestamp.now()))
+      Healthy(instance.instanceId, instance.runSpecVersion, Timestamp.now())
     }(ThreadPoolContext.ioContext)
   }
 
@@ -142,32 +138,35 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     instance: Instance,
     check: MarathonHttpHealthCheck,
     host: String,
-    port: Int): Future[Option[HealthResult]] = {
+    port: Int)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
+    implicit val ec = mat.executionContext
 
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"https://$host:$port$absolutePath"
     logger.debug(s"Checking the health of [$url] for instance=${instance.instanceId} via HTTPS")
 
-    singleRequestHttps(
-      RequestBuilding.Get(url),
-      check.timeout
-    ).map { response =>
+    singleRequestHttps(RequestBuilding.Get(url), check.timeout)
+      .map { response =>
         response.discardEntityBytes() // forget about the body
         if (acceptableResponses.contains(response.status.intValue())) {
-          Some(Healthy(instance.instanceId, instance.runSpecVersion))
+          Healthy(instance.instanceId, instance.runSpecVersion)
         } else {
           logger.debug(s"Health check for ${instance.instanceId} responded with ${response.status}")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
+          Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString())
         }
-      }.recover {
+      }
+      .recover {
         case NonFatal(e) =>
-          logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
+          logger.debug(s"Health check for instance=${instance.instanceId} failed to respond due to ${e.getMessage}.")
+          Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage)
       }
   }
 
-  def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: Materializer): Future[HttpResponse] = {
+  def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: ActorMaterializer): Future[HttpResponse] = {
+    implicit val system = mat.system
+
     val host = httpRequest.uri.authority.host.toString()
     val port = httpRequest.uri.effectivePort
     val hostHeader = headers.Host(host, port)
@@ -183,7 +182,9 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     Source.single(effectiveRequest).via(connectionFlow).runWith(Sink.head)
   }
 
-  def singleRequestHttps(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: Materializer): Future[HttpResponse] = {
+  def singleRequestHttps(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: ActorMaterializer): Future[HttpResponse] = {
+    implicit val system = mat.system
+
     val host = httpRequest.uri.authority.host.toString()
     val port = httpRequest.uri.effectivePort
     val hostHeader = headers.Host(host, port)
@@ -199,10 +200,6 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     )
     Source.single(effectiveRequest).via(connectionFlow).runWith(Sink.head)
   }
-}
-
-@SuppressWarnings(Array("NullParameter"))
-object HealthCheckWorker {
 
   // Similar to AWS R53, we accept all responses in [200, 399]
   protected[health] val acceptableResponses = Range(200, 400)
@@ -224,7 +221,7 @@ object HealthCheckWorker {
     context
   }
 
-  def disabledSslConfig()(implicit as: ActorSystem) = AkkaSSLConfig().mapSettings(s => s.withLoose {
+  def disabledSslConfig()(implicit as: ActorSystem): AkkaSSLConfig = AkkaSSLConfig().mapSettings(s => s.withLoose {
     s.loose.withAcceptAnyCertificate(true)
       .withAllowLegacyHelloMessages(Some(true))
       .withAllowUnsafeRenegotiation(Some(true))

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorker.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorker.scala
@@ -19,21 +19,14 @@ import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
 import mesosphere.util.ThreadPoolContext
+import mesosphere.marathon.util.toRichFuture
 
+import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 
 object HealthCheckWorker extends StrictLogging {
-
-  implicit class RichFuture[T](f: Future[T])(implicit ec: ExecutionContext) {
-    def mapAll[U](pf: PartialFunction[Try[T], U]): Future[U] = {
-      val p = Promise[U]()
-      f.onComplete(r => p.complete(Try(pf(r))))
-      p.future
-    }
-  }
 
   def run(app: AppDefinition, instance: Instance, healthCheck: MarathonHealthCheck)(implicit mat: ActorMaterializer): Future[HealthResult] = {
     logger.debug("Dispatching health check job for {}", instance.instanceId)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -1,12 +1,14 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.Done
 import akka.actor.{ ActorRef, ActorRefFactory }
 import akka.event.EventStream
 import akka.pattern.ask
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ MergeHub, Sink }
 import akka.util.Timeout
+import akka.{ Done, NotUsed }
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.async.ExecutionContexts.global
 import mesosphere.marathon.core.event.{ AddHealthCheck, RemoveHealthCheck }
 import mesosphere.marathon.core.group.GroupManager
@@ -26,13 +28,15 @@ import scala.collection.immutable.{ Map, Seq }
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 class MarathonHealthCheckManager(
     actorRefFactory: ActorRefFactory,
     killService: KillService,
     eventBus: EventStream,
     instanceTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) extends HealthCheckManager {
+    groupManager: GroupManager,
+    conf: MarathonConf)(implicit mat: ActorMaterializer) extends HealthCheckManager with StrictLogging {
 
   protected[this] case class ActiveHealthCheck(
     healthCheck: HealthCheck,
@@ -51,6 +55,32 @@ class MarathonHealthCheckManager(
       ahcs(appId).values.flatten.toSet
     }
 
+  /**
+    * A common materialized merge hub that is used by all [[HealthCheckActor]]s to channel the Marathon health checks.
+    * Its main purpose is to provide a global throttling mechanism that limit a total number of concurrent Marathon
+    * health check in the system defined by [[MarathonConf.maxConcurrentMarathonHealthChecks]] parameter. After
+    * executing the health check by calling the [[HealthCheckWorker.run()]] method the result is sent back to the
+    * HealthCheckActor via the provided ActorRef.
+    */
+  val healthCheckWorkerHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed] =
+    MergeHub
+      .source[(AppDefinition, Instance, MarathonHealthCheck, ActorRef)](1)
+      .mapAsync(conf.maxConcurrentMarathonHealthChecks()){
+        case (app, instance, marathonHealthCheck, actorRef) =>
+          HealthCheckWorker
+            .run(app, instance, marathonHealthCheck)
+            .map(healthResult => actorRef ! healthResult)
+            .recover {
+              // Theoretically we should never get there: [[HealthCheckWorker.run]] already wraps failed health checks into
+              // successful futures with Healthy/Unhealthy message. But just in case the underlying implementation changes...
+              case NonFatal(e) =>
+                logger.warn(s"HealthCheck stream for app ${app.id} version ${app.version} " +
+                  s"and healthCheck $marathonHealthCheck failed with: ", e)
+            }
+      }
+      .to(Sink.ignore)
+      .run()
+
   protected[this] def listActive(appId: PathId, appVersion: Timestamp): Set[ActiveHealthCheck] =
     appHealthChecks.readLock { ahcs =>
       ahcs(appId)(appVersion)
@@ -66,7 +96,7 @@ class MarathonHealthCheckManager(
         log.info(s"Adding health check for app [${app.id}] and version [${app.version}]: [$healthCheck]")
 
         val ref = actorRefFactory.actorOf(
-          HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus))
+          HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus, healthCheckWorkerHub))
         val newHealthChecksForApp =
           healthChecksForApp + ActiveHealthCheck(healthCheck, ref)
 
@@ -151,7 +181,7 @@ class MarathonHealthCheckManager(
 
     def reconcileApp(app: AppDefinition, instances: Seq[Instance]): Future[Done] = {
       val appId = app.id
-      log.info(s"reconcile [$appId] with latest version [${app.version}]")
+      log.info(s"reconcile $appId with latest version ${app.version} for instances: $instances")
 
       val instancesByVersion = instances.groupBy(_.version)
 

--- a/src/main/scala/mesosphere/marathon/util/RichFuture.scala
+++ b/src/main/scala/mesosphere/marathon/util/RichFuture.scala
@@ -3,7 +3,7 @@ package util
 
 import mesosphere.marathon.core.async.ExecutionContexts
 
-import scala.concurrent.{ Future, Promise }
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.Try
 
 class RichFuture[T](val future: Future[T]) extends AnyVal {
@@ -18,5 +18,11 @@ class RichFuture[T](val future: Future[T]) extends AnyVal {
       x: Try[T] => promise.success(x)
     }(ExecutionContexts.callerThread)
     promise.future
+  }
+
+  def mapAll[U](pf: PartialFunction[Try[T], U])(implicit ec: ExecutionContext): Future[U] = {
+    val p = Promise[U]()
+    future.onComplete(r => p.complete(Try(pf(r))))
+    p.future
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -1,111 +1,100 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.actor.Props
+import akka.NotUsed
+import akka.actor.{ ActorRef, Props }
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ MergeHub, Sink }
 import akka.testkit._
 import mesosphere.AkkaUnitTest
-import mesosphere.marathon.core.health.{ Health, HealthCheck, MarathonHttpHealthCheck, PortReference }
-import mesosphere.marathon.core.instance.TestInstanceBuilder
+import mesosphere.marathon.core.health.impl.AppHealthCheckActor.PurgeHealthCheckStatuses
+import mesosphere.marathon.core.health.{ Health, HealthCheck, Healthy, MarathonHealthCheck, MarathonHttpHealthCheck, PortReference }
+import mesosphere.marathon.core.instance.{ Instance, TestInstanceBuilder }
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.{ KillReason, KillService }
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{ AppDefinition, Timestamp }
-import mesosphere.marathon.storage.repository.AppRepository
-import org.apache.mesos.SchedulerDriver
-import org.mockito.Mockito.{ verifyNoMoreInteractions, when }
+import org.mockito.Mockito.verifyNoMoreInteractions
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class HealthCheckActorTest extends AkkaUnitTest {
   class Fixture {
-    val tracker = mock[InstanceTracker]
+    implicit val mat: ActorMaterializer = ActorMaterializer()
+
+    val instanceTracker = mock[InstanceTracker]
 
     val appId = "/test".toPath
     val appVersion = Timestamp(1)
     val app = AppDefinition(id = appId)
-    val appRepository: AppRepository = mock[AppRepository]
-    val holder: MarathonSchedulerDriverHolder = new MarathonSchedulerDriverHolder
-    val driver = mock[SchedulerDriver]
-    holder.driver = Some(driver)
-    when(appRepository.getVersion(appId, appVersion.toOffsetDateTime)).thenReturn(Future.successful(Some(app)))
     val killService: KillService = mock[KillService]
-    when(appRepository.getVersion(appId, appVersion.toOffsetDateTime)).thenReturn(Future.successful(Some(app)))
 
     val scheduler: MarathonScheduler = mock[MarathonScheduler]
 
     val instanceBuilder = TestInstanceBuilder.newBuilder(appId, version = appVersion).addTaskRunning()
     val instance = instanceBuilder.getInstance()
-    val appHealthCheckActor = TestProbe()
 
+    val appHealthCheckActor = TestProbe()
+    val healthCheck = MarathonHttpHealthCheck(portIndex = Some(PortReference(0)), interval = 1.second)
     val task: Task = instance.appTask
 
     val unreachableInstance = TestInstanceBuilder.newBuilder(appId).addTaskUnreachable().getInstance()
-    val unreachableTask: Task = unreachableInstance.appTask
+    val lostInstance = TestInstanceBuilder.newBuilder(appId).addTaskLost().getInstance()
+
+    val healthCheckWorkerHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed] =
+      MergeHub
+        .source[(AppDefinition, Instance, MarathonHealthCheck, ActorRef)](1)
+        .map { case (_, instance, _, ref) => ref ! Healthy(instance.instanceId, Timestamp.now()) }
+        .to(Sink.ignore)
+        .run()
 
     def actor(healthCheck: HealthCheck) = TestActorRef[HealthCheckActor](
       Props(
-        new HealthCheckActor(app, appHealthCheckActor.ref, killService, healthCheck, tracker, system.eventStream)
+        new HealthCheckActor(app, appHealthCheckActor.ref, killService, healthCheck, instanceTracker, system.eventStream, healthCheckWorkerHub)
       )
     )
 
-    def actorWithLatch(latch: TestLatch) = TestActorRef[HealthCheckActor](
+    def healthCheckActor() = TestActorRef[HealthCheckActor](
       Props(
         new HealthCheckActor(
           app,
           appHealthCheckActor.ref,
           killService,
-          MarathonHttpHealthCheck(portIndex = Some(PortReference(0))),
-          tracker,
-          system.eventStream) {
-
-          override val workerProps = Props {
-            latch.countDown()
-            new TestActors.EchoActor
-          }
+          healthCheck,
+          instanceTracker,
+          system.eventStream,
+          healthCheckWorkerHub) {
         }
       )
     )
   }
 
   "HealthCheckActor" should {
-    // regression test for #934
-    "should not dispatch health checks for staging tasks" in {
-      val f = new Fixture
-      val latch = TestLatch(1)
-      val appId = "/test".toPath
-      val appVersion = Timestamp(1)
-      val app = AppDefinition(id = appId)
-      val appRepository: AppRepository = mock[AppRepository]
+    //regression test for #934
+    "should not dispatch health checks for staging tasks" in new Fixture {
+      instanceTracker.specInstances(any)(any) returns Future.successful(Seq(instance))
 
-      when(appRepository.getVersion(appId, appVersion.toOffsetDateTime)).thenReturn(Future.successful(Some(app)))
+      val actor = healthCheckActor()
 
-      val actor = f.actorWithLatch(latch)
-      actor.underlyingActor.dispatchJobs(Seq(f.instance))
-      latch.isOpen should be (false)
-      verifyNoMoreInteractions(f.driver)
+      appHealthCheckActor.expectMsgAllClassOf(classOf[PurgeHealthCheckStatuses])
     }
 
-    "should not dispatch health checks for lost tasks" in {
-      val f = new Fixture
-      val latch = TestLatch(1)
+    "should not dispatch health checks for lost tasks" in new Fixture {
+      instanceTracker.specInstances(any)(any) returns Future.successful(Seq(lostInstance))
 
-      val actor = f.actorWithLatch(latch)
+      val actor = healthCheckActor()
 
-      actor.underlyingActor.dispatchJobs(Seq(f.unreachableInstance))
-      latch.isOpen should be (false)
-      verifyNoMoreInteractions(f.driver)
+      appHealthCheckActor.expectMsgAllClassOf(classOf[PurgeHealthCheckStatuses])
     }
 
-    "should not dispatch health checks for unreachable tasks" in {
-      val f = new Fixture
-      val latch = TestLatch(1)
+    "should not dispatch health checks for unreachable tasks" in new Fixture {
+      instanceTracker.specInstances(any)(any) returns Future.successful(Seq(unreachableInstance))
 
-      val actor = f.actorWithLatch(latch)
+      val actor = healthCheckActor()
 
-      actor.underlyingActor.dispatchJobs(Seq(f.unreachableInstance))
-      latch.isOpen should be (false)
-      verifyNoMoreInteractions(f.driver)
+      appHealthCheckActor.expectMsgAllClassOf(classOf[PurgeHealthCheckStatuses])
     }
 
     // regression test for #1456
@@ -115,7 +104,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
 
       actor.underlyingActor.checkConsecutiveFailures(f.instance, Health(f.instance.instanceId, consecutiveFailures = 3))
       verify(f.killService).killInstancesAndForget(Seq(f.instance), KillReason.FailedHealthChecks)
-      verifyNoMoreInteractions(f.tracker, f.driver, f.scheduler)
+      verifyNoMoreInteractions(f.instanceTracker, f.scheduler)
     }
 
     "task should not be killed if health check fails, but the task is unreachable" in {
@@ -123,7 +112,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
       val actor = f.actor(MarathonHttpHealthCheck(maxConsecutiveFailures = 3, portIndex = Some(PortReference(0))))
 
       actor.underlyingActor.checkConsecutiveFailures(f.unreachableInstance, Health(f.unreachableInstance.instanceId, consecutiveFailures = 3))
-      verifyNoMoreInteractions(f.tracker, f.driver, f.scheduler)
+      verifyNoMoreInteractions(f.instanceTracker, f.scheduler)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.event.EventStream
+import akka.stream.ActorMaterializer
 import com.typesafe.config.{ Config, ConfigFactory }
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.group.GroupManager
@@ -32,6 +33,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
   private val clock = new SettableClock()
 
   case class Fixture() {
+    implicit val mat: ActorMaterializer = ActorMaterializer()
     val leadershipModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
     val taskTrackerModule: InstanceTrackerModule = MarathonTestHelper.createTaskTrackerModule(leadershipModule)
     val taskTracker: InstanceTracker = taskTrackerModule.instanceTracker
@@ -40,12 +42,15 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
     val groupManager: GroupManager = mock[GroupManager]
     implicit val eventStream: EventStream = new EventStream(system)
     val killService: KillService = mock[KillService]
+    val conf = MarathonTestHelper.defaultConfig()
+
     implicit val hcManager: MarathonHealthCheckManager = new MarathonHealthCheckManager(
       system,
       killService,
       eventStream,
       taskTracker,
-      groupManager
+      groupManager,
+      conf
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -321,7 +321,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
     "an unhealthy app fails to deploy because health checks takes too long to pass" in {
       Given("a new app that is not healthy")
       val id = appId(Some("unhealthy-fails-to-deploy-because-health-check-takes-too-long"))
-      registerAppProxyHealthCheck(id, "v1", state = true).withHealthAction(_ => Thread.sleep(20000))
+      val check = registerAppProxyHealthCheck(id, "v1", state = false)
       val app = appProxy(id, "v1", instances = 1, healthCheck = Some(appProxyHealthCheck().copy(timeoutSeconds = 2)))
 
       When("The app is deployed")
@@ -338,6 +338,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
           callbackEvent.eventType == "failed_health_check_event"
       )
 
+      check.afterDelay(20.seconds, true)
       for (event <- Iterator.continually(interestingEvent()).take(10)) {
         event.eventType should be("failed_health_check_event")
       }


### PR DESCRIPTION
Summary:
- introduced a new command line argument `--max_concurrent_marathon_health_checks` that defines the maximum number of concurrent *Marathon* health checks (HTTP/S and TCP)
- internally all Marathon health checks are now using the same materialized akka-stream MergeHub which throttles the health checks
- `HealthCheckWorkerActor` became `HealthCheckWorker` returning a `Future[HealthResult]`

JIRA issues: MARATHON-8596
