### PR TITLE
Ignore out of date Jessie repos. (#6857)

### DIFF
--- a/tests/package/README.md
+++ b/tests/package/README.md
@@ -22,18 +22,20 @@ Build with:
 ```
 cd {marathon_project_dir}
 rm -rf target/packages
-sbt docker:publishLocal packageLinux
+sbt docker:publishLocal
+cd tools/packager
+make clean all -j
 ```
 
 ### 2) Build the test bed docker images
 
 There are docker images created for:
 
-  * centos systemd
-  * centos systemv
-  * debian systemd
-  * debian systemv
-  * ubuntu upstart
+  * Centos 6
+  * Centos 7
+  * Debian 8
+  * Ubuntu 14.04
+  * Ubuntu 16.04
 
 The Dockerfiles for these images in subfolders of this directory.  
 These test bed docker images must be built prior to running the tests. If you don't build them, the tests will fail.
@@ -66,7 +68,7 @@ If you wanted to run just the DebianSystemd test, you could run:
 
 ```
 # case-insensitive substring filter
-amm test.sc debiansystemd
+amm test.sc Ubuntu1604Test
 ```
 
 # Debugging
@@ -74,7 +76,7 @@ amm test.sc debiansystemd
 If you wanted to the docker images to stay running for further debugging, then use the filter to run a single suite and set the environment variable to disable cleanup:
 
 ```
-SKIP_CLEANUP=1 amm test.sc debiansystemd
+SKIP_CLEANUP=1 amm test.sc Ubuntu1604Test
 ```
 
 The docker containers will be left running after the suite runs, so you can `docker exec` in to them and check things out.

--- a/tests/package/debian8/Dockerfile
+++ b/tests/package/debian8/Dockerfile
@@ -3,10 +3,10 @@ FROM debian:jessie
 COPY ./mesos-version /mesos-version
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF && \
-    echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
     echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-    apt-get update && \
+    apt-get -o Acquire::Check-Valid-Until=false update && \
     # this MUST be done first, unfortunately, because Mesos packages will create folders that should be symlinks and break the python install process
     apt-get install python2.7-minimal -y && \
     apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20161107~bpo8+1 && \

--- a/tests/package/mesos/Dockerfile
+++ b/tests/package/mesos/Dockerfile
@@ -2,7 +2,7 @@ FROM marathon-package-test:debian8
 
 COPY zookeeper.service /lib/systemd/system
 
-RUN apt-get update && \
+RUN apt-get -o Acquire::Check-Valid-Until=false update && \
   apt-get install -y curl zookeeper && \
   systemctl enable zookeeper && \
   systemctl enable mesos-master

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -170,7 +170,7 @@ trait Debian8Container extends MesosTest {
     System.err.println(s"Installing package...")
     // install the package
     execBashWithoutCapture(systemd.containerId, s"""
-      apt-get update
+      apt-get update -o Acquire::Check-Valid-Until=false
       echo
       echo "We expect this to fail, due to dependencies missing:"
       echo


### PR DESCRIPTION
Summary:
The Marathon package tests fail because we cannot provision the test
Docker images. This is because the jessie-backports have been
deprecated. We should update to Debian 9 and drop support for Debian 8
at some point.