### PR TITLE
Do not fail on offers with RAW and BLOCK disk types

### DIFF
--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -475,7 +475,14 @@ object ResourceMatcher extends StrictLogging {
 
     val diskResources = groupedResources.getOrElse(Resource.DISK, Seq.empty)
 
-    val resourcesByType: Map[DiskType, Seq[Protos.Resource]] = diskResources.groupBy { r =>
+    val withoutUnsupportedTypes = diskResources.filterNot { r =>
+      r.getDiskSourceOption.exists { source =>
+        source.getType == Source.Type.BLOCK ||
+          source.getType == Source.Type.RAW
+      }
+    }
+
+    val resourcesByType: Map[DiskType, Seq[Protos.Resource]] = withoutUnsupportedTypes.groupBy { r =>
       DiskSource.fromMesos(r.getDiskSourceOption).diskType
     }.withDefault(_ => Nil)
 

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -186,6 +186,30 @@ object MarathonTestHelper {
   def pathDisk(path: String): Mesos.Resource.DiskInfo =
     pathDisk(Some(path))
 
+  def rawSource: Mesos.Resource.DiskInfo.Source = {
+    val b = Mesos.Resource.DiskInfo.Source.newBuilder.
+      setType(Mesos.Resource.DiskInfo.Source.Type.RAW)
+    b.build
+  }
+
+  def rawDisk(): Mesos.Resource.DiskInfo = {
+    Mesos.Resource.DiskInfo.newBuilder.
+      setSource(rawSource).
+      build
+  }
+
+  def blockSource: Mesos.Resource.DiskInfo.Source = {
+    val b = Mesos.Resource.DiskInfo.Source.newBuilder.
+      setType(Mesos.Resource.DiskInfo.Source.Type.BLOCK)
+    b.build
+  }
+
+  def blockDisk(): Mesos.Resource.DiskInfo = {
+    Mesos.Resource.DiskInfo.newBuilder.
+      setSource(blockSource).
+      build
+  }
+
   def scalarResource(
     name: String, d: Double, role: String = ResourceRole.Unreserved,
     providerId: Option[protos.ResourceProviderID] = None, reservation: Option[ReservationInfo] = None,

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -26,7 +26,6 @@ import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.{Resource, ResourceProviderID, TextAttribute}
 import mesosphere.util.state.FrameworkId
 import org.apache.mesos.Protos.{Attribute, Offer}
-import org.apache.mesos.Protos.Resource.DiskInfo
 import org.scalatest.Inside
 import org.scalatest.prop.TableDrivenPropertyChecks
 


### PR DESCRIPTION
Summary:
Marathon now will recognize offers with RAW and BLOCK disk types instead always rejecting them, but will refuse to schedule any runSpec that will require it to be used.
RunSpecs which do not require disk at all will be scheduled using such offers.

JIRA issues: MARATHON-8590

