### PR TITLE
Ignore volumes with unknown disk type.

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
+++ b/src/main/scala/mesosphere/marathon/api/serialization/ContainerSerializer.scala
@@ -177,6 +177,8 @@ object PersistentVolumeInfoSerializer {
         builder.setType(mesos.Protos.Resource.DiskInfo.Source.Type.PATH)
       case DiskType.Mount =>
         builder.setType(mesos.Protos.Resource.DiskInfo.Source.Type.MOUNT)
+      case DiskType.Unkown(_) =>
+        ()
     }
     builder.addAllConstraints(info.constraints.asJava)
     info.maxSize.foreach(builder.setMaxSize)

--- a/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
@@ -180,7 +180,7 @@ trait VolumeConversion extends ConstraintConversion with DefaultConversions {
     }
 
   implicit val appPersistentVolTypeProtoRamlWriter: Writes[Mesos.Resource.DiskInfo.Source.Type, PersistentVolumeType] = Writes { typ =>
-    import Mesos.Resource.DiskInfo.Source.Type._
+    import Mesos.Resource.DiskInfo.Source.Type.{MOUNT, PATH}
     typ match {
       case MOUNT => PersistentVolumeType.Mount
       case PATH => PersistentVolumeType.Path

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -204,7 +204,7 @@ object DiskType {
       case None => DiskType.Root
       case Some(Source.Type.PATH) => DiskType.Path
       case Some(Source.Type.MOUNT) => DiskType.Mount
-      case Some(other) => Unkown(other)
+      //      case Some(other) => Unkown(other)
     }
 }
 

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -204,7 +204,7 @@ object DiskType {
       case None => DiskType.Root
       case Some(Source.Type.PATH) => DiskType.Path
       case Some(Source.Type.MOUNT) => DiskType.Mount
-      //      case Some(other) => Unkown(other)
+      case Some(other) => Unkown(other)
     }
 }
 

--- a/src/main/scala/mesosphere/marathon/state/Volume.scala
+++ b/src/main/scala/mesosphere/marathon/state/Volume.scala
@@ -194,14 +194,17 @@ object DiskType {
     def toMesos: Option[Source.Type] = Some(Source.Type.MOUNT)
   }
 
-  val all: List[DiskType] = Root :: Path :: Mount :: Nil
+  case class Unkown(sourceType: Source.Type) extends DiskType {
+    override def toString: String = "unknown"
+    def toMesos: Option[Source.Type] = Some(sourceType)
+  }
 
   def fromMesosType(o: Option[Source.Type]): DiskType =
     o match {
       case None => DiskType.Root
       case Some(Source.Type.PATH) => DiskType.Path
       case Some(Source.Type.MOUNT) => DiskType.Mount
-      case Some(other) => throw new RuntimeException(s"unknown mesos disk type: $other")
+      case Some(other) => Unkown(other)
     }
 }
 

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -333,6 +333,8 @@ object ResourceMatcher extends StrictLogging {
         resources.sortBy(_.size)(implicitly[Ordering[Double]].reverse)
       case DiskType.Mount =>
         resources.sortBy(_.size)
+      case DiskType.Unkown(_) =>
+        Nil
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -188,7 +188,7 @@ object MarathonTestHelper {
 
   def rawSource(path: String): Mesos.Resource.DiskInfo.Source = {
     val b = Mesos.Resource.DiskInfo.Source.newBuilder.
-      setType(Mesos.Resource.DiskInfo.Source.Type.PATH).
+      setType(Mesos.Resource.DiskInfo.Source.Type.RAW).
       setPath(Mesos.Resource.DiskInfo.Source.Path.newBuilder.setRoot(path))
     b.build
   }

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -186,6 +186,19 @@ object MarathonTestHelper {
   def pathDisk(path: String): Mesos.Resource.DiskInfo =
     pathDisk(Some(path))
 
+  def rawSource(path: String): Mesos.Resource.DiskInfo.Source = {
+    val b = Mesos.Resource.DiskInfo.Source.newBuilder.
+      setType(Mesos.Resource.DiskInfo.Source.Type.PATH).
+      setPath(Mesos.Resource.DiskInfo.Source.Path.newBuilder.setRoot(path))
+    b.build
+  }
+
+  def rawDisk(path: String): Mesos.Resource.DiskInfo = {
+    Mesos.Resource.DiskInfo.newBuilder.
+      setSource(rawSource(path)).
+      build()
+  }
+
   def scalarResource(
     name: String, d: Double, role: String = ResourceRole.Unreserved,
     providerId: Option[protos.ResourceProviderID] = None, reservation: Option[ReservationInfo] = None,

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -1025,23 +1025,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         .addResources(MarathonTestHelper.scalarResource("disk", 1024.0, disk = Some(MarathonTestHelper.rawDisk("/path"))))
         .build()
 
-      val volume = VolumeWithMount(
-        PersistentVolume(
-          name = None,
-          persistent = PersistentVolumeInfo(
-            size = 128,
-            `type` = DiskType.Path)),
-        VolumeMount(None, "/var/lib/data"))
-
-      val app = AppDefinition(
-        id = "/test".toRootPath,
-        resources = Resources(
-          cpus = 1.0,
-          mem = 128.0,
-          disk = 0.0),
-        container = Some(Container.Mesos(
-          volumes = List(volume))),
-        versionInfo = OnlyVersion(Timestamp(2)))
+      val app = MarathonTestHelper.appWithPersistentVolume()
 
       val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty, localRegion = None)
 


### PR DESCRIPTION
Summary:
If an offer includes a disk type other than `PATH` and `MOUNT` we
are ignoring the disk.

JIRA issues: MARATHON-8590