### PR TITLE
Ignore out of date Jessie repos.

### DIFF
--- a/tests/package/debian-systemd/Dockerfile
+++ b/tests/package/debian-systemd/Dockerfile
@@ -3,10 +3,10 @@ FROM debian:jessie
 COPY ./mesos-version /mesos-version
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF && \
-    echo "deb http://ftp.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
     echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-    apt-get update && \
+    apt-get -o Acquire::Check-Valid-Until=false update && \
     # this MUST be done first, unfortunately, because Mesos packages will create folders that should be symlinks and break the python install process
     apt-get install python2.7-minimal -y && \
     apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20161107~bpo8+1 && \

--- a/tests/package/mesos/Dockerfile
+++ b/tests/package/mesos/Dockerfile
@@ -2,7 +2,7 @@ FROM marathon-package-test:debian-systemd
 
 COPY zookeeper.service /lib/systemd/system
 
-RUN apt-get update && \
+RUN apt-get update -o Acquire::Check-Valid-Until=false && \
   apt-get install -y curl zookeeper && \
   systemctl enable zookeeper && \
   systemctl enable mesos-master

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -114,7 +114,7 @@ class DebianSystemdTest extends MesosTest {
     System.err.println(s"Installing package...")
     // install the package
     execBashWithoutCapture(systemd.containerId, """
-      apt-get update
+      apt-get update -o Acquire::Check-Valid-Until=false
       echo
       echo "We expect this to fail, due to dependencies missing:"
       echo


### PR DESCRIPTION
Summary:
The Marathon package tests fail because we cannot provision the test
Docker images. This is because the jessie-backports have been
deprecated. We should update to Debian 9 and drop support for Debian 8
at some point.

Backport of #6857.