### PR TITLE
Fix restarting unhealthy instances.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthModule.scala
@@ -16,14 +16,14 @@ class HealthModule(
     actorSystem: ActorSystem,
     killService: KillService,
     eventBus: EventStream,
-    taskTracker: InstanceTracker,
+    instanceTracker: InstanceTracker,
     groupManager: GroupManager,
     conf: MarathonConf)(implicit mat: ActorMaterializer) {
   lazy val healthCheckManager = new MarathonHealthCheckManager(
     actorSystem,
     killService,
     eventBus,
-    taskTracker,
+    instanceTracker,
     groupManager,
     conf)
 }

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -28,9 +28,10 @@ private[health] class HealthCheckActor(
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
     eventBus: EventStream,
-    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer)
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])
   extends Actor with StrictLogging {
 
+  implicit val mat = ActorMaterializer()
   import context.dispatcher
 
   val healthByInstanceId = TrieMap.empty[Instance.Id, Health]
@@ -59,7 +60,6 @@ private[health] class HealthCheckActor(
             done.onComplete {
               case Success(_) =>
                 logger.info(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck was stopped")
-                self ! 'restart
 
               case Failure(ex) =>
                 logger.warn(s"HealthCheck stream for app ${app.id} version ${app.version} and healthCheck $healthCheck crashed due to:", ex)
@@ -205,7 +205,7 @@ object HealthCheckActor {
     healthCheck: HealthCheck,
     instanceTracker: InstanceTracker,
     eventBus: EventStream,
-    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed])(implicit mat: ActorMaterializer): Props = {
+    healthCheckHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed]): Props = {
 
     Props(new HealthCheckActor(
       app,

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -87,7 +87,6 @@ private[health] class HealthCheckActor(
   }
 
   def checkConsecutiveFailures(instance: Instance, health: Health): Unit = {
-    logger.info(s"Check consecutive failures for ${instance.instanceId} with health $health")
     val consecutiveFailures = health.consecutiveFailures
     val maxFailures = healthCheck.maxConsecutiveFailures
 
@@ -134,7 +133,6 @@ private[health] class HealthCheckActor(
 
   def handleHealthResult(result: HealthResult): Unit = {
     val instanceId = result.instanceId
-    logger.info(s"Current health states: $healthByInstanceId")
     val health = healthByInstanceId.getOrElse(instanceId, Health(instanceId))
 
     val updatedHealth = result match {
@@ -173,7 +171,7 @@ private[health] class HealthCheckActor(
     val health = instanceHealth.health
     val newHealth = instanceHealth.newHealth
 
-    logger.info(s"Received health result for app [${app.id}] version [${app.version}]: result:=$result, update health=$newHealth")
+    logger.info(s"Received health result for app [${app.id}] version [${app.version}]: [$result]")
     healthByInstanceId += (instanceId -> instanceHealth.newHealth)
     appHealthCheckActor ! HealthCheckStatusChanged(ApplicationKey(app.id, app.version), healthCheck, newHealth)
 

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -33,7 +33,7 @@ private[health] class HealthCheckActor(
 
   import context.dispatcher
 
-  var healthByInstanceId = TrieMap.empty[Instance.Id, Health]
+  val healthByInstanceId = TrieMap.empty[Instance.Id, Health]
 
   override def preStart(): Unit = {
     healthCheck match {
@@ -89,6 +89,7 @@ private[health] class HealthCheckActor(
   }
 
   def checkConsecutiveFailures(instance: Instance, health: Health): Unit = {
+    logger.info(s"Check consecutive failures for ${instance.instanceId} with health $health")
     val consecutiveFailures = health.consecutiveFailures
     val maxFailures = healthCheck.maxConsecutiveFailures
 
@@ -135,6 +136,7 @@ private[health] class HealthCheckActor(
 
   def handleHealthResult(result: HealthResult): Unit = {
     val instanceId = result.instanceId
+    logger.info(s"Current health states: $healthByInstanceId")
     val health = healthByInstanceId.getOrElse(instanceId, Health(instanceId))
 
     val updatedHealth = result match {
@@ -173,7 +175,7 @@ private[health] class HealthCheckActor(
     val health = instanceHealth.health
     val newHealth = instanceHealth.newHealth
 
-    logger.info("Received health result for app [{}] version [{}]: [{}]", app.id, app.version, result)
+    logger.info(s"Received health result for app [${app.id}] version [${app.version}]: result:=$result, update health=$newHealth")
     healthByInstanceId += (instanceId -> instanceHealth.newHealth)
     appHealthCheckActor ! HealthCheckStatusChanged(ApplicationKey(app.id, app.version), healthCheck, newHealth)
 

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -74,10 +74,10 @@ private[health] class HealthCheckActor(
   def purgeStatusOfDoneInstances(instances: Seq[Instance]): Unit = {
     logger.debug(s"Purging health status of inactive instances for app ${app.id} version ${app.version} and healthCheck ${healthCheck}")
 
-    val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isActive).map(_.instanceId)(collection.breakOut)
-    // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
-    // Therefore we materialize it into a new map.
-    healthByInstanceId.filterKeys(activeInstanceIds)
+    val inactiveInstanceIds: Set[Instance.Id] = instances.filterNot(_.isActive).map(_.instanceId)(collection.breakOut)
+    inactiveInstanceIds.foreach { inactiveId =>
+      healthByInstanceId.remove(inactiveId)
+    }
 
     val checksToPurge = instances.withFilter(!_.isActive).map(instance => {
       val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)

--- a/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/impl/HealthCheckActor.scala
@@ -77,9 +77,7 @@ private[health] class HealthCheckActor(
     val activeInstanceIds: Set[Instance.Id] = instances.withFilter(_.isActive).map(_.instanceId)(collection.breakOut)
     // The Map built with filterKeys wraps the original map and contains a reference to activeInstanceIds.
     // Therefore we materialize it into a new map.
-    activeInstanceIds.foreach { activeId =>
-      healthByInstanceId.remove(activeId)
-    }
+    healthByInstanceId.filterKeys(activeInstanceIds)
 
     val checksToPurge = instances.withFilter(!_.isActive).map(instance => {
       val instanceKey = InstanceKey(ApplicationKey(instance.runSpecId, instance.runSpecVersion), instance.instanceId)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -38,6 +38,9 @@ object InstanceTrackerActor {
   /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]]. */
   private[impl] case object List
 
+  /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]] by RunSpec [[PathId]]. */
+  private[impl] case class ListBySpec(appId: PathId)
+
   private[impl] case class Get(instanceId: Instance.Id)
 
   /** Add a new subscription for sender to instance updates */
@@ -138,6 +141,9 @@ private[impl] class InstanceTrackerActor(
 
       case InstanceTrackerActor.List =>
         sender() ! instancesBySpec
+
+      case InstanceTrackerActor.ListBySpec(appId: PathId) =>
+        sender() ! instancesBySpec.specInstances(appId)
 
       case InstanceTrackerActor.Get(instanceId) =>
         sender() ! instancesBySpec.instance(instanceId)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -86,7 +86,7 @@ private[impl] class InstanceTrackerActor(
   override def preStart(): Unit = {
     super.preStart()
 
-    logger.info(s"${getClass.getSimpleName} is starting. Task loading initiated.")
+    logger.info(s"${getClass.getSimpleName} is starting. Instances loading initiated.")
     metrics.resetMetrics()
 
     import context.dispatcher
@@ -104,6 +104,7 @@ private[impl] class InstanceTrackerActor(
   private[this] def initializing: Receive = LoggingReceive.withLabel("initializing") {
     case initialInstances: InstanceTracker.InstancesBySpec =>
       logger.info("Instances loading complete.")
+      logger.info(s"Loaded ${initialInstances.allInstances.size} instances.")
 
       instancesBySpec = initialInstances
       counts = TaskCounts(initialInstances.allInstances, healthStatuses = Map.empty)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -45,7 +45,8 @@ private[tracker] class InstanceTrackerDelegate(
       (instanceTrackerRef ? InstanceTrackerActor.List).mapTo[InstanceTracker.InstancesBySpec].recover {
         case e: AskTimeoutException =>
           throw new TimeoutException(
-            "timeout while calling list. If you know what you are doing, you can adjust the timeout " +
+            "timeout while calling instancesBySpec() (current value = ${config.internalTaskTrackerRequestTimeout().milliseconds}ms." +
+              s"If you know what you are doing, you can adjust the timeout " +
               s"with --${config.internalTaskTrackerRequestTimeout.name}."
           )
       }
@@ -54,17 +55,20 @@ private[tracker] class InstanceTrackerDelegate(
   // TODO(jdef) support pods when counting launched instances
   override def countActiveSpecInstances(appId: PathId): Future[Int] = {
     import scala.concurrent.ExecutionContext.Implicits.global
-    instancesBySpec().map(_.specInstances(appId).count(instance => instance.isActive))
+    specInstances(appId).map(_.count(instance => instance.isActive))
   }
 
-  override def hasSpecInstancesSync(appId: PathId): Boolean = instancesBySpecSync.hasSpecInstances(appId)
+  override def hasSpecInstancesSync(appId: PathId): Boolean = specInstancesSync(appId).nonEmpty
   override def hasSpecInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Boolean] =
-    instancesBySpec().map(_.hasSpecInstances(appId))
+    specInstances(appId).map(_.nonEmpty)
 
-  override def specInstancesSync(appId: PathId): Seq[Instance] =
-    instancesBySpecSync.specInstances(appId)
+  override def specInstancesSync(appId: PathId): Seq[Instance] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    Await.result(specInstances(appId), instanceTrackerQueryTimeout.duration)
+  }
+
   override def specInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] =
-    instancesBySpec().map(_.specInstances(appId))
+    (instanceTrackerRef ? InstanceTrackerActor.ListBySpec(appId)).mapTo[Seq[Instance]]
 
   override def instance(taskId: Instance.Id): Future[Option[Instance]] =
     (instanceTrackerRef ? InstanceTrackerActor.Get(taskId)).mapTo[Option[Instance]]

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -46,7 +46,7 @@ private[tracker] class InstanceTrackerDelegate(
         case e: AskTimeoutException =>
           throw new TimeoutException(
             "timeout while calling instancesBySpec() (current value = ${config.internalTaskTrackerRequestTimeout().milliseconds}ms." +
-              s"If you know what you are doing, you can adjust the timeout " +
+              "If you know what you are doing, you can adjust the timeout " +
               s"with --${config.internalTaskTrackerRequestTimeout.name}."
           )
       }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -280,7 +280,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForDeployment(result)
     }
 
-    "create a simple app with a Mesos TCP healh check" in {
+    "create a simple app with a Mesos TCP health check" in {
       Given("a new app")
       val app = appProxy(appId(Some("with-mesos-tcp-health-check")), "v1", instances = 1, healthCheck = None).
         copy(healthChecks = Set(ramlHealthCheck.copy(protocol = AppHealthCheckProtocol.Tcp)))

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -59,13 +59,12 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       waitForEvent("unhealthy_instance_kill_event")
 
       And("a replacement is started")
-      // This fails.
-      //check.afterDelay(1.seconds, true)
-      //eventually {
-      //  val currentTasks = marathon.tasks(id).value
-      //  currentTasks should have size (1)
-      //  currentTasks.map(_.id) should not contain (oldTaskId)
-      //}
+      check.afterDelay(1.seconds, true)
+      eventually {
+        val currentTasks = marathon.tasks(id).value
+        currentTasks should have size (1)
+        currentTasks.map(_.id) should not contain (oldTaskId)
+      }
     }
   }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -33,7 +33,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       waitForEvent("unhealthy_instance_kill_event")
 
       And("a replacement is started")
-      check.afterDelay(1.seconds, true)
+      check.afterDelay(0.seconds, true)
       eventually {
         val currentTasks = marathon.tasks(id).value
         currentTasks should have size (1)
@@ -59,7 +59,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       waitForEvent("unhealthy_instance_kill_event")
 
       And("a replacement is started")
-      check.afterDelay(1.seconds, true)
+      check.afterDelay(0.seconds, true)
       eventually {
         val currentTasks = marathon.tasks(id).value
         currentTasks should have size (1)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -71,7 +71,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
   private def ramlHealthCheck(protocol: AppHealthCheckProtocol) = AppHealthCheck(
     path = Some("/health"),
     protocol = protocol,
-    gracePeriodSeconds = 0,
+    gracePeriodSeconds = 3,
     intervalSeconds = 1,
     maxConsecutiveFailures = 3,
     portIndex = Some(0),

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -45,7 +45,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       Given("a deployed app with health checks")
       val id = appId(Some(s"replace-mesos-http-health-check"))
       val app = appProxy(id, "v1", instances = 1, healthCheck = None).
-        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.Http)))
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.MesosHttp)))
       val check = registerAppProxyHealthCheck(id, "v1", state = true)
       val result = marathon.createAppV2(app)
       result should be(Created)
@@ -71,10 +71,10 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
   private def ramlHealthCheck(protocol: AppHealthCheckProtocol) = AppHealthCheck(
     path = Some("/health"),
     protocol = protocol,
-    gracePeriodSeconds = 20,
+    gracePeriodSeconds = 0,
     intervalSeconds = 1,
-    maxConsecutiveFailures = 5,
+    maxConsecutiveFailures = 3,
     portIndex = Some(0),
-    delaySeconds = 2
+    delaySeconds = 3
   )
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -1,0 +1,44 @@
+package mesosphere.marathon
+package integration
+
+import java.util.UUID
+
+import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
+import mesosphere.marathon.raml.{AppHealthCheck, AppHealthCheckProtocol}
+import mesosphere.marathon.state.PathId
+
+import scala.concurrent.duration._
+
+class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
+
+  def appId(suffix: Option[String] = None): PathId = testBasePath / s"app-${suffix.getOrElse(UUID.randomUUID)}"
+
+  "Health checks" should {
+    "replace an unhealthy app" in {
+      Given("a deployed app with health checks")
+      val app = appProxy(appId(Some("replace-marathon-http-health-check")), "v1", instances = 1, healthCheck = None).
+        copy(healthChecks = Set(ramlHealthCheck))
+      val check = registerAppProxyHealthCheck(PathId(app.id), "v1", state = true)
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+
+      When("the app becomes unhealthy")
+      check.afterDelay(1.seconds, false)
+
+      Then("the unhealthy instance is killed")
+      waitForEvent("unhealthy_instance_kill_event")
+    }
+  }
+
+  private val ramlHealthCheck = AppHealthCheck(
+    path = Some("/health"),
+    protocol = AppHealthCheckProtocol.Http,
+    gracePeriodSeconds = 20,
+    intervalSeconds = 1,
+    maxConsecutiveFailures = 5,
+    portIndex = Some(0),
+    delaySeconds = 2
+  )
+}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -15,7 +15,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
   def appId(suffix: Option[String] = None): PathId = testBasePath / s"app-${suffix.getOrElse(UUID.randomUUID)}"
 
   "Health checks" should {
-    "replace an unhealthy app" in {
+    "kill unhealthy instance" in {
       Given("a deployed app with health checks")
       val app = appProxy(appId(Some("replace-marathon-http-health-check")), "v1", instances = 1, healthCheck = None).
         copy(healthChecks = Set(ramlHealthCheck))

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -33,7 +33,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       waitForEvent("unhealthy_instance_kill_event")
 
       And("a replacement is started")
-      check.afterDelay(0.seconds, true)
+      check.afterDelay(1.seconds, true)
       eventually {
         val currentTasks = marathon.tasks(id).value
         currentTasks should have size (1)
@@ -59,7 +59,7 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       waitForEvent("unhealthy_instance_kill_event")
 
       And("a replacement is started")
-      check.afterDelay(0.seconds, true)
+      check.afterDelay(1.seconds, true)
       eventually {
         val currentTasks = marathon.tasks(id).value
         currentTasks should have size (1)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -15,26 +15,63 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
   def appId(suffix: Option[String] = None): PathId = testBasePath / s"app-${suffix.getOrElse(UUID.randomUUID)}"
 
   "Health checks" should {
-    "kill unhealthy instance" in {
+    "kill instance with failing Marathon health checks" in {
       Given("a deployed app with health checks")
-      val app = appProxy(appId(Some("replace-marathon-http-health-check")), "v1", instances = 1, healthCheck = None).
-        copy(healthChecks = Set(ramlHealthCheck))
-      val check = registerAppProxyHealthCheck(PathId(app.id), "v1", state = true)
+      val id = appId(Some(s"replace-marathon-http-health-check"))
+      val app = appProxy(id, "v1", instances = 1, healthCheck = None).
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.Http)))
+      val check = registerAppProxyHealthCheck(id, "v1", state = true)
       val result = marathon.createAppV2(app)
       result should be(Created)
       waitForDeployment(result)
 
       When("the app becomes unhealthy")
+      val oldTaskId = marathon.tasks(id).value.head.id
       check.afterDelay(1.seconds, false)
 
       Then("the unhealthy instance is killed")
       waitForEvent("unhealthy_instance_kill_event")
+
+      And("a replacement is started")
+      check.afterDelay(1.seconds, true)
+      eventually {
+        val currentTasks = marathon.tasks(id).value
+        currentTasks should have size (1)
+        currentTasks.map(_.id) should not contain (oldTaskId)
+      }
+    }
+
+    "kill instance with failing Mesos health checks" in {
+      Given("a deployed app with health checks")
+      val id = appId(Some(s"replace-mesos-http-health-check"))
+      val app = appProxy(id, "v1", instances = 1, healthCheck = None).
+        copy(healthChecks = Set(ramlHealthCheck(AppHealthCheckProtocol.Http)))
+      val check = registerAppProxyHealthCheck(id, "v1", state = true)
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+
+      When("the app becomes unhealthy")
+      val oldTaskId = marathon.tasks(id).value.head.id
+      check.afterDelay(1.seconds, false)
+
+      Then("the unhealthy instance is killed")
+      waitForEvent("unhealthy_instance_kill_event")
+
+      And("a replacement is started")
+      // This fails.
+      //check.afterDelay(1.seconds, true)
+      //eventually {
+      //  val currentTasks = marathon.tasks(id).value
+      //  currentTasks should have size (1)
+      //  currentTasks.map(_.id) should not contain (oldTaskId)
+      //}
     }
   }
 
-  private val ramlHealthCheck = AppHealthCheck(
+  private def ramlHealthCheck(protocol: AppHealthCheckProtocol) = AppHealthCheck(
     path = Some("/health"),
-    protocol = AppHealthCheckProtocol.Http,
+    protocol = protocol,
     gracePeriodSeconds = 20,
     intervalSeconds = 1,
     maxConsecutiveFailures = 5,

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/IntegrationHealthCheck.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/IntegrationHealthCheck.scala
@@ -41,8 +41,4 @@ class IntegrationHealthCheck(val appId: PathId, val versionId: String, var state
     logger.debug(s"Get health state from: app=$appId -> $state")
     state
   }
-
-  def forVersion(versionId: String, state: Boolean) = {
-    new IntegrationHealthCheck(appId, versionId, state)
-  }
 }

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -548,8 +548,8 @@ def test_task_gets_restarted_due_to_network_split():
     # introduce a network partition
     common.block_iptable_rules_for_seconds(host, port, sleep_seconds=10, block_input=True, block_output=False)
 
-    # Network partition should cause the task to restart N times untill the partition is resvoled (since we
-    # pinned the task to the split agent). A new task with a new taskId should eventually be runnig and healthy.
+    # Network partition should cause the task to restart N times until the partition is resolved (since we
+    # pinned the task to the split agent). A new task with a new taskId should eventually be running and healthy.
     @retrying.retry(wait_fixed=1000, stop_max_attempt_number=30, retry_on_exception=common.ignore_exception)
     def check_health_message():
         tasks = client.get_tasks(app_id)

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -524,7 +524,7 @@ def test_failing_health_check_results_in_unhealthy_app():
 def test_task_gets_restarted_due_to_network_split():
     """Verifies that a health check fails in presence of a network partition."""
 
-    app_def = apps.http_server()
+    app_def = apps.http_server("app-network-split")
     app_id = app_def["id"]
     app_def['healthChecks'] = [common.health_check()]
     common.pin_to_host(app_def, common.ip_other_than_mom())


### PR DESCRIPTION
Summary:
Certain system tests for apps with Marathon health check fail because we are not
killing unhealthy instances. This is because we would not count the consecutive
health check failures. This change fixes the logic and introduces integration tests
for failing health checks.

JIRA issues: DCOS_OSS-4997

Co-authored-by: Aleksey Dukhovniy <adukhovniy@mesosphere.io>