### PR TITLE
Introduced global throttling for Marathon health checks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### Apps names restrictions (breaking change)
 From now on, apps which uses ids which ends with "restart", "tasks", "versions" won't be valid anymore. Such apps already had broken behavior (for example it wasn't possible to use a `GET /v2/apps` endpoint with them), so we made that constraint more explicit. Existing apps with such names will continue working, however all operations on them (except deletion) will result in an error. Please take care of renaming them before upgrading Marathon.
+
 ### Introduce global throttling to Marathon health checks
 Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ### Apps names restrictions (breaking change)
 From now on, apps which uses ids which ends with "restart", "tasks", "versions" won't be valid anymore. Such apps already had broken behavior (for example it wasn't possible to use a `GET /v2/apps` endpoint with them), so we made that constraint more explicit. Existing apps with such names will continue working, however all operations on them (except deletion) will result in an error. Please take care of renaming them before upgrading Marathon.
+### Introduce global throttling to Marathon health checks
+Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.
+
+- [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) - We fixed a race condition causing `v2/deployments` not containing a confirmed deployment after HTTP 200/201 response was returned.
+
+## Changes to 1.7.187
 
 ### Default for "max-open-connections" increased for asynchronous standby proxy, now configurable
 In some clusters with heavy standby-proxy usage, a limit of 32 max-open-connections was too small. This default has been increased to 64. In addition, the flag `--leader_proxy_max_open_connections` has been introduced to tune the value further, if needed.

--- a/changelog.md
+++ b/changelog.md
@@ -6,10 +6,6 @@ From now on, apps which uses ids which ends with "restart", "tasks", "versions" 
 ### Introduce global throttling to Marathon health checks
 Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.
 
-- [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) - We fixed a race condition causing `v2/deployments` not containing a confirmed deployment after HTTP 200/201 response was returned.
-
-## Changes to 1.7.187
-
 ### Default for "max-open-connections" increased for asynchronous standby proxy, now configurable
 In some clusters with heavy standby-proxy usage, a limit of 32 max-open-connections was too small. This default has been increased to 64. In addition, the flag `--leader_proxy_max_open_connections` has been introduced to tune the value further, if needed.
 

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -314,6 +314,14 @@ trait MarathonConf
     default = Some(GpuSchedulingBehavior.Undefined),
     validate = validateGpuSchedulingBehavior
   )
+
+  lazy val maxConcurrentMarathonHealthChecks = opt[Int](
+    name = "max_concurrent_marathon_health_checks",
+    descr = "Defines maximum number of concurrent *Marathon* health checks (HTTP/S and TCP). Note that setting a big value" +
+      "here will overload Marathon leading to internal timeouts and unstable behavior.",
+    noshort = true,
+    default = Some(256)
+  )
 }
 
 object MarathonConf extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -200,7 +200,7 @@ class CoreModuleImpl @Inject() (
 
   override lazy val healthModule: HealthModule = new HealthModule(
     actorSystem, taskTerminationModule.taskKillService, eventStream,
-    instanceTrackerModule.instanceTracker, groupManagerModule.groupManager)(actorsModule.materializer)
+    instanceTrackerModule.instanceTracker, groupManagerModule.groupManager, marathonConf)(actorsModule.materializer)
 
   // GROUP MANAGER
 

--- a/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
@@ -3,7 +3,7 @@ package core.health
 
 import akka.actor.ActorSystem
 import akka.event.EventStream
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.impl.MarathonHealthCheckManager
 import mesosphere.marathon.core.task.termination.KillService
@@ -17,11 +17,13 @@ class HealthModule(
     killService: KillService,
     eventBus: EventStream,
     taskTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) {
+    groupManager: GroupManager,
+    conf: MarathonConf)(implicit mat: ActorMaterializer) {
   lazy val healthCheckManager = new MarathonHealthCheckManager(
     actorSystem,
     killService,
     eventBus,
     taskTracker,
-    groupManager)
+    groupManager,
+    conf)
 }

--- a/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
@@ -23,3 +23,13 @@ case class Unhealthy(
     cause: String,
     time: Timestamp = Timestamp.now(),
     publishEvent: Boolean = true) extends HealthResult
+
+/**
+  * Representing an ignored HTTP response code (see [[MarathonHttpHealthCheck.ignoreHttp1xx]]. Will not update the
+  * health check state and not be published.
+  */
+case class Ignored(
+    instanceId: Instance.Id,
+    version: Timestamp,
+    time: Timestamp = Timestamp.now(),
+    publishEvent: Boolean = false) extends HealthResult

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -1,10 +1,11 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.Done
-import akka.actor.{Actor, ActorRef, Cancellable, Props}
+import akka.NotUsed
+import akka.actor.{Actor, ActorRef, Props}
 import akka.event.EventStream
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.event._
 import mesosphere.marathon.core.health._
@@ -15,6 +16,7 @@ import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{AppDefinition, Timestamp}
 
+import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -25,103 +27,64 @@ private[health] class HealthCheckActor(
     killService: KillService,
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
-    eventBus: EventStream)(implicit mat: Materializer) extends Actor with StrictLogging {
+    eventBus: EventStream,
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])
+  extends Actor with StrictLogging {
 
-  import HealthCheckWorker.HealthCheckJob
+  implicit val mat = ActorMaterializer()
   import context.dispatcher
 
-  var nextScheduledCheck: Option[Cancellable] = None
-  var healthByInstanceId = Map.empty[Instance.Id, Health]
-
-  val workerProps: Props = Props(classOf[HealthCheckWorkerActor], mat)
+  var healthByInstanceId = TrieMap.empty[Instance.Id, Health]
 
   override def preStart(): Unit = {
-    logger.info(
-      "Starting health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
-    //Start health checking not after the default first health check
-    val start = math.min(healthCheck.interval.toMillis, HealthCheck.DefaultFirstHealthCheckAfter.toMillis).millis
-    scheduleNextHealthCheck(Some(start))
-  }
+    healthCheck match {
+      case marathonHealthCheck: MarathonHealthCheck =>
+        //Start health checking not after the default first health check
+        val startAfter = math.min(marathonHealthCheck.interval.toMillis, HealthCheck.DefaultFirstHealthCheckAfter.toMillis).millis
 
-  override def preRestart(reason: Throwable, message: Option[Any]): Unit =
-    logger.info(
-      "Restarting health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
+        logger.info(s"Starting health check for ${app.id} version ${app.version} and healthCheck $marathonHealthCheck in $startAfter ms")
 
-  override def postStop(): Unit = {
-    nextScheduledCheck.forall { _.cancel() }
-    logger.info(
-      "Stopped health check actor for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
-  }
+        Source
+          .tick(startAfter, marathonHealthCheck.interval, Tick)
+          .mapAsync(1)(_ => instanceTracker.specInstances(app.id))
+          .map { instances =>
+            purgeStatusOfDoneInstances(instances)
+            instances.collect {
+              case instance if instance.runSpecVersion == app.version && instance.isRunning =>
+                logger.debug("Making a health check request for {}", instance.instanceId)
+                (app, instance, marathonHealthCheck, self)
+            }
+          }
+          .mapConcat(identity)
+          .watchTermination(){ (_, done) =>
+            done.onComplete {
+              case Success(_) =>
+                logger.info(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck was stopped")
+                self ! 'restart
 
-  def updateInstances(): Future[Done] = {
-    instanceTracker.specInstances(app.id).map { instances =>
-      self ! InstancesUpdate(version = app.version, instances = instances)
-      Done
-    }.recover {
-      case t =>
-        logger.error(s"An error has occurred: ${t.getMessage}", t)
-        Done
+              case Failure(ex) =>
+                logger.warn(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck crashed due to:", ex)
+                self ! 'restart
+            }
+          }
+          .runWith(healthCheckHub)
+      case _ => // Don't do anything for Mesos health checks
     }
   }
 
   def purgeStatusOfDoneInstances(instances: Seq[Instance]): Unit = {
-    logger.debug(
-      "Purging health status of inactive instances for app [{}] version [{}] and healthCheck [{}]",
-      app.id,
-      app.version,
-      healthCheck
-    )
-    val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isActive).map(_.instanceId)(collection.breakOut)
-    // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
-    // Therefore we materialize it into a new map.
-    healthByInstanceId = healthByInstanceId.filterKeys(activeInstanceIds).iterator.toMap
+    logger.debug(s"Purging health status of inactive instances for app ${app.id} version ${app.version} and healthCheck ${healthCheck}")
 
-    val hcToPurge = instances.withFilter(!_.isActive).map(instance => {
+    val inactiveInstanceIds: Set[Instance.Id] = instances.filterNot(_.isActive).map(_.instanceId)(collection.breakOut)
+    inactiveInstanceIds.foreach { inactiveId =>
+      healthByInstanceId.remove(inactiveId)
+    }
+
+    val checksToPurge = instances.withFilter(!_.isActive).map(instance => {
       val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)
       (instanceKey, healthCheck)
     })
-    appHealthCheckActor ! PurgeHealthCheckStatuses(hcToPurge)
-  }
-
-  def scheduleNextHealthCheck(interval: Option[FiniteDuration] = None): Unit = healthCheck match {
-    case hc: MarathonHealthCheck =>
-      logger.debug(
-        "Scheduling next health check for app [{}] version [{}] and healthCheck [{}]",
-        app.id,
-        app.version,
-        hc
-      )
-      nextScheduledCheck = Some(
-        context.system.scheduler.scheduleOnce(interval.getOrElse(hc.interval)) {
-          self ! Tick
-        }
-      )
-    case _ => // Don't do anything for Mesos health checks
-  }
-
-  def dispatchJobs(instances: Seq[Instance]): Unit = healthCheck match {
-    case hc: MarathonHealthCheck =>
-      logger.debug("Dispatching health check jobs to workers")
-      instances.foreach { instance =>
-        if (instance.runSpecVersion == app.version && instance.isRunning) {
-          logger.debug("Dispatching health check job for {}", instance.instanceId)
-          val worker: ActorRef = context.actorOf(workerProps)
-          worker ! HealthCheckJob(app, instance, hc)
-        }
-      }
-    case _ => // Don't do anything for Mesos health checks
+    appHealthCheckActor ! PurgeHealthCheckStatuses(checksToPurge)
   }
 
   def checkConsecutiveFailures(instance: Instance, health: Health): Unit = {
@@ -175,9 +138,9 @@ private[health] class HealthCheckActor(
 
     val updatedHealth = result match {
       case Healthy(_, _, _, _) =>
-        Future(health.update(result))
+        Future.successful(health.update(result))
       case Unhealthy(_, _, _, _, _) =>
-        instanceTracker.instance(instanceId).map({
+        instanceTracker.instance(instanceId).map {
           case Some(instance) =>
             if (ignoreFailures(instance, health)) {
               // Don't update health
@@ -193,7 +156,9 @@ private[health] class HealthCheckActor(
           case None =>
             logger.error(s"Couldn't find instance $instanceId")
             health.update(result)
-        })
+        }
+      case _: Ignored =>
+        Future.successful(health) // Ignore and keep the old health
     }
     updatedHealth.onComplete {
       case Success(newHealth) => self ! InstanceHealth(result, health, newHealth)
@@ -222,25 +187,14 @@ private[health] class HealthCheckActor(
     case GetAppHealth =>
       sender() ! AppHealth(healthByInstanceId.values.to[Seq])
 
-    case Tick =>
-      updateInstances().andThen{ case _ => self ! ScheduleNextHealthCheck() }
-
-    case ScheduleNextHealthCheck(interval) =>
-      scheduleNextHealthCheck(interval)
-
-    case InstancesUpdate(version, instances) if version == app.version =>
-      purgeStatusOfDoneInstances(instances)
-      dispatchJobs(instances)
-
     case result: HealthResult if result.version == app.version =>
       handleHealthResult(result)
 
     case instanceHealth: InstanceHealth =>
       updateInstanceHealth(instanceHealth)
 
-    case result: HealthResult =>
-      logger.warn(s"Ignoring health result [$result] due to version mismatch.")
-
+    case 'restart =>
+      throw new RuntimeException("HealthCheckActor stream stopped, restarting")
   }
 }
 
@@ -251,7 +205,8 @@ object HealthCheckActor {
     killService: KillService,
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
-    eventBus: EventStream)(implicit mat: Materializer): Props = {
+    eventBus: EventStream,
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed]): Props = {
 
     Props(new HealthCheckActor(
       app,
@@ -259,18 +214,17 @@ object HealthCheckActor {
       killService,
       healthCheck,
       instanceTracker,
-      eventBus))
+      eventBus,
+      healthCheckHub))
   }
 
   // self-sent every healthCheck.intervalSeconds
   case object Tick
   case class GetInstanceHealth(instanceId: Instance.Id)
   case object GetAppHealth
-  case class ScheduleNextHealthCheck(interval: Option[FiniteDuration] = None)
 
   case class AppHealth(health: Seq[Health])
 
   case class InstanceHealth(result: HealthResult, health: Health, newHealth: Health)
   case class InstancesUpdate(version: Timestamp, instances: Seq[Instance])
-
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorker.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckWorker.scala
@@ -3,17 +3,18 @@ package core.health.impl
 
 import java.net.{InetSocketAddress, Socket}
 import java.security.cert.X509Certificate
-import javax.net.ssl.{KeyManager, SSLContext, X509TrustManager}
 
-import akka.actor.{Actor, ActorSystem, PoisonPill}
-import akka.http.scaladsl.settings.ClientConnectionSettings
+import akka.actor.ActorSystem
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, headers}
+import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.{ConnectionContext, Http}
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.scalalogging.StrictLogging
 import com.typesafe.sslconfig.akka.AkkaSSLConfig
+import javax.net.ssl.{KeyManager, SSLContext, X509TrustManager}
+import mesosphere.marathon.Protos.HealthCheckDefinition.Protocol
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.{AppDefinition, Timestamp}
@@ -24,64 +25,50 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
-class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with StrictLogging {
+object HealthCheckWorker extends StrictLogging {
 
-  import HealthCheckWorker._
+  def run(app: AppDefinition, instance: Instance, healthCheck: MarathonHealthCheck)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+    logger.debug("Dispatching health check job for {}", instance.instanceId)
 
-  private implicit val system = context.system
-  import context.dispatcher // execution context for futures
+    implicit val system = mat.system
+    implicit val ex = mat.executionContext
 
-  def receive: Receive = {
-    case HealthCheckJob(app, instance, check) =>
-      val replyTo = sender() // avoids closing over the volatile sender ref
-
-      doCheck(app, instance, check)
-        .andThen {
-          case Success(Some(result)) => replyTo ! result
-          case Success(None) => // ignore
-          case Failure(t) =>
-            logger.warn(s"Performing health check for app=${app.id} instance=${instance.instanceId} port=${check.port} failed with exception", t)
-            replyTo ! Unhealthy(
-              instance.instanceId,
-              instance.runSpecVersion,
-              s"${t.getClass.getSimpleName}: ${t.getMessage}"
-            )
-        }
-        .onComplete { _ => self ! PoisonPill }
+    check(app, instance, healthCheck)
+      .transform {
+        case Failure(ex) =>
+          logger.warn(s"Performing health check for app=${app.id} instance=${instance.instanceId} port=${healthCheck.port} failed with exception", ex)
+          Success(Unhealthy(
+            instance.instanceId,
+            instance.runSpecVersion,
+            s"${ex.getClass.getSimpleName}: ${ex.getMessage}"
+          ))
+        case other => other
+      }
   }
 
-  def doCheck(
-    app: AppDefinition, instance: Instance, check: MarathonHealthCheck): Future[Option[HealthResult]] = {
+  def check(
+    app: AppDefinition,
+    instance: Instance,
+    healthCheck: MarathonHealthCheck)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
     // HealthChecks are only supported for legacy App instances with exactly one task
     val effectiveIpAddress = instance.appTask.status.networkInfo.effectiveIpAddress(app)
     effectiveIpAddress match {
       case Some(host) =>
-        val maybePort = check.effectivePort(app, instance)
-        (check, maybePort) match {
+        val maybePort = healthCheck.effectivePort(app, instance)
+        (healthCheck, maybePort) match {
           case (hc: MarathonHttpHealthCheck, Some(port)) =>
             hc.protocol match {
-              case Protos.HealthCheckDefinition.Protocol.HTTPS => https(instance, hc, host, port)
-              case Protos.HealthCheckDefinition.Protocol.HTTP => http(instance, hc, host, port)
-              case invalidProtocol: Protos.HealthCheckDefinition.Protocol =>
-                Future.failed {
-                  val message = s"Health check failed: HTTP health check contains invalid protocol: $invalidProtocol"
-                  logger.warn(message)
-                  new UnsupportedOperationException(message)
-                }
+              case Protocol.HTTPS => https(instance, hc, host, port)
+              case Protocol.HTTP => http(instance, hc, host, port)
+              case invalid =>
+                Future.failed (new UnsupportedOperationException(s"Health check failed: HTTP health check contains invalid protocol: $invalid"))
             }
           case (hc: MarathonTcpHealthCheck, Some(port)) => tcp(instance, hc, host, port)
-          case _ => Future.failed {
-            val message = "Health check failed: unable to get the task's effectivePort"
-            logger.warn(message)
-            new UnsupportedOperationException(message)
-          }
+          case _ => Future.failed(new UnsupportedOperationException("Health check failed: unable to get the task's effectivePort"))
         }
       case None =>
-        Future.failed {
-          val message = "Health check failed: unable to get the task's effective IP address"
-          logger.warn(message)
-          new UnsupportedOperationException(message)
-        }
+        Future.failed(new UnsupportedOperationException("Health check failed: unable to get the task's effective IP address"))
     }
   }
 
@@ -89,30 +76,32 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     instance: Instance,
     check: MarathonHttpHealthCheck,
     host: String,
-    port: Int): Future[Option[HealthResult]] = {
+    port: Int)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
+    implicit val ec = mat.executionContext
+
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"http://$host:$port$absolutePath"
     logger.debug(s"Checking the health of [$url] for instance=${instance.instanceId} via HTTP")
 
-    singleRequest(
-      RequestBuilding.Get(url),
-      check.timeout
-    ).map { response =>
+    singleRequest(RequestBuilding.Get(url), check.timeout)
+      .map { response =>
         response.discardEntityBytes() //forget about the body
         if (acceptableResponses.contains(response.status.intValue())) {
-          Some(Healthy(instance.instanceId, instance.runSpecVersion))
+          Healthy(instance.instanceId, instance.runSpecVersion)
         } else if (check.ignoreHttp1xx && (toIgnoreResponses.contains(response.status.intValue))) {
           logger.debug(s"Ignoring health check HTTP response ${response.status.intValue} for instance=${instance.instanceId}")
-          None
+          Ignored(instance.instanceId, instance.runSpecVersion)
         } else {
           logger.debug(s"Health check for instance=${instance.instanceId} responded with ${response.status}")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
+          Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString())
         }
-      }.recover {
+      }
+      .recover {
         case NonFatal(e) =>
           logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
+          Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage)
       }
   }
 
@@ -120,7 +109,8 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     instance: Instance,
     check: MarathonTcpHealthCheck,
     host: String,
-    port: Int): Future[Option[HealthResult]] = {
+    port: Int)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
     val address = s"$host:$port"
     val timeoutMillis = check.timeout.toMillis.toInt
     logger.debug(s"Checking the health of [$address] for instance=${instance.instanceId} via TCP")
@@ -132,7 +122,7 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
         socket.connect(address, timeoutMillis)
         socket.close()
       }
-      Some(Healthy(instance.instanceId, instance.runSpecVersion, Timestamp.now()))
+      Healthy(instance.instanceId, instance.runSpecVersion, Timestamp.now())
     }(ThreadPoolContext.ioContext)
   }
 
@@ -140,32 +130,35 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     instance: Instance,
     check: MarathonHttpHealthCheck,
     host: String,
-    port: Int): Future[Option[HealthResult]] = {
+    port: Int)(implicit mat: ActorMaterializer): Future[HealthResult] = {
+
+    implicit val ec = mat.executionContext
 
     val rawPath = check.path.getOrElse("")
     val absolutePath = if (rawPath.startsWith("/")) rawPath else s"/$rawPath"
     val url = s"https://$host:$port$absolutePath"
     logger.debug(s"Checking the health of [$url] for instance=${instance.instanceId} via HTTPS")
 
-    singleRequestHttps(
-      RequestBuilding.Get(url),
-      check.timeout
-    ).map { response =>
+    singleRequestHttps(RequestBuilding.Get(url), check.timeout)
+      .map { response =>
         response.discardEntityBytes() // forget about the body
         if (acceptableResponses.contains(response.status.intValue())) {
-          Some(Healthy(instance.instanceId, instance.runSpecVersion))
+          Healthy(instance.instanceId, instance.runSpecVersion)
         } else {
           logger.debug(s"Health check for ${instance.instanceId} responded with ${response.status}")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString()))
+          Unhealthy(instance.instanceId, instance.runSpecVersion, response.status.toString())
         }
-      }.recover {
+      }
+      .recover {
         case NonFatal(e) =>
-          logger.debug(s"Health check for instance=${instance.instanceId} did not respond due to ${e.getMessage}.")
-          Some(Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage))
+          logger.debug(s"Health check for instance=${instance.instanceId} failed to respond due to ${e.getMessage}.")
+          Unhealthy(instance.instanceId, instance.runSpecVersion, e.getMessage)
       }
   }
 
-  def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration): Future[HttpResponse] = {
+  def singleRequest(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: ActorMaterializer): Future[HttpResponse] = {
+    implicit val system = mat.system
+
     val host = httpRequest.uri.authority.host.toString()
     val port = httpRequest.uri.effectivePort
     val hostHeader = headers.Host(host, port)
@@ -181,7 +174,9 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     Source.single(effectiveRequest).via(connectionFlow).runWith(Sink.head)
   }
 
-  def singleRequestHttps(httpRequest: HttpRequest, timeout: FiniteDuration): Future[HttpResponse] = {
+  def singleRequestHttps(httpRequest: HttpRequest, timeout: FiniteDuration)(implicit mat: ActorMaterializer): Future[HttpResponse] = {
+    implicit val system = mat.system
+
     val host = httpRequest.uri.authority.host.toString()
     val port = httpRequest.uri.effectivePort
     val hostHeader = headers.Host(host, port)
@@ -197,10 +192,6 @@ class HealthCheckWorkerActor(implicit mat: Materializer) extends Actor with Stri
     )
     Source.single(effectiveRequest).via(connectionFlow).runWith(Sink.head)
   }
-}
-
-@SuppressWarnings(Array("NullParameter"))
-object HealthCheckWorker {
 
   // Similar to AWS R53, we accept all responses in [200, 399]
   protected[health] val acceptableResponses = Range(200, 400)
@@ -222,7 +213,7 @@ object HealthCheckWorker {
     context
   }
 
-  def disabledSslConfig()(implicit as: ActorSystem) = AkkaSSLConfig().mapSettings(s => s.withLoose {
+  def disabledSslConfig()(implicit as: ActorSystem): AkkaSSLConfig = AkkaSSLConfig().mapSettings(s => s.withLoose {
     s.loose.withAcceptAnyCertificate(true)
       .withAllowLegacyHelloMessages(Some(true))
       .withAllowUnsafeRenegotiation(Some(true))

--- a/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManager.scala
@@ -1,11 +1,12 @@
 package mesosphere.marathon
 package core.health.impl
 
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.actor.{ActorRef, ActorRefFactory}
 import akka.event.EventStream
 import akka.pattern.ask
-import akka.stream.Materializer
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{MergeHub, Sink}
 import akka.util.Timeout
 import com.typesafe.scalalogging.StrictLogging
 
@@ -28,13 +29,15 @@ import scala.collection.immutable.{Map, Seq}
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 class MarathonHealthCheckManager(
     actorRefFactory: ActorRefFactory,
     killService: KillService,
     eventBus: EventStream,
     instanceTracker: InstanceTracker,
-    groupManager: GroupManager)(implicit mat: Materializer) extends HealthCheckManager with StrictLogging {
+    groupManager: GroupManager,
+    conf: MarathonConf)(implicit mat: ActorMaterializer) extends HealthCheckManager with StrictLogging {
 
   protected[this] case class ActiveHealthCheck(
       healthCheck: HealthCheck,
@@ -53,6 +56,32 @@ class MarathonHealthCheckManager(
       ahcs(appId).values.flatten.toSet
     }
 
+  /**
+    * A common materialized merge hub that is used by all [[HealthCheckActor]]s to channel the Marathon health checks.
+    * Its main purpose is to provide a global throttling mechanism that limit a total number of concurrent Marathon
+    * health check in the system defined by [[MarathonConf.maxConcurrentMarathonHealthChecks]] parameter. After
+    * executing the health check by calling the [[HealthCheckWorker.run()]] method the result is sent back to the
+    * HealthCheckActor via the provided ActorRef.
+    */
+  val healthCheckWorkerHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed] =
+    MergeHub
+      .source[(AppDefinition, Instance, MarathonHealthCheck, ActorRef)](1)
+      .mapAsync(conf.maxConcurrentMarathonHealthChecks()){
+        case (app, instance, marathonHealthCheck, actorRef) =>
+          HealthCheckWorker
+            .run(app, instance, marathonHealthCheck)
+            .map(healthResult => actorRef ! healthResult)
+            .recover {
+              // Theoretically we should never get there: [[HealthCheckWorker.run]] already wraps failed health checks into
+              // successful futures with Healthy/Unhealthy message. But just in case the underlying implementation changes...
+              case NonFatal(e) =>
+                logger.warn(s"HealthCheck stream for app ${app.id} version ${app.version} " +
+                  s"and healthCheck $marathonHealthCheck failed with: ", e)
+            }
+      }
+      .to(Sink.ignore)
+      .run()
+
   protected[this] def listActive(appId: PathId, appVersion: Timestamp): Set[ActiveHealthCheck] =
     appHealthChecks.readLock { ahcs =>
       ahcs(appId)(appVersion)
@@ -68,7 +97,7 @@ class MarathonHealthCheckManager(
         logger.info(s"Adding health check for app [${app.id}] and version [${app.version}]: [$healthCheck]")
 
         val ref = actorRefFactory.actorOf(
-          HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus))
+          HealthCheckActor.props(app, appHealthChecksActor, killService, healthCheck, instanceTracker, eventBus, healthCheckWorkerHub))
         val newHealthChecksForApp =
           healthChecksForApp + ActiveHealthCheck(healthCheck, ref)
 
@@ -153,7 +182,7 @@ class MarathonHealthCheckManager(
 
     def reconcileApp(app: AppDefinition, instances: Seq[Instance]): Future[Done] = {
       val appId = app.id
-      logger.info(s"reconcile [$appId] with latest version [${app.version}]")
+      logger.info(s"reconcile $appId with latest version ${app.version} for instances: $instances")
 
       val instancesByVersion = instances.groupBy(_.version)
 

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -32,6 +32,9 @@ object InstanceTrackerActor {
   /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]]. */
   private[impl] case object List
 
+  /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]] by RunSpec [[PathId]]. */
+  private[impl] case class ListBySpec(appId: PathId)
+
   private[impl] case class Get(instanceId: Instance.Id)
 
   private[impl] case class UpdateContext(deadline: Timestamp, op: InstanceUpdateOperation) {
@@ -91,7 +94,7 @@ private[impl] class InstanceTrackerActor(
   override def preStart(): Unit = {
     super.preStart()
 
-    logger.info(s"${getClass.getSimpleName} is starting. Task loading initiated.")
+    logger.info(s"${getClass.getSimpleName} is starting. Instances loading initiated.")
     metrics.resetMetrics()
 
     import akka.pattern.pipe
@@ -135,6 +138,9 @@ private[impl] class InstanceTrackerActor(
     LoggingReceive.withLabel("initialized") {
       case InstanceTrackerActor.List =>
         sender() ! instancesBySpec
+
+      case InstanceTrackerActor.ListBySpec(appId: PathId) =>
+        sender() ! instancesBySpec.specInstances(appId)
 
       case InstanceTrackerActor.Get(instanceId) =>
         sender() ! instancesBySpec.instance(instanceId)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
@@ -11,7 +11,7 @@ import akka.testkit.ImplicitSender
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.{Instance, LegacyAppInstance, TestInstanceBuilder, TestTaskBuilder}
+import mesosphere.marathon.core.instance.{Instance, LegacyAppInstance, TestTaskBuilder}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{AppDefinition, PathId, PortDefinition, UnreachableStrategy}

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
@@ -2,15 +2,16 @@ package mesosphere.marathon
 package core.health.impl
 
 import java.net.{InetAddress, ServerSocket}
+import java.util.UUID
 
-import akka.actor.Props
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
-import akka.testkit.{ImplicitSender, TestActorRef}
+import akka.stream.ActorMaterializer
+import akka.testkit.ImplicitSender
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.{Instance, LegacyAppInstance, TestTaskBuilder}
+import mesosphere.marathon.core.instance.{Instance, LegacyAppInstance, TestInstanceBuilder, TestTaskBuilder}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{AppDefinition, PathId, PortDefinition, UnreachableStrategy}
@@ -18,12 +19,10 @@ import mesosphere.marathon.state.{AppDefinition, PathId, PortDefinition, Unreach
 import scala.collection.immutable.Seq
 import scala.concurrent.{Future, Promise}
 
-class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
+class HealthCheckWorkerTest extends AkkaUnitTest with ImplicitSender {
 
-  import HealthCheckWorker._
-
-  "HealthCheckWorkerActor" should {
-    "A TCP health check should correctly resolve the hostname" in {
+  "HealthCheckWorker" should {
+    "A TCP health check should correctly resolve the hostname and return a Healthy result" in {
       val socket = new ServerSocket(0)
       val socketPort: Int = socket.getLocalPort
 
@@ -31,7 +30,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
         socket.accept().close()
       }
 
-      val appId = PathId("/test_id")
+      val appId = PathId(s"/app-with-tcp-health-check-${UUID.randomUUID()}")
       val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
       val hostName = InetAddress.getLocalHost.getCanonicalHostName
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
@@ -42,48 +41,13 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       }
       val instance = LegacyAppInstance(task, agentInfo, UnreachableStrategy.default())
 
-      val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
+      val resF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))(mat.asInstanceOf[ActorMaterializer])
 
       try { res.futureValue }
       finally { socket.close() }
 
-      expectMsgPF(patienceConfig.timeout) {
-        case Healthy(_, _, _, _) => ()
-      }
-    }
-
-    "A health check worker should shut itself down" in {
-      val socket = new ServerSocket(0)
-      val socketPort: Int = socket.getLocalPort
-
-      val res = Future {
-        socket.accept().close()
-      }
-
-      val appId = PathId("/test_id")
-      val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
-      val hostName = InetAddress.getLocalHost.getCanonicalHostName
-      val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
-      val task = {
-        val t: Task = TestTaskBuilder.Helper.runningTaskForApp(appId)
-        val hostPorts = Seq(socketPort)
-        t.copy(status = t.status.copy(networkInfo = NetworkInfo(hostName, hostPorts, ipAddresses = Nil)))
-      }
-      val instance = LegacyAppInstance(task, agentInfo, UnreachableStrategy.default())
-
-      val ref = TestActorRef[HealthCheckWorkerActor](Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonTcpHealthCheck(portIndex = Some(PortReference(0))))
-
-      try { res.futureValue }
-      finally { socket.close() }
-
-      expectMsgPF(patienceConfig.timeout) {
-        case _: HealthResult => ()
-      }
-
-      watch(ref)
-      expectTerminated(ref)
+      resF.futureValue shouldBe a[Healthy]
     }
 
     "A HTTP health check should work as expected" in {
@@ -110,7 +74,7 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
       val port = binding.localAddress.getPort
 
       val hostName = "localhost"
-      val appId = PathId("/test_id")
+      val appId = PathId(s"/app-with-http-health-check-${UUID.randomUUID()}")
       val app = AppDefinition(id = appId, portDefinitions = Seq(PortDefinition(0)))
       val agentInfo = AgentInfo(host = hostName, agentId = Some("agent"), region = None, zone = None, attributes = Nil)
       val task = {
@@ -125,16 +89,16 @@ class HealthCheckWorkerActorTest extends AkkaUnitTest with ImplicitSender {
 
       val instance = Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy, None)
 
-      val ref = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
-      ref ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))
-      expectMsgClass(classOf[Healthy])
+      val resF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonHttpHealthCheck(port = Some(port), path = Some("/health")))(mat.asInstanceOf[ActorMaterializer])
 
+      resF.futureValue shouldBe a[Healthy]
       promise.future.futureValue shouldEqual "success"
 
-      val unhealthy = system.actorOf(Props(classOf[HealthCheckWorkerActor], mat))
-      unhealthy ! HealthCheckJob(app, instance, MarathonHttpHealthCheck(port = Some(port), path = Some("/unhealthy")))
-      expectMsgClass(classOf[Unhealthy])
+      val unhealthyResF = HealthCheckWorker.run(app, instance,
+        healthCheck = MarathonHttpHealthCheck(port = Some(port), path = Some("/unhealthy")))(mat.asInstanceOf[ActorMaterializer])
 
+      unhealthyResF.futureValue shouldBe a[Unhealthy]
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package core.health.impl
 
 import akka.event.EventStream
+import akka.stream.ActorMaterializer
 import com.typesafe.config.{Config, ConfigFactory}
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.group.GroupManager
@@ -31,18 +32,22 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
   private val clock = new SettableClock()
 
   case class Fixture() {
+    implicit val mat: ActorMaterializer = ActorMaterializer()
     val leadershipModule: LeadershipModule = AlwaysElectedLeadershipModule.forRefFactory(system)
     val instanceTrackerModule: InstanceTrackerModule = MarathonTestHelper.createTaskTrackerModule(leadershipModule)
     implicit val instanceTracker: InstanceTracker = instanceTrackerModule.instanceTracker
     val groupManager: GroupManager = mock[GroupManager]
     implicit val eventStream: EventStream = new EventStream(system)
     val killService: KillService = mock[KillService]
+    val conf = MarathonTestHelper.defaultConfig()
+
     implicit val hcManager: MarathonHealthCheckManager = new MarathonHealthCheckManager(
       system,
       killService,
       eventStream,
       instanceTracker,
-      groupManager
+      groupManager,
+      conf
     )
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -8,7 +8,6 @@ import mesosphere.marathon.core.instance.TestInstanceBuilder._
 import mesosphere.marathon.core.instance.update.{InstanceUpdateEffect, InstanceUpdateOperation}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
-import mesosphere.marathon.core.task.tracker.InstanceTracker.{InstancesBySpec, SpecInstances}
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.test.MarathonTestHelper
 import org.apache.mesos.Protos.{TaskID, TaskStatus}
@@ -183,8 +182,8 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       var instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
       val reservedTask: Task = instance.appTask
       instance = instance.copy(tasksMap = Map(reservedTask.taskId -> reservedTask.copy(status = reservedTask.status.copy(mesosStatus = Some(MesosTaskStatusTestHelper.failed(reservedTask.taskId))))))
-      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
-      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.ListBySpec(PathId("/test")))
+      f.taskTrackerProbe.reply(Seq(instance))
 
       val activeCount = activeCountFuture.futureValue
       activeCount should be(0)
@@ -199,8 +198,8 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       var instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
       val reservedTask: Task = instance.appTask
       instance = instance.copy(tasksMap = Map(reservedTask.taskId -> reservedTask.copy(status = reservedTask.status.copy(mesosStatus = Some(MesosTaskStatusTestHelper.running(reservedTask.taskId))))))
-      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
-      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.ListBySpec(PathId("/test")))
+      f.taskTrackerProbe.reply(Seq(instance))
 
       val activeCount = activeCountFuture.futureValue
       activeCount should be(1)
@@ -213,8 +212,8 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       val activeCountFuture = f.delegate.countActiveSpecInstances(appId)
 
       val instance = TestInstanceBuilder.newBuilder(appId).addTaskReserved(None).getInstance()
-      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.List)
-      f.taskTrackerProbe.reply(InstancesBySpec(Map(appId -> SpecInstances(Map(instance.instanceId -> instance)))))
+      f.taskTrackerProbe.expectMsg(InstanceTrackerActor.ListBySpec(PathId("/test")))
+      f.taskTrackerProbe.reply(Seq(instance))
 
       val activeCount = activeCountFuture.futureValue
       activeCount should be(1)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -235,7 +235,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForDeployment(result)
     }
 
-    "create a simple app with a Mesos TCP healh check" in {
+    "create a simple app with a Mesos TCP health check" in {
       Given("a new app")
       val app = appProxy(appId(Some("with-mesos-tcp-health-check")), "v1", instances = 1, healthCheck = None).
         copy(healthChecks = Set(ramlHealthCheck.copy(protocol = AppHealthCheckProtocol.Tcp)))
@@ -320,7 +320,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
     "an unhealthy app fails to deploy because health checks takes too long to pass" in {
       Given("a new app that is not healthy")
       val id = appId(Some("unhealthy-fails-to-deploy-because-health-check-takes-too-long"))
-      registerAppProxyHealthCheck(id, "v1", state = true).withHealthAction(_ => Thread.sleep(20000))
+      val check = registerAppProxyHealthCheck(id, "v1", state = false)
       val app = appProxy(id, "v1", instances = 1, healthCheck = Some(appProxyHealthCheck().copy(timeoutSeconds = 2)))
 
       When("The app is deployed")
@@ -337,6 +337,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
           callbackEvent.eventType == "failed_health_check_event"
       )
 
+      check.afterDelay(20.seconds, true)
       for (event <- Iterator.continually(interestingEvent()).take(10)) {
         event.eventType should be("failed_health_check_event")
       }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -1,0 +1,90 @@
+package mesosphere.marathon
+package integration
+
+import java.util.UUID
+
+import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.core.event.UnhealthyInstanceKillEvent
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
+import mesosphere.marathon.raml.{AppHealthCheck, AppHealthCheckProtocol}
+import mesosphere.marathon.state.PathId
+
+import scala.concurrent.duration._
+
+class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
+
+  def appId(suffix: Option[String] = None): PathId = testBasePath / s"app-${suffix.getOrElse(UUID.randomUUID)}"
+
+  "Health checks" should {
+    "kill instance with failing Marathon health checks" in {
+      Given("a deployed app with health checks")
+      val id = appId(Some(s"replace-marathon-http-health-check"))
+      val app = appProxy(id, "v1", instances = 1, healthCheck = None).
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.Http)))
+      val check = registerAppProxyHealthCheck(id, "v1", state = true)
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+
+      When("the app becomes unhealthy")
+      val oldTaskId = marathon.tasks(id).value.head.id
+      check.afterDelay(1.seconds, false)
+
+      Then("the unhealthy instance is killed")
+      waitForEventWith(
+        "unhealthy_instance_kill_event",
+        { event => event.info("taskId") == oldTaskId },
+        "Unhealthy instance killed event was not sent.")
+
+      And("a replacement is started")
+      check.afterDelay(1.seconds, true)
+      eventually {
+        val currentTasks = marathon.tasks(id).value
+        currentTasks should have size (1)
+        currentTasks.map(_.id) should not contain (oldTaskId)
+      }
+    }
+
+    "kill instance with failing Mesos health checks" in {
+      Given("a deployed app with health checks")
+      val id = appId(Some(s"replace-mesos-http-health-check"))
+      val app = appProxy(id, "v1", instances = 1, healthCheck = None).
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.MesosHttp)))
+      val check = registerAppProxyHealthCheck(id, "v1", state = true)
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+
+      When("the app becomes unhealthy")
+      val oldTaskId = marathon.tasks(id).value.head.id
+      val oldInstanceId = Task.Id(oldTaskId).instanceId.idString
+      check.afterDelay(1.seconds, false)
+
+      Then("the unhealthy instance is killed")
+      waitForEventWith(
+        "instance_changed_event",
+        { event => event.info("condition") == "Killed" && event.info("instanceId") == oldInstanceId },
+        "Unhealthy instance killed event was not sent.")
+
+      And("a replacement is started")
+      check.afterDelay(1.seconds, true)
+      eventually {
+        val currentTasks = marathon.tasks(id).value
+        currentTasks should have size (1)
+        currentTasks.map(_.id) should not contain (oldTaskId)
+      }
+    }
+  }
+
+  private def ramlHealthCheck(protocol: AppHealthCheckProtocol) = AppHealthCheck(
+    path = Some("/health"),
+    protocol = protocol,
+    gracePeriodSeconds = 3,
+    intervalSeconds = 1,
+    maxConsecutiveFailures = 3,
+    portIndex = Some(0),
+    delaySeconds = 3
+  )
+}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -388,38 +388,39 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
       simplePod("simple-pod-with-one-instance-wipe-test").copy(instances = 1) -> "simple"
     )
 
-    pods.foreach { case (pod, podType) =>
-      s"wipe $podType pod instance" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
-        Given(s"a $podType pod")
+    pods.foreach {
+      case (pod, podType) =>
+        s"wipe $podType pod instance" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
+          Given(s"a $podType pod")
 
-        When(s"The $podType pod is created")
-        val createResult = marathon.createPodV2(pod)
-        createResult should be(Created)
-        waitForDeployment(createResult)
+          When(s"The $podType pod is created")
+          val createResult = marathon.createPodV2(pod)
+          createResult should be(Created)
+          waitForDeployment(createResult)
 
-        Then("pod status should be stable")
-        eventually {
-          marathon.status(pod.id) should be(Stable)
-        }
+          Then("pod status should be stable")
+          eventually {
+            marathon.status(pod.id) should be(Stable)
+          }
 
-        When("Pods instance is deleted with wipe=true")
-        val status = marathon.status(pod.id)
-        val instanceId = status.value.instances.head.id
-        val deleteResult = marathon.deleteInstance(pod.id, instanceId, wipe = true)
-        deleteResult should be(OK)
-
-        Then("pod instance is erased from marathon's knowledge ")
-        val knownInstanceIds = marathon.status(pod.id).value.instances.map(_.id)
-        knownInstanceIds should not contain instanceId
-
-        And(s"a new pod ${if (podType == "persistent") "with a new persistent volume " else ""}is scheduled")
-        waitForStatusUpdates("TASK_RUNNING")
-        eventually {
+          When("Pods instance is deleted with wipe=true")
           val status = marathon.status(pod.id)
-          status.value.instances should have size 1
-          status.value.instances.map(_.id) should not contain instanceId
+          val instanceId = status.value.instances.head.id
+          val deleteResult = marathon.deleteInstance(pod.id, instanceId, wipe = true)
+          deleteResult should be(OK)
+
+          Then("pod instance is erased from marathon's knowledge ")
+          val knownInstanceIds = marathon.status(pod.id).value.instances.map(_.id)
+          knownInstanceIds should not contain instanceId
+
+          And(s"a new pod ${if (podType == "persistent") "with a new persistent volume " else ""}is scheduled")
+          waitForStatusUpdates("TASK_RUNNING")
+          eventually {
+            val status = marathon.status(pod.id)
+            status.value.instances should have size 1
+            status.value.instances.map(_.id) should not contain instanceId
+          }
         }
-      }
     }
 
     "deploy a simple pod with unique constraint and then " taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {


### PR DESCRIPTION
Summary:
- introduced a new command line argument `--max_concurrent_marathon_health_checks`
  that defines the maximum number of concurrent *Marathon* health checks (HTTP/S and TCP)
- internally all Marathon health checks are now using the same materialized akka-stream 
  MergeHub which throttles the health checks
- `HealthCheckWorkerActor` became `HealthCheckWorker` returning a `Future[HealthResult]`

Backport of #6879, #6870 and #6888.

JIRA issues: MARATHON-8596

Co-authored-by: Aleksey Dukhovniy <adukhovniy@mesosphere.io>