### PR TITLE
Remove unused option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,9 @@ From now on, apps which uses ids which ends with "restart", "tasks", "versions" 
 We no longer allow a standby Marathon instance to proxy `/v2/events` from Marathon master. Previously it was possible to use `proxy_events` flag to force Marathon
 to proxy the response from `/v2/events`, now it's deprecated. 
 
+### save_tasks_to_launch_timeout was removed
+This option was deprecated since 1.5 and using that have no effect on Marathon. Marathon will no longer start with that option provided.
+
 ### Fixed issues
 
 - [MARATHON-8482](https://jira.mesosphere.com/browse/MARATHON-8482) - We fixed a possibly incorrect behavior around killing overdue tasks: `--task_launch_confirm_timeout` parameter properly controls the time the task spends in `Provisioned` stage (between being launched and receiving `TASK_STAGING` status update).

--- a/src/main/scala/mesosphere/marathon/core/launcher/OfferProcessorConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/OfferProcessorConfig.scala
@@ -5,16 +5,6 @@ import org.rogach.scallop.ScallopConf
 
 trait OfferProcessorConfig extends ScallopConf {
 
-  @deprecated("The save tasks timeout is not used any longer", since = "1.5")
-  lazy val saveTasksToLaunchTimeout = opt[Int](
-    "save_tasks_to_launch_timeout",
-    descr = "Timeout (ms) after matching an offer for saving all matched tasks that we are about to launch. " +
-      "When reaching the timeout, only the tasks that we could save within the timeout are also launched. " +
-      "All other task launches are temporarily rejected and retried later.",
-    default = Some(3000),
-    hidden = true
-  )
-
   lazy val declineOfferDuration = opt[Long](
     "decline_offer_duration",
     descr = "(Default: 120 seconds) " +


### PR DESCRIPTION
We did not do proper deprecation cycle for this but since it's not doing anything since 1.5 and it's said to be *deprecated*...