### PR TITLE
Use Java 8 for building.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ ansiColor('xterm') {
             string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY')
         ]) {
+	    sh """sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"""
             sh """sudo -E ci/pipeline jenkins"""
         }
       } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ ansiColor('xterm') {
             string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY')
         ]) {
-	    sh """sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"""
+            sh """sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"""
             sh """sudo -E ci/pipeline jenkins"""
         }
       } finally {


### PR DESCRIPTION
Summary:
The change from mesosphere/mesos-plugin#23 installs Java 11 on our
Jenkins nodes. If the node does not terminate a Marathon build will end
up using Java 11 instead of Java 11. According to ToolsInfra nodes
should used only once. In DCOS_OSS-4605 I reported that this is not the
case but it was dismissed. The ticket has been reopened. Until that is
fixed we have to use this work around.