### PR TITLE
 Introduced global throttling for Marathon health checks (#6850)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ## Changes to 1.8.xxx
 
+### Introduce global throttling to Marathon health checks
+Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.  
+
 ### `--gpu_scheduling_behavior` default is now `restricted`; `undefined` is deprecated and will be removed
 
 The default GPU Scheduling Behavior has been changed to `restricted`, and `undefined` has been deprecated and will be removed in `1.9.x`. Operators with GPU clusters that are upgrading to Marathon 1.8.x should think carefully about their desired policy and set accordingly; as a general rule:

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -318,6 +318,14 @@ trait MarathonConf
       Left(s"${groupVersionsCacheSize.name} must be more than 2 times higher than ${maxRunningDeployments.name}")
     }
   }
+
+  lazy val maxConcurrentMarathonHealthChecks = opt[Int](
+    name = "max_concurrent_marathon_health_checks",
+    descr = "Defines maximum number of concurrent *Marathon* health checks (HTTP/S and TCP). Note that setting a big value" +
+      "here will overload Marathon leading to internal timeouts and unstable behavior.",
+    noshort = true,
+    default = Some(256)
+  )
 }
 
 object MarathonConf extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -213,7 +213,7 @@ class CoreModuleImpl @Inject() (
 
   override lazy val healthModule: HealthModule = new HealthModule(
     actorSystem, taskTerminationModule.taskKillService, eventStream,
-    instanceTrackerModule.instanceTracker, groupManagerModule.groupManager)(actorsModule.materializer)
+    instanceTrackerModule.instanceTracker, groupManagerModule.groupManager, marathonConf)(actorsModule.materializer)
 
   // GROUP MANAGER
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
@@ -3,7 +3,7 @@ package core.health
 
 import akka.actor.ActorSystem
 import akka.event.EventStream
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.impl.MarathonHealthCheckManager
 import mesosphere.marathon.core.task.termination.KillService
@@ -17,11 +17,13 @@ class HealthModule(
     killService: KillService,
     eventBus: EventStream,
     taskTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) {
+    groupManager: GroupManager,
+    conf: MarathonConf)(implicit mat: ActorMaterializer) {
   lazy val healthCheckManager = new MarathonHealthCheckManager(
     actorSystem,
     killService,
     eventBus,
     taskTracker,
-    groupManager)
+    groupManager,
+    conf)
 }

--- a/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
@@ -23,3 +23,13 @@ case class Unhealthy(
     cause: String,
     time: Timestamp = Timestamp.now(),
     publishEvent: Boolean = true) extends HealthResult
+
+/**
+  * Representing an ignored HTTP response code (see [[MarathonHttpHealthCheck.ignoreHttp1xx]]. Will not update the
+  * health check state and not be published.
+  */
+case class Ignored(
+    instanceId: Instance.Id,
+    version: Timestamp,
+    time: Timestamp = Timestamp.now(),
+    publishEvent: Boolean = false) extends HealthResult

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
@@ -2,15 +2,16 @@ package mesosphere.marathon
 package core.health.impl
 
 import java.net.{InetAddress, ServerSocket}
+import java.util.UUID
 
-import akka.actor.Props
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
-import akka.testkit.{ImplicitSender, TestActorRef}
+import akka.stream.ActorMaterializer
+import akka.testkit.ImplicitSender
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.{Goal, Instance, TestTaskBuilder, TestInstanceBuilder}
+import mesosphere.marathon.core.instance._
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{AppDefinition, PathId, PortDefinition, UnreachableStrategy}
@@ -18,12 +19,10 @@ import mesosphere.marathon.state.{AppDefinition, PathId, PortDefinition, Unreach
 import scala.collection.immutable.Seq
 import scala.concurrent.{Future, Promise}
 
-class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
+class HealthCheckWorkerTest extends AkkaUnitTest with ImplicitSender {
 
-  import HealthCheckWorker._
-
-  "HealthCheckWorkerActor" should {
-    "A TCP health check should correctly resolve the hostname" in {
+  "HealthCheckWorker" should {
+    "A TCP health check should correctly resolve the hostname and return a Healthy result" in {
       val socket = new ServerSocket(0)
       val socketPort: Int = socket.getLocalPort
 
@@ -31,7 +30,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
         socket.accept().close()
       }
 
-      val appId = PathId("/test_id")
+      val appId = PathId(s"/app-with-tcp-health-check-${UUID.randomUUID()}")
       val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
       val hostName = InetAddress.getLocalHost.getCanonicalHostName
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
@@ -42,48 +41,13 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       }
       val instance = TestInstanceBuilder.fromTask(task, agentInfo, UnreachableStrategy.default())
 
-      val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
+      val resF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))(mat.asInstanceOf[ActorMaterializer])
 
       try { res.futureValue }
       finally { socket.close() }
 
-      expectMsgPF(patienceConfig.timeout) {
-        case Healthy(_, _, _, _) => ()
-      }
-    }
-
-    "A health check worker should shut itself down" in {
-      val socket = new ServerSocket(0)
-      val socketPort: Int = socket.getLocalPort
-
-      val res = Future {
-        socket.accept().close()
-      }
-
-      val appId = PathId("/test_id")
-      val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
-      val hostName = InetAddress.getLocalHost.getCanonicalHostName
-      val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
-      val task = {
-        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
-        val hostPorts = Seq(socketPort)
-        t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
-      }
-      val instance = TestInstanceBuilder.fromTask(task, agentInfo, UnreachableStrategy.default())
-
-      val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
-
-      try { res.futureValue }
-      finally { socket.close() }
-
-      expectMsgPF(patienceConfig.timeout) {
-        case _: HealthResult => ()
-      }
-
-      watch(ref)
-      expectTerminated(ref)
+      resF.futureValue shouldBe a[Healthy]
     }
 
     "A HTTP health check should work as expected" in {
@@ -110,7 +74,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       val port = binding.localAddress.getPort
 
       val hostName = "localhost"
-      val appId = PathId("/test_id")
+      val appId = PathId(s"/app-with-http-health-check-${UUID.randomUUID()}")
       val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
       val task = {
@@ -125,16 +89,16 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
 
       val instance = Instance(task.taskId.instanceId, Some(agentInfo), state, tasksMap, app, None)
 
-      val ref = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))
-      expectMsgClass(classOf[Healthy])
+      val resF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))(mat.asInstanceOf[ActorMaterializer])
 
+      resF.futureValue shouldBe a[Healthy]
       promise.future.futureValue shouldEqual "success"
 
-      val unhealthy = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
-      unhealthy ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/unhealthy")))
-      expectMsgClass(classOf[Unhealthy])
+      val unhealthyResF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonHttpHealthCheck(port = Some(port), path = Some("/unhealthy")))(mat.asInstanceOf[ActorMaterializer])
 
+      unhealthyResF.futureValue shouldBe a[Unhealthy]
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.event.EventStream
+import akka.stream.ActorMaterializer
 import com.typesafe.config.{Config, ConfigFactory}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.group.GroupManager
@@ -36,18 +37,22 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
   private val clock = new SettableClock()
 
   case class Fixture() {
+    implicit val mat: ActorMaterializer = ActorMaterializer()
     val leadershipModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
     val instanceTrackerModule: InstanceTrackerModule = MarathonTestHelper.createTaskTrackerModule(leadershipModule)
     implicit val instanceTracker: InstanceTracker = instanceTrackerModule.instanceTracker
     val groupManager: GroupManager = mock[GroupManager]
     implicit val eventStream: EventStream = new EventStream(system)
     val killService: KillService = mock[KillService]
+    val conf = MarathonTestHelper.defaultConfig()
+
     implicit val hcManager: MarathonHealthCheckManager = new MarathonHealthCheckManager(
       system,
       killService,
       eventStream,
       instanceTracker,
-      groupManager
+      groupManager,
+      conf
     )
   }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -365,7 +365,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
     "an unhealthy app fails to deploy because health checks takes too long to pass" in {
       Given("a new app that is not healthy")
       val id = appId(Some("unhealthy-fails-to-deploy-because-health-check-takes-too-long"))
-      registerAppProxyHealthCheck(id, "v1", state = true).withHealthAction(_ => Thread.sleep(20000))
+      val check = registerAppProxyHealthCheck(id, "v1", state = false)
       val app = appProxy(id, "v1", instances = 1, healthCheck = Some(appProxyHealthCheck().copy(timeoutSeconds = 2)))
 
       When("The app is deployed")
@@ -382,6 +382,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
           callbackEvent.eventType == "failed_health_check_event"
       )
 
+      check.afterDelay(20.seconds, true)
       for (event <- Iterator.continually(interestingEvent()).take(10)) {
         event.eventType should be("failed_health_check_event")
       }


### PR DESCRIPTION
Summary:
- introduced a new command line argument `--max_concurrent_marathon_health_checks`
  that defines the maximum number of concurrent *Marathon* health checks (HTTP/S and TCP)
- internally all Marathon health checks are now using the same materialized akka-stream
  MergeHub which throttles the health checks
- `HealthCheckWorkerActor` became `HealthCheckWorker` returning a `Future[HealthResult]`

JIRA issues: MARATHON-8596