### PR TITLE
Introduced global throttling for Marathon health checks.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,38 +1,7 @@
 ## Changes to 1.7.XXX
 
 ### Introduce global throttling to Marathon health checks
-Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.  
-
-### `--gpu_scheduling_behavior` default is now `restricted`; `undefined` is deprecated and will be removed
-
-The default GPU Scheduling Behavior has been changed to `restricted`, and `undefined` has been deprecated and will be removed in `1.9.x`. Operators with GPU clusters that are upgrading to Marathon 1.8.x should think carefully about their desired policy and set accordingly; as a general rule:
-
-* You only need to configure `--gpu_scheduling_behavior` if Marathon is GPU enabled (`--enable_features gpu_resources`).
-* If you are using GPUs, and most nodes have GPUs, set the `unrestricted`.
-* If you are using GPUs, and most nodes do not have GPUs, set to `restricted` (the default).
-
-For more information on `gpu_scheduling_behavior`, please see [the docs](https://mesosphere.github.io/marathon/docs/preferential-gpu-scheduling.html)
-
-### Upgrades only from Marathon 1.6+
-
-You can only upgrade to Marathon 1.8 from 1.6.x and 1.7.x. If you'd like to upgrade from an earlier version you should
-upgrade to Marathon 1.6 or 1.7 first.
-
-### /v2/events
-The default (and only) response format of the `/v2/events` is always "light". This is in accordance with the previously published deprecation plan. If `--deprecated_features=api_heavy_events` is still specified, Marathon will refuse to launch, with an error.
-
-### Removed deprecated metrics
-We removed deprecated Kamon based metrics from the code base (see the 1.7.xxx changelog for details on new metrics). This led to removal of deprecated command line arguments e.g. old reporters like `--reporter_graphite`, `--reporter_datadog`, `--reporter_datadog` and `--metrics_averaging_window`.
-
-### Apps names restrictions (breaking change)
-From now on, apps which uses ids which ends with "restart", "tasks", "versions" won't be valid anymore. Such apps already had broken behavior (for example it wasn't possible to use a `GET /v2/apps` endpoint with them), so we made that constraint more explicit. Existing apps with such names will continue working, however all operations on them (except deletion) will result in an error. Please take care of renaming them before upgrading Marathon.
-### Standby marathon instances no longer proxy events
-We no longer allow a standby Marathon instance to proxy `/v2/events` from Marathon master. Previously it was possible to use `proxy_events` flag to force Marathon
-to proxy the response from `/v2/events`, now it's deprecated. 
-
-### Fixed issues
-
-- [MARATHON-8482](https://jira.mesosphere.com/browse/MARATHON-8482) - We fixed a possibly incorrect behavior around killing overdue tasks: `--task_launch_confirm_timeout` parameter properly controls the time the task spends in `Provisioned` stage (between being launched and receiving `TASK_STAGING` status update).
+Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.
 
 - [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) - We fixed a race condition causing `v2/deployments` not containing a confirmed deployment after HTTP 200/201 response was returned.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,39 @@
 ## Changes to 1.7.XXX
+## Changes to 1.8.xxx
+
+### Introduce global throttling to Marathon health checks
+Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.  
+
+### `--gpu_scheduling_behavior` default is now `restricted`; `undefined` is deprecated and will be removed
+
+The default GPU Scheduling Behavior has been changed to `restricted`, and `undefined` has been deprecated and will be removed in `1.9.x`. Operators with GPU clusters that are upgrading to Marathon 1.8.x should think carefully about their desired policy and set accordingly; as a general rule:
+
+* You only need to configure `--gpu_scheduling_behavior` if Marathon is GPU enabled (`--enable_features gpu_resources`).
+* If you are using GPUs, and most nodes have GPUs, set the `unrestricted`.
+* If you are using GPUs, and most nodes do not have GPUs, set to `restricted` (the default).
+
+For more information on `gpu_scheduling_behavior`, please see [the docs](https://mesosphere.github.io/marathon/docs/preferential-gpu-scheduling.html)
+
+### Upgrades only from Marathon 1.6+
+
+You can only upgrade to Marathon 1.8 from 1.6.x and 1.7.x. If you'd like to upgrade from an earlier version you should
+upgrade to Marathon 1.6 or 1.7 first.
+
+### /v2/events
+The default (and only) response format of the `/v2/events` is always "light". This is in accordance with the previously published deprecation plan. If `--deprecated_features=api_heavy_events` is still specified, Marathon will refuse to launch, with an error.
+
+### Removed deprecated metrics
+We removed deprecated Kamon based metrics from the code base (see the 1.7.xxx changelog for details on new metrics). This led to removal of deprecated command line arguments e.g. old reporters like `--reporter_graphite`, `--reporter_datadog`, `--reporter_datadog` and `--metrics_averaging_window`.
+
+### Apps names restrictions (breaking change)
+From now on, apps which uses ids which ends with "restart", "tasks", "versions" won't be valid anymore. Such apps already had broken behavior (for example it wasn't possible to use a `GET /v2/apps` endpoint with them), so we made that constraint more explicit. Existing apps with such names will continue working, however all operations on them (except deletion) will result in an error. Please take care of renaming them before upgrading Marathon.
+### Standby marathon instances no longer proxy events
+We no longer allow a standby Marathon instance to proxy `/v2/events` from Marathon master. Previously it was possible to use `proxy_events` flag to force Marathon
+to proxy the response from `/v2/events`, now it's deprecated. 
+
+### Fixed issues
+
+- [MARATHON-8482](https://jira.mesosphere.com/browse/MARATHON-8482) - We fixed a possibly incorrect behavior around killing overdue tasks: `--task_launch_confirm_timeout` parameter properly controls the time the task spends in `Provisioned` stage (between being launched and receiving `TASK_STAGING` status update).
 
 - [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) - We fixed a race condition causing `v2/deployments` not containing a confirmed deployment after HTTP 200/201 response was returned.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,4 @@
 ## Changes to 1.7.XXX
-## Changes to 1.8.xxx
 
 ### Introduce global throttling to Marathon health checks
 Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.  

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -332,6 +332,14 @@ trait MarathonConf
       Left(s"${groupVersionsCacheSize.name} must be more than 2 times higher than ${maxRunningDeployments.name}")
     }
   }
+
+  lazy val maxConcurrentMarathonHealthChecks = opt[Int](
+    name = "max_concurrent_marathon_health_checks",
+    descr = "Defines maximum number of concurrent *Marathon* health checks (HTTP/S and TCP). Note that setting a big value" +
+      "here will overload Marathon leading to internal timeouts and unstable behavior.",
+    noshort = true,
+    default = Some(256)
+  )
 }
 
 object MarathonConf extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -266,7 +266,7 @@ class CoreModuleImpl @Inject() (
 
   override lazy val healthModule: HealthModule = new HealthModule(
     actorSystem, taskTerminationModule.taskKillService, eventStream,
-    instanceTrackerModule.instanceTracker, groupManagerModule.groupManager)(actorsModule.materializer)
+    instanceTrackerModule.instanceTracker, groupManagerModule.groupManager, marathonConf)(actorsModule.materializer)
 
   // GROUP MANAGER
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
@@ -3,7 +3,7 @@ package core.health
 
 import akka.actor.ActorSystem
 import akka.event.EventStream
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.impl.MarathonHealthCheckManager
 import mesosphere.marathon.core.task.termination.KillService
@@ -17,11 +17,13 @@ class HealthModule(
     killService: KillService,
     eventBus: EventStream,
     taskTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) {
+    groupManager: GroupManager,
+    conf: MarathonConf)(implicit mat: ActorMaterializer) {
   lazy val healthCheckManager = new MarathonHealthCheckManager(
     actorSystem,
     killService,
     eventBus,
     taskTracker,
-    groupManager)
+    groupManager,
+    conf)
 }

--- a/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
@@ -23,3 +23,13 @@ case class Unhealthy(
     cause: String,
     time: Timestamp = Timestamp.now(),
     publishEvent: Boolean = true) extends HealthResult
+
+/**
+  * Representing an ignored HTTP response code (see [[MarathonHttpHealthCheck.ignoreHttp1xx]]. Will not update the
+  * health check state and not be published.
+  */
+case class Ignored(
+    instanceId: Instance.Id,
+    version: Timestamp,
+    time: Timestamp = Timestamp.now(),
+    publishEvent: Boolean = false) extends HealthResult

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -206,7 +206,7 @@ object HealthCheckActor {
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
     eventBus: EventStream,
-    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer): Props = {
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed]): Props = {
 
     Props(new HealthCheckActor(
       app,

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -28,9 +28,10 @@ private[health] class HealthCheckActor(
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
     eventBus: EventStream,
-    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer)
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])
   extends Actor with StrictLogging {
 
+  implicit val mat = ActorMaterializer()
   import context.dispatcher
 
   var healthByInstanceId = TrieMap.empty[Instance.Id, Health]

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -1,10 +1,11 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.Done
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.NotUsed
+import akka.actor.{Actor, ActorRef, Props}
 import akka.event.EventStream
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
@@ -15,6 +16,7 @@ import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{AppDefinition, Timestamp}
 
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -25,103 +27,65 @@ private[health] class HealthCheckActor(
     killService: KillService,
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
-    eventBus: EventStream)(implicit mat: Materializer) extends Actor with StrictLogging {
+    eventBus: EventStream,
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer)
+  extends Actor with StrictLogging {
 
-  import HealthCheckWorker.HealthCheckJob
   import context.dispatcher
 
-  var nextScheduledCheck: Option[Cancellable] = None
-  var healthByInstanceId = Map.empty[Instance.Id, Health]
-
-  val workerProps: Props = Props(classOf[HealthCheckWorkerActor], mat)
+  var healthByInstanceId = TrieMap.empty[Instance.Id, Health]
 
   override def preStart(): Unit = {
-    logger.info(
-      "Starting health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
-    //Start health checking not after the default first health check
-    val start = math.min(healthCheck.interval.toMillis, HealthCheck.DefaultFirstHealthCheckAfter.toMillis).millis
-    scheduleNextHealthCheck(Some(start))
-  }
+    healthCheck match {
+      case marathonHealthCheck: MarathonHealthCheck =>
+        //Start health checking not after the default first health check
+        val startAfter = math.min(marathonHealthCheck.interval.toMillis, HealthCheck.DefaultFirstHealthCheckAfter.toMillis).millis
 
-  override def preRestart(reason: Throwable, message: Option[Any]): Unit =
-    logger.info(
-      "Restarting health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
+        logger.info(s"Starting health check for ${app.id} version ${app.version} and healthCheck $marathonHealthCheck in $startAfter ms")
 
-  override def postStop(): Unit = {
-    nextScheduledCheck.forall { _.cancel() }
-    logger.info(
-      "Stopped health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
-  }
+        Source
+          .tick(startAfter, marathonHealthCheck.interval, Tick)
+          .mapAsync(1)(_ => instanceTracker.specInstances(app.id))
+          .map { instances =>
+            purgeStatusOfDoneInstances(instances)
+            instances.collect {
+              case instance if instance.runSpecVersion == app.version && instance.isRunning =>
+                logger.debug("Making a health check request for {}", instance.instanceId)
+                (app, instance, marathonHealthCheck, self)
+            }
+          }
+          .mapConcat(identity)
+          .watchTermination(){ (_, done) =>
+            done.onComplete {
+              case Success(_) =>
+                logger.info(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck was stopped")
+                self ! 'restart
 
-  def updateInstances(): Future[Done] = {
-    instanceTracker.specInstances(app.id).map { instances =>
-      self ! InstancesUpdate(version = app.version, instances = instances)
-      Done
-    }.recover {
-      case t =>
-        logger.error(s"An error has occurred: ${t.getMessage}", t)
-        Done
+              case Failure(ex) =>
+                logger.warn(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck crashed due to:", ex)
+                self ! 'restart
+            }
+          }
+          .runWith(healthCheckHub)
+      case _ => // Don't do anything for Mesos health checks
     }
   }
 
   def purgeStatusOfDoneInstances(instances: Seq[Instance]): Unit = {
-    logger.debug(
-      "Purging health status of inactive instances for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
+    logger.debug(s"Purging health status of inactive instances for app ${app.id} version ${app.version} and healthCheck ${healthCheck}")
+
     val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isActive).map(_.instanceId)(collection.breakOut)
     // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
     // Therefore we materialize it into a new map.
-    healthByInstanceId = healthByInstanceId.filterKeys(activeInstanceIds).iterator.toMap
+    activeInstanceIds.foreach { activeId =>
+      healthByInstanceId.remove(activeId)
+    }
 
-    val hcToPurge = instances.withFilter(!_.isActive).map(instance => {
+    val checksToPurge = instances.withFilter(!_.isActive).map(instance => {
       val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)
       (instanceKey, healthCheck)
     })
-    appHealthCheckActor ! PurgeHealthCheckStatuses(hcToPurge)
-  }
-
-  def scheduleNextHealthCheck(interval: Option[FiniteDuration] = None): Unit = healthCheck match {
-    case hc: MarathonHealthCheck =>
-      logger.debug(
-        "Scheduling next health check for app [{}] version [{}] and healthCheck [{}]",
-        app.id,
-        app.version,
-        hc
-      )
-      nextScheduledCheck = Some(
-        context.system.scheduler.scheduleOnce(interval.getOrElse(hc.interval)) {
-          self ! Tick
-        }
-      )
-    case _ => // Don't do anything for Mesos health checks
-  }
-
-  def dispatchJobs(instances: Seq[Instance]): Unit = healthCheck match {
-    case hc: MarathonHealthCheck =>
-      logger.debug("Dispatching health check jobs to workers")
-      instances.foreach { instance =>
-        if (instance.runSpecVersion == app.version && instance.isRunning) {
-          logger.debug("Dispatching health check job for {}", instance.instanceId)
-          val worker: ActorRef = context.actorOf(workerProps)
-          worker ! HealthCheckJob(app, instance, hc)
-        }
-      }
-    case _ => // Don't do anything for Mesos health checks
+    appHealthCheckActor ! PurgeHealthCheckStatuses(checksToPurge)
   }
 
   def checkConsecutiveFailures(instance: Instance, health: Health): Unit = {
@@ -175,9 +139,9 @@ private[health] class HealthCheckActor(
 
     val updatedHealth = result match {
       case Healthy(_, _, _, _) =>
-        Future(health.update(result))
+        Future.successful(health.update(result))
       case Unhealthy(_, _, _, _, _) =>
-        instanceTracker.instance(instanceId).map({
+        instanceTracker.instance(instanceId).map {
           case Some(instance) =>
             if (ignoreFailures(instance, health)) {
               // Don't update health
@@ -193,7 +157,9 @@ private[health] class HealthCheckActor(
           case None =>
             logger.error(s"Couldn't find instance $instanceId")
             health.update(result)
-        })
+        }
+      case _: Ignored =>
+        Future.successful(health) // Ignore and keep the old health
     }
     updatedHealth.onComplete {
       case Success(newHealth) => self ! InstanceHealth(result, health, newHealth)
@@ -222,25 +188,14 @@ private[health] class HealthCheckActor(
     case GetAppHealth =>
       sender() ! AppHealth(healthByInstanceId.values.to[Seq])
 
-    case Tick =>
-      updateInstances().andThen{ case _ => self ! ScheduleNextHealthCheck() }
-
-    case ScheduleNextHealthCheck(interval) =>
-      scheduleNextHealthCheck(interval)
-
-    case InstancesUpdate(version, instances) if version == app.version =>
-      purgeStatusOfDoneInstances(instances)
-      dispatchJobs(instances)
-
     case result: HealthResult if result.version == app.version =>
       handleHealthResult(result)
 
     case instanceHealth: InstanceHealth =>
       updateInstanceHealth(instanceHealth)
 
-    case result: HealthResult =>
-      logger.warn(s"Ignoring health result [$result] due to version mismatch.")
-
+    case 'restart =>
+      throw new RuntimeException("HealthCheckActor stream stopped, restarting")
   }
 }
 
@@ -251,7 +206,8 @@ object HealthCheckActor {
     killService: KillService,
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
-    eventBus: EventStream)(implicit mat: Materializer): Props = {
+    eventBus: EventStream,
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer): Props = {
 
     Props(new HealthCheckActor(
       app,
@@ -259,18 +215,17 @@ object HealthCheckActor {
       killService,
       healthCheck,
       instanceTracker,
-      eventBus))
+      eventBus,
+      healthCheckHub))
   }
 
   // self-sent every healthCheck.intervalSeconds
   case object Tick
   case class GetInstanceHealth(instanceId: Instance.Id)
   case object GetAppHealth
-  case class ScheduleNextHealthCheck(interval: Option[FiniteDuration] = None)
 
   case class AppHealth(health: Seq[Health])
 
   case class InstanceHealth(result: HealthResult, health: Health, newHealth: Health)
   case class InstancesUpdate(version: Timestamp, instances: Seq[Instance])
-
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -74,10 +74,10 @@ private[health] class HealthCheckActor(
   def purgeStatusOfDoneInstances(instances: Seq[Instance]): Unit = {
     logger.debug(s"Purging health status of inactive instances for app ${app.id} version ${app.version} and healthCheck ${healthCheck}")
 
-    val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isActive).map(_.instanceId)(collection.breakOut)
-    // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
-    // Therefore we materialize it into a new map.
-    healthByInstanceId.filterKeys(activeInstanceIds)
+    val inactiveInstanceIds: Set[Instance.Id] = instances.filterNot(_.isActive).map(_.instanceId)(collection.breakOut)
+    inactiveInstanceIds.foreach { inactiveId =>
+      healthByInstanceId.remove(inactiveId)
+    }
 
     val checksToPurge = instances.withFilter(!_.isActive).map(instance => {
       val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -77,9 +77,7 @@ private[health] class HealthCheckActor(
     val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isActive).map(_.instanceId)(collection.breakOut)
     // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
     // Therefore we materialize it into a new map.
-    activeInstanceIds.foreach { activeId =>
-      healthByInstanceId.remove(activeId)
-    }
+    healthByInstanceId.filterKeys(activeInstanceIds)
 
     val checksToPurge = instances.withFilter(!_.isActive).map(instance => {
       val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -1,11 +1,12 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.actor.{ActorRef, ActorRefFactory}
 import akka.event.EventStream
 import akka.pattern.ask
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{MergeHub, Sink}
 import akka.util.Timeout
 import com.typesafe.scalalogging.StrictLogging
 
@@ -28,13 +29,15 @@ import scala.collection.immutable.{Map, Seq}
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 class MarathonHealthCheckManager(
     actorRefFactory: ActorRefFactory,
     killService: KillService,
     eventBus: EventStream,
     instanceTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) extends HealthCheckManager with StrictLogging {
+    groupManager: GroupManager,
+    conf: MarathonConf)(implicit mat: ActorMaterializer) extends HealthCheckManager with StrictLogging {
 
   protected[this] case class ActiveHealthCheck(
       healthCheck: HealthCheck,
@@ -53,6 +56,32 @@ class MarathonHealthCheckManager(
       ahcs(appId).values.flatten.toSet
     }
 
+  /**
+    * A common materialized merge hub that is used by all [[HealthCheckActor]]s to channel the Marathon health checks.
+    * Its main purpose is to provide a global throttling mechanism that limit a total number of concurrent Marathon
+    * health check in the system defined by [[MarathonConf.maxConcurrentMarathonHealthChecks]] parameter. After
+    * executing the health check by calling the [[HealthCheckWorker.run()]] method the result is sent back to the
+    * HealthCheckActor via the provided ActorRef.
+    */
+  val healthCheckWorkerHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed] =
+    MergeHub
+      .source[(AppDefinition, Instance, MarathonHealthCheck, ActorRef)](1)
+      .mapAsync(conf.maxConcurrentMarathonHealthChecks()){
+        case (app, instance, marathonHealthCheck, actorRef) =>
+          HealthCheckWorker
+            .run(app, instance, marathonHealthCheck)
+            .map(healthResult => actorRef ! healthResult)
+            .recover {
+              // Theoretically we should never get there: [[HealthCheckWorker.run]] already wraps failed health checks into
+              // successful futures with Healthy/Unhealthy message. But just in case the underlying implementation changes...
+              case NonFatal(e) =>
+                logger.warn(s"HealthCheck stream for app ${app.id} version ${app.version} " +
+                  s"and healthCheck $marathonHealthCheck failed with: ", e)
+            }
+      }
+      .to(Sink.ignore)
+      .run()
+
   protected[this] def listActive(appId: PathId, appVersion: Timestamp): Set[ActiveHealthCheck] =
     appHealthChecks.readLock { ahcs =>
       ahcs(appId)(appVersion)
@@ -68,7 +97,7 @@ class MarathonHealthCheckManager(
         logger.info(s"Adding health check for app [${app.id}] and version [${app.version}]: [$healthCheck]")
 
         val ref = actorRefFactory.actorOf(
-          HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus))
+          HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus, healthCheckWorkerHub))
         val newHealthChecksForApp =
           healthChecksForApp + ActiveHealthCheck(healthCheck, ref)
 
@@ -152,7 +181,7 @@ class MarathonHealthCheckManager(
 
     def reconcileApp(app: AppDefinition, instances: Seq[Instance]): Future[Done] = {
       val appId = app.id
-      logger.info(s"reconcile [$appId] with latest version [${app.version}]")
+      logger.info(s"reconcile $appId with latest version ${app.version} for instances: $instances")
 
       val instancesByVersion = instances.groupBy(_.version)
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -32,6 +32,9 @@ object InstanceTrackerActor {
   /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]]. */
   private[impl] case object List
 
+  /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]] by RunSpec [[PathId]]. */
+  private[impl] case class ListBySpec(appId: PathId)
+
   private[impl] case class Get(instanceId: Instance.Id)
 
   private[impl] case class UpdateContext(deadline: Timestamp, op: InstanceUpdateOperation) {
@@ -97,7 +100,7 @@ private[impl] class InstanceTrackerActor(
   override def preStart(): Unit = {
     super.preStart()
 
-    logger.info(s"${getClass.getSimpleName} is starting. Task loading initiated.")
+    logger.info(s"${getClass.getSimpleName} is starting. Instances loading initiated.")
     metrics.resetMetrics()
 
     import akka.pattern.pipe
@@ -142,6 +145,9 @@ private[impl] class InstanceTrackerActor(
     LoggingReceive.withLabel("initialized") {
       case InstanceTrackerActor.List =>
         sender() ! instancesBySpec
+
+      case InstanceTrackerActor.ListBySpec(appId: PathId) =>
+        sender() ! instancesBySpec.specInstances(appId)
 
       case InstanceTrackerActor.Get(instanceId) =>
         sender() ! instancesBySpec.instance(instanceId)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -43,7 +43,8 @@ private[tracker] class InstanceTrackerDelegate(
         (instanceTrackerRef ? InstanceTrackerActor.List).mapTo[InstanceTracker.InstancesBySpec].recover {
           case e: AskTimeoutException =>
             throw new TimeoutException(
-              "timeout while calling list. If you know what you are doing, you can adjust the timeout " +
+              s"timeout while calling instancesBySpec() (current value = ${config.internalTaskTrackerRequestTimeout().milliseconds}ms." +
+                "If you know what you are doing, you can adjust the timeout " +
                 s"with --${config.internalTaskTrackerRequestTimeout.name}."
             )
         }
@@ -53,17 +54,19 @@ private[tracker] class InstanceTrackerDelegate(
   // TODO(jdef) support pods when counting launched instances
   override def countActiveSpecInstances(appId: PathId): Future[Int] = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isActive || (instance.isReserved && !instance.isReservedTerminal)))
+    specInstances(appId).map(_.count(instance => instance.isActive || (instance.isReserved && !instance.isReservedTerminal)))
   }
 
-  override def hasSpecInstancesSync(appId: PathId): Boolean = instancesBySpecSync.hasSpecInstances(appId)
+  override def hasSpecInstancesSync(appId: PathId): Boolean = specInstancesSync(appId).nonEmpty
   override def hasSpecInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Boolean] =
-    instancesBySpec().map(_.hasSpecInstances(appId))
+    specInstances(appId).map(_.nonEmpty)
 
-  override def specInstancesSync(appId: PathId): Seq[Instance] =
-    instancesBySpecSync.specInstances(appId)
+  override def specInstancesSync(appId: PathId): Seq[Instance] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    Await.result(specInstances(appId), instanceTrackerQueryTimeout.duration)
+  }
   override def specInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] =
-    instancesBySpec().map(_.specInstances(appId))
+    (instanceTrackerRef ? InstanceTrackerActor.ListBySpec(appId)).mapTo[Seq[Instance]]
 
   override def instance(taskId: Instance.Id): Future[Option[Instance]] =
     (instanceTrackerRef ? InstanceTrackerActor.Get(taskId)).mapTo[Option[Instance]]

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
@@ -2,11 +2,12 @@ package mesosphere.marathon
 package core.health.impl
 
 import java.net.{InetAddress, ServerSocket}
+import java.util.UUID
 
-import akka.actor.Props
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
-import akka.testkit.{ImplicitSender, TestActorRef}
+import akka.stream.ActorMaterializer
+import akka.testkit.ImplicitSender
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance.AgentInfo
@@ -18,12 +19,10 @@ import mesosphere.marathon.state.{AppDefinition, PathId, PortDefinition, Unreach
 import scala.collection.immutable.Seq
 import scala.concurrent.{Future, Promise}
 
-class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
+class HealthCheckWorkerTest extends AkkaUnitTest with ImplicitSender {
 
-  import HealthCheckWorker._
-
-  "HealthCheckWorkerActor" should {
-    "A TCP health check should correctly resolve the hostname" in {
+  "HealthCheckWorker" should {
+    "A TCP health check should correctly resolve the hostname and return a Healthy result" in {
       val socket = new ServerSocket(0)
       val socketPort: Int = socket.getLocalPort
 
@@ -31,7 +30,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
         socket.accept().close()
       }
 
-      val appId = PathId("/test_id")
+      val appId = PathId(s"/app-with-tcp-health-check-${UUID.randomUUID()}")
       val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
       val hostName = InetAddress.getLocalHost.getCanonicalHostName
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
@@ -42,48 +41,13 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       }
       val instance = TestInstanceBuilder.fromTask(task, agentInfo, UnreachableStrategy.default())
 
-      val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
+      val resF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))(mat.asInstanceOf[ActorMaterializer])
 
       try { res.futureValue }
       finally { socket.close() }
 
-      expectMsgPF(patienceConfig.timeout) {
-        case Healthy(_, _, _, _) => ()
-      }
-    }
-
-    "A health check worker should shut itself down" in {
-      val socket = new ServerSocket(0)
-      val socketPort: Int = socket.getLocalPort
-
-      val res = Future {
-        socket.accept().close()
-      }
-
-      val appId = PathId("/test_id")
-      val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
-      val hostName = InetAddress.getLocalHost.getCanonicalHostName
-      val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
-      val task = {
-        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
-        val hostPorts = Seq(socketPort)
-        t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
-      }
-      val instance = TestInstanceBuilder.fromTask(task, agentInfo, UnreachableStrategy.default())
-
-      val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
-
-      try { res.futureValue }
-      finally { socket.close() }
-
-      expectMsgPF(patienceConfig.timeout) {
-        case _: HealthResult => ()
-      }
-
-      watch(ref)
-      expectTerminated(ref)
+      resF.futureValue shouldBe a[Healthy]
     }
 
     "A HTTP health check should work as expected" in {
@@ -110,7 +74,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       val port = binding.localAddress.getPort
 
       val hostName = "localhost"
-      val appId = PathId("/test_id")
+      val appId = PathId(s"/app-with-http-health-check-${UUID.randomUUID()}")
       val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
       val task = {
@@ -125,16 +89,16 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
 
       val instance = Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy, None)
 
-      val ref = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))
-      expectMsgClass(classOf[Healthy])
+      val resF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))(mat.asInstanceOf[ActorMaterializer])
 
+      resF.futureValue shouldBe a[Healthy]
       promise.future.futureValue shouldEqual "success"
 
-      val unhealthy = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
-      unhealthy ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/unhealthy")))
-      expectMsgClass(classOf[Unhealthy])
+      val unhealthyResF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonHttpHealthCheck(port = Some(port), path = Some("/unhealthy")))(mat.asInstanceOf[ActorMaterializer])
 
+      unhealthyResF.futureValue shouldBe a[Unhealthy]
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.event.EventStream
+import akka.stream.ActorMaterializer
 import com.typesafe.config.{Config, ConfigFactory}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.group.GroupManager
@@ -31,18 +32,22 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
   private val clock = new SettableClock()
 
   case class Fixture() {
+    implicit val mat: ActorMaterializer = ActorMaterializer()
     val leadershipModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
     val instanceTrackerModule: InstanceTrackerModule = MarathonTestHelper.createTaskTrackerModule(leadershipModule)
     implicit val instanceTracker: InstanceTracker = instanceTrackerModule.instanceTracker
     val groupManager: GroupManager = mock[GroupManager]
     implicit val eventStream: EventStream = new EventStream(system)
     val killService: KillService = mock[KillService]
+    val conf = MarathonTestHelper.defaultConfig()
+
     implicit val hcManager: MarathonHealthCheckManager = new MarathonHealthCheckManager(
       system,
       killService,
       eventStream,
       instanceTracker,
-      groupManager
+      groupManager,
+      conf
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -185,8 +185,8 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       var instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
       val reservedTask: Task = instance.appTask
       instance = instance.copy(tasksMap = Map(reservedTask.taskId -> reservedTask.copy(status = reservedTask.status.copy(mesosStatus = Some(MesosTaskStatusTestHelper.failed(reservedTask.taskId))))))
-      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
-      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.ListBySpec(PathId("/test")))
+      f.taskTrackerProbe.reply(Seq(instance))
 
       val activeCount = activeCountFuture.futureValue
       activeCount should be(0)
@@ -201,8 +201,8 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       var instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
       val reservedTask: Task = instance.appTask
       instance = instance.copy(tasksMap = Map(reservedTask.taskId -> reservedTask.copy(status = reservedTask.status.copy(mesosStatus = Some(MesosTaskStatusTestHelper.running(reservedTask.taskId))))))
-      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
-      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.ListBySpec(PathId("/test")))
+      f.taskTrackerProbe.reply(Seq(instance))
 
       val activeCount = activeCountFuture.futureValue
       activeCount should be(1)
@@ -215,8 +215,8 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       val activeCountFuture = f.delegate.countActiveSpecInstances(appId)
 
       val instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
-      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
-      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.ListBySpec(PathId("/test")))
+      f.taskTrackerProbe.reply(Seq(instance))
 
       val activeCount = activeCountFuture.futureValue
       activeCount should be(1)

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -8,7 +8,6 @@ import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
-import mesosphere.marathon.core.task.tracker.InstanceTracker.{InstancesBySpec, SpecInstances}
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
 import org.apache.mesos.Protos.{TaskID, TaskStatus}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -236,7 +236,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForDeployment(result)
     }
 
-    "create a simple app with a Mesos TCP healh check" in {
+    "create a simple app with a Mesos TCP health check" in {
       Given("a new app")
       val app = appProxy(appId(Some("with-mesos-tcp-health-check")), "v1", instances = 1, healthCheck = None).
         copy(healthChecks = Set(ramlHealthCheck.copy(protocol = AppHealthCheckProtocol.Tcp)))

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -321,7 +321,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
     "an unhealthy app fails to deploy because health checks takes too long to pass" in {
       Given("a new app that is not healthy")
       val id = appId(Some("unhealthy-fails-to-deploy-because-health-check-takes-too-long"))
-      registerAppProxyHealthCheck(id, "v1", state = true).withHealthAction(_ => Thread.sleep(20000))
+      val check = registerAppProxyHealthCheck(id, "v1", state = false)
       val app = appProxy(id, "v1", instances = 1, healthCheck = Some(appProxyHealthCheck().copy(timeoutSeconds = 2)))
 
       When("The app is deployed")
@@ -338,6 +338,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
           callbackEvent.eventType == "failed_health_check_event"
       )
 
+      check.afterDelay(20.seconds, true)
       for (event <- Iterator.continually(interestingEvent()).take(10)) {
         event.eventType should be("failed_health_check_event")
       }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -59,13 +59,12 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       waitForEvent("unhealthy_instance_kill_event")
 
       And("a replacement is started")
-      // This fails.
-      //check.afterDelay(1.seconds, true)
-      //eventually {
-      //  val currentTasks = marathon.tasks(id).value
-      //  currentTasks should have size (1)
-      //  currentTasks.map(_.id) should not contain (oldTaskId)
-      //}
+      check.afterDelay(1.seconds, true)
+      eventually {
+        val currentTasks = marathon.tasks(id).value
+        currentTasks should have size (1)
+        currentTasks.map(_.id) should not contain (oldTaskId)
+      }
     }
   }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -71,7 +71,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
   private def ramlHealthCheck(protocol: AppHealthCheckProtocol) = AppHealthCheck(
     path = Some("/health"),
     protocol = protocol,
-    gracePeriodSeconds = 0,
+    gracePeriodSeconds = 3,
     intervalSeconds = 1,
     maxConsecutiveFailures = 3,
     portIndex = Some(0),

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -45,7 +45,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       Given("a deployed app with health checks")
       val id = appId(Some(s"replace-mesos-http-health-check"))
       val app = appProxy(id, "v1", instances = 1, healthCheck = None).
-        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.Http)))
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.MesosHttp)))
       val check = registerAppProxyHealthCheck(id, "v1", state = true)
       val result = marathon.createAppV2(app)
       result should be(Created)
@@ -71,10 +71,10 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
   private def ramlHealthCheck(protocol: AppHealthCheckProtocol) = AppHealthCheck(
     path = Some("/health"),
     protocol = protocol,
-    gracePeriodSeconds = 20,
+    gracePeriodSeconds = 0,
     intervalSeconds = 1,
-    maxConsecutiveFailures = 5,
+    maxConsecutiveFailures = 3,
     portIndex = Some(0),
-    delaySeconds = 2
+    delaySeconds = 3
   )
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -4,6 +4,9 @@ package integration
 import java.util.UUID
 
 import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.core.event.UnhealthyInstanceKillEvent
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
 import mesosphere.marathon.raml.{AppHealthCheck, AppHealthCheckProtocol}
 import mesosphere.marathon.state.PathId
@@ -30,7 +33,10 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       check.afterDelay(1.seconds, false)
 
       Then("the unhealthy instance is killed")
-      waitForEvent("unhealthy_instance_kill_event")
+      waitForEventWith(
+        "unhealthy_instance_kill_event",
+        { event => event.info("taskId") == oldTaskId },
+        "Unhealthy instance killed event was not sent.")
 
       And("a replacement is started")
       check.afterDelay(1.seconds, true)
@@ -53,10 +59,14 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
 
       When("the app becomes unhealthy")
       val oldTaskId = marathon.tasks(id).value.head.id
+      val oldInstanceId = Task.Id(oldTaskId).instanceId.idString
       check.afterDelay(1.seconds, false)
 
       Then("the unhealthy instance is killed")
-      waitForEvent("unhealthy_instance_kill_event")
+      waitForEventWith(
+        "instance_changed_event",
+        { event => event.info("condition") == "Killed" && event.info("instanceId") == oldInstanceId },
+        "Unhealthy instance killed event was not sent.")
 
       And("a replacement is started")
       check.afterDelay(1.seconds, true)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -1,0 +1,81 @@
+package mesosphere.marathon
+package integration
+
+import java.util.UUID
+
+import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
+import mesosphere.marathon.raml.{AppHealthCheck, AppHealthCheckProtocol}
+import mesosphere.marathon.state.PathId
+
+import scala.concurrent.duration._
+
+class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
+
+  def appId(suffix: Option[String] = None): PathId = testBasePath / s"app-${suffix.getOrElse(UUID.randomUUID)}"
+
+  "Health checks" should {
+    "kill instance with failing Marathon health checks" in {
+      Given("a deployed app with health checks")
+      val id = appId(Some(s"replace-marathon-http-health-check"))
+      val app = appProxy(id, "v1", instances = 1, healthCheck = None).
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.Http)))
+      val check = registerAppProxyHealthCheck(id, "v1", state = true)
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+
+      When("the app becomes unhealthy")
+      val oldTaskId = marathon.tasks(id).value.head.id
+      check.afterDelay(1.seconds, false)
+
+      Then("the unhealthy instance is killed")
+      waitForEvent("unhealthy_instance_kill_event")
+
+      And("a replacement is started")
+      check.afterDelay(1.seconds, true)
+      eventually {
+        val currentTasks = marathon.tasks(id).value
+        currentTasks should have size (1)
+        currentTasks.map(_.id) should not contain (oldTaskId)
+      }
+    }
+
+    "kill instance with failing Mesos health checks" in {
+      Given("a deployed app with health checks")
+      val id = appId(Some(s"replace-mesos-http-health-check"))
+      val app = appProxy(id, "v1", instances = 1, healthCheck = None).
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.Http)))
+      val check = registerAppProxyHealthCheck(id, "v1", state = true)
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+
+      When("the app becomes unhealthy")
+      val oldTaskId = marathon.tasks(id).value.head.id
+      check.afterDelay(1.seconds, false)
+
+      Then("the unhealthy instance is killed")
+      waitForEvent("unhealthy_instance_kill_event")
+
+      And("a replacement is started")
+      // This fails.
+      //check.afterDelay(1.seconds, true)
+      //eventually {
+      //  val currentTasks = marathon.tasks(id).value
+      //  currentTasks should have size (1)
+      //  currentTasks.map(_.id) should not contain (oldTaskId)
+      //}
+    }
+  }
+
+  private def ramlHealthCheck(protocol: AppHealthCheckProtocol) = AppHealthCheck(
+    path = Some("/health"),
+    protocol = protocol,
+    gracePeriodSeconds = 20,
+    intervalSeconds = 1,
+    maxConsecutiveFailures = 5,
+    portIndex = Some(0),
+    delaySeconds = 2
+  )
+}


### PR DESCRIPTION
Summary:
- introduced a new command line argument `--max_concurrent_marathon_health_checks`
  that defines the maximum number of concurrent *Marathon* health checks (HTTP/S and TCP)
- internally all Marathon health checks are now using the same materialized akka-stream
  MergeHub which throttles the health checks
- `HealthCheckWorkerActor` became `HealthCheckWorker` returning a `Future[HealthResult]`

Backport of #6879, #6870 and #6888.

JIRA issues: MARATHON-8596

Co-authored-by: Aleksey Dukhovniy <adukhovniy@mesosphere.io>