### PR TITLE
Do not fail on offers with RAW and BLOCK disk types (#6876) (Backport)

### DIFF
--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -473,7 +473,14 @@ object ResourceMatcher extends StrictLogging {
 
     val diskResources = groupedResources.getOrElse(Resource.DISK, Seq.empty)
 
-    val resourcesByType: Map[DiskType, Seq[Protos.Resource]] = diskResources.groupBy { r =>
+    val withoutUnsupportedTypes = diskResources.filterNot { r =>
+      r.getDiskSourceOption.exists { source =>
+        source.getType == Source.Type.BLOCK ||
+          source.getType == Source.Type.RAW
+      }
+    }
+
+    val resourcesByType: Map[DiskType, Seq[Protos.Resource]] = withoutUnsupportedTypes.groupBy { r =>
       DiskSource.fromMesos(r.getDiskSourceOption).diskType
     }.withDefault(_ => Nil)
 

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -190,6 +190,30 @@ object MarathonTestHelper {
   def pathDisk(path: String): Mesos.Resource.DiskInfo =
     pathDisk(Some(path))
 
+  def rawSource: Mesos.Resource.DiskInfo.Source = {
+    val b = Mesos.Resource.DiskInfo.Source.newBuilder.
+      setType(Mesos.Resource.DiskInfo.Source.Type.RAW)
+    b.build
+  }
+
+  def rawDisk(): Mesos.Resource.DiskInfo = {
+    Mesos.Resource.DiskInfo.newBuilder.
+      setSource(rawSource).
+      build
+  }
+
+  def blockSource: Mesos.Resource.DiskInfo.Source = {
+    val b = Mesos.Resource.DiskInfo.Source.newBuilder.
+      setType(Mesos.Resource.DiskInfo.Source.Type.BLOCK)
+    b.build
+  }
+
+  def blockDisk(): Mesos.Resource.DiskInfo = {
+    Mesos.Resource.DiskInfo.newBuilder.
+      setSource(blockSource).
+      build
+  }
+
   def scalarResource(
     name: String, d: Double, role: String = ResourceRole.Unreserved,
     providerId: Option[protos.ResourceProviderID] = None, reservation: Option[ReservationInfo] = None,

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -17,12 +17,12 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.tasks.PortsMatcher
 import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
-import mesosphere.mesos.NoOfferMatchReason.{AgentMaintenance, DeclinedScarceResources, InsufficientCpus, UnfulfilledConstraint}
+import mesosphere.mesos.NoOfferMatchReason.{AgentMaintenance, DeclinedScarceResources, InsufficientCpus, InsufficientDisk, UnfulfilledConstraint}
 import mesosphere.mesos.ResourceMatcher.ResourceSelector
 import mesosphere.mesos.protos.Implicits._
 import mesosphere.mesos.protos.{Resource, ResourceProviderID, TextAttribute}
 import mesosphere.util.state.FrameworkId
-import org.apache.mesos.Protos.Attribute
+import org.apache.mesos.Protos.{Attribute, Offer}
 import org.scalatest.Inside
 import org.scalatest.prop.TableDrivenPropertyChecks
 import java.util.UUID
@@ -1209,6 +1209,97 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
 
       resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
       resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch].reasons.head shouldEqual DeclinedScarceResources
+    }
+
+    List("RAW", "BLOCK").foreach { diskType =>
+
+      def addDiskResource(diskType: String, builder: Offer.Builder) = {
+        diskType match {
+          case "RAW" =>
+            builder.addResources(
+              MarathonTestHelper.scalarResource("disk", 1024.0,
+                disk = Some(MarathonTestHelper.rawDisk())))
+
+          case "BLOCK" =>
+            builder.addResources(
+              MarathonTestHelper.scalarResource("disk", 1024.0,
+                disk = Some(MarathonTestHelper.blockDisk())))
+
+          case other => throw new IllegalArgumentException("expected RAW or BLOCK disk type but got " + other)
+        }
+      }
+
+      s"Match an offer with $diskType disk type if disk is not required" in {
+
+        val offerBuilder = MarathonTestHelper.makeBasicOffer()
+        val diskResourceIndex = offerBuilder.getResourcesList.toIndexedSeq.indexWhere(_.getName == "disk")
+        offerBuilder.removeResources(diskResourceIndex)
+
+        addDiskResource(diskType, offerBuilder)
+
+        val offer = offerBuilder.build()
+
+        val app = AppDefinition(
+          id = "/test".toRootPath,
+          resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
+          portDefinitions = PortDefinitions(0, 0)
+        )
+
+        val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
+
+        resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
+        val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
+
+        res.scalarMatch(Resource.CPUS).get.roles should be(Seq(ResourceRole.Unreserved))
+        res.scalarMatch(Resource.MEM).get.roles should be(Seq(ResourceRole.Unreserved))
+        res.scalarMatch(Resource.DISK) should be(empty)
+
+      }
+
+      s"Match an offer with $diskType disk type if disk is required and there are other disk types available" in {
+        val offerBuilder = MarathonTestHelper.makeBasicOffer()
+
+        addDiskResource(diskType, offerBuilder)
+
+        val offer = offerBuilder.build()
+
+        val app = AppDefinition(
+          id = "/test".toRootPath,
+          resources = Resources(cpus = 1.0, mem = 128.0, disk = 1.0),
+          portDefinitions = PortDefinitions(0, 0)
+        )
+
+        val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
+
+        resourceMatchResponse shouldBe a[ResourceMatchResponse.Match]
+        val res = resourceMatchResponse.asInstanceOf[ResourceMatchResponse.Match].resourceMatch
+
+        res.scalarMatch(Resource.CPUS).get.roles should be(Seq(ResourceRole.Unreserved))
+        res.scalarMatch(Resource.MEM).get.roles should be(Seq(ResourceRole.Unreserved))
+        res.scalarMatch(Resource.DISK) shouldNot be(empty)
+      }
+
+      s"Reject an offer with $diskType disk type if disk is required and there are no other disk types available" in {
+        val offerBuilder = MarathonTestHelper.makeBasicOffer()
+        val diskResourceIndex = offerBuilder.getResourcesList.toIndexedSeq.indexWhere(_.getName == "disk")
+        offerBuilder.removeResources(diskResourceIndex)
+
+        addDiskResource(diskType, offerBuilder)
+
+        val offer = offerBuilder.build()
+
+        val app = AppDefinition(
+          id = "/test".toRootPath,
+          resources = Resources(cpus = 1.0, mem = 128.0, disk = 1.0),
+          portDefinitions = PortDefinitions(0, 0)
+        )
+
+        val resourceMatchResponse = ResourceMatcher.matchResources(offer, app, knownInstances = Seq.empty, unreservedResourceSelector, config, Seq.empty)
+
+        resourceMatchResponse shouldBe a[ResourceMatchResponse.NoMatch]
+        resourceMatchResponse.asInstanceOf[ResourceMatchResponse.NoMatch].reasons.head shouldEqual InsufficientDisk
+      }
+
     }
 
   }


### PR DESCRIPTION
Summary: Marathon now will recognize offers with RAW and BLOCK disk types instead always rejecting them, but will refuse to schedule any runSpec that will require to be used.
RunSpecs which do not require disk at all will be scheduled using such offers.

JIRA issues: MARATHON-8590

(cherry picked from commit 3ec9080edd544f9ac1ed6026170efc177877027b)

