### PR TITLE
Don't self-pipe done in TaskLauncherActor

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -197,7 +197,6 @@ private class TaskLauncherActor(
               await(instanceTracker.forceExpunge(instance.instanceId)): @silent
               await(instanceTracker.schedule(Instance.scheduled(instance.runSpec)))
             }
-            Status.Success(s"Rescheduled ${instance.instanceId} due to provision timeout.")
           }.failed.map(Status.Failure).pipeTo(self)
         }
       }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -142,6 +142,8 @@ private class TaskLauncherActor(
   }
 
   private[this] def receiveUnknown: Receive = {
+    case Status.Success(msg) =>
+      logger.debug(s"TaskLauncherActor received a success from ${sender}; ${msg}")
     case Status.Failure(ex) =>
       logger.error(s"TaskLauncherActor received a failure from ${sender}", ex)
 
@@ -197,6 +199,7 @@ private class TaskLauncherActor(
               await(instanceTracker.forceExpunge(instance.instanceId)): @silent
               await(instanceTracker.schedule(Instance.scheduled(instance.runSpec)))
             }
+            Status.Success(s"Rescheduled ${instance.instanceId} due to provision timeout.")
           } pipeTo self
         }
       }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActor.scala
@@ -142,8 +142,6 @@ private class TaskLauncherActor(
   }
 
   private[this] def receiveUnknown: Receive = {
-    case Status.Success(msg) =>
-      logger.debug(s"TaskLauncherActor received a success from ${sender}; ${msg}")
     case Status.Failure(ex) =>
       logger.error(s"TaskLauncherActor received a failure from ${sender}", ex)
 
@@ -200,7 +198,7 @@ private class TaskLauncherActor(
               await(instanceTracker.schedule(Instance.scheduled(instance.runSpec)))
             }
             Status.Success(s"Rescheduled ${instance.instanceId} due to provision timeout.")
-          } pipeTo self
+          }.failed.map(Status.Failure).pipeTo(self)
         }
       }
 


### PR DESCRIPTION
We only self-pipe the failure so we can log it.