### PR TITLE
Map `tcp,udp` to `udp,tcp` during migration. (#6827)

### DIFF
--- a/src/main/scala/mesosphere/marathon/raml/NetworkConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/NetworkConversion.scala
@@ -40,7 +40,12 @@ trait NetworkConversion {
   }
 
   implicit val protocolWrites: Writes[String, NetworkProtocol] = Writes { protocol =>
-    NetworkProtocol.fromString(protocol).getOrElse(throw new IllegalStateException(s"unsupported protocol $protocol"))
+    // Regression MARATHON-8575
+    if (protocol == "tcp,udp") {
+      NetworkProtocol.UdpTcp
+    } else {
+      NetworkProtocol.fromString(protocol).getOrElse(throw new IllegalStateException(s"unsupported protocol $protocol"))
+    }
   }
 
   implicit val portDefinitionWrites: Writes[state.PortDefinition, PortDefinition] = Writes { port =>

--- a/src/test/scala/mesosphere/marathon/raml/NetworkConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/NetworkConversionTest.scala
@@ -23,6 +23,7 @@ class NetworkConversionTest extends UnitTest {
       "tcp".toRaml[NetworkProtocol] should be(NetworkProtocol.Tcp)
       "udp".toRaml[NetworkProtocol] should be(NetworkProtocol.Udp)
       "udp,tcp".toRaml[NetworkProtocol] should be(NetworkProtocol.UdpTcp)
+      "tcp,udp".toRaml[NetworkProtocol] should be(NetworkProtocol.UdpTcp)
     }
   }
   "NetworkConversion port definition conversion" should {


### PR DESCRIPTION
Summary:
Marathon 1.4 would accept `tcp,udp` as a protocol in Docker port
mappings. However, that value is illegal. It breaks migrations to 1.5
and up. This patch will fix the migration.

Forward port of #6827.

JIRA issues: MARATHON-8575