### PR TITLE
Deduce overdue flag correctly and update docs to reflect the actual implementation

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/queue.raml
+++ b/docs/docs/rest-api/public/api/v2/types/queue.raml
@@ -64,7 +64,9 @@ types:
         description: The number of seconds to wait, before the next launch attempt is started.
       overdue:
         type: boolean
-        description: true, if this run spec is backed off. Otherwise false.
+        description: |
+          true, if this run spec is waiting on offers. If false, the run spec is backed off and waits until
+          timeLeftSeconds for the next launch attempt.
 
   QueueObject:
     properties:

--- a/docs/docs/rest-api/public/api/v2/types/queue.raml
+++ b/docs/docs/rest-api/public/api/v2/types/queue.raml
@@ -65,8 +65,8 @@ types:
       overdue:
         type: boolean
         description: |
-          true, if this runspec is waiting on offers. If false, it either means runspec is backed off and waits until
-          timeLeftSeconds for the next launch attempt OR the runspec is healthy.
+          true, if this runspec is waiting on offers. If false, it means runspec is backed off and waits until
+          timeLeftSeconds for the next launch attempt.
 
   QueueObject:
     properties:

--- a/docs/docs/rest-api/public/api/v2/types/queue.raml
+++ b/docs/docs/rest-api/public/api/v2/types/queue.raml
@@ -65,8 +65,8 @@ types:
       overdue:
         type: boolean
         description: |
-          true, if this run spec is waiting on offers. If false, the run spec is backed off and waits until
-          timeLeftSeconds for the next launch attempt.
+          true, if this runspec is waiting on offers. If false, it either means runspec is backed off and waits until
+          timeLeftSeconds for the next launch attempt OR the runspec is healthy.
 
   QueueObject:
     properties:
@@ -76,7 +76,7 @@ types:
         description: The number of instances left to launch.
       delay:
         type: QueueDelay
-        description: If a runspec has failed to often the launch will be delayed. See backoff to tune this behavior.
+        description: If a runspec has failed too often the launch will be delayed. See backoff to tune this behavior.
       since:
         type: datetime
         description: point in time since Marathon has started to launch tasks.

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
@@ -170,7 +170,7 @@ object LaunchStats extends StrictLogging {
   ) {
     def queueDelay(clock: Clock): QueueDelay = {
       val timeLeft = this.backOffUntil.map(clock.now() until _).getOrElse(0.seconds)
-      val overdue = timeLeft.toSeconds < 0
+      val overdue = timeLeft.toSeconds <= 0
       QueueDelay(math.max(0, timeLeft.toSeconds), overdue)
     }
   }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
@@ -170,7 +170,7 @@ object LaunchStats extends StrictLogging {
   ) {
     def queueDelay(clock: Clock): QueueDelay = {
       val timeLeft = this.backOffUntil.map(clock.now() until _).getOrElse(0.seconds)
-      val overdue = timeLeft.toSeconds <= 0
+      val overdue = backOffUntil.isEmpty || timeLeft.toSeconds < 0
       QueueDelay(math.max(0, timeLeft.toSeconds), overdue)
     }
   }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -671,6 +671,11 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       Then("the deployment gets created")
       WaitTestSupport.validFor("deployment visible", 1.second)(marathon.listDeploymentsForPathId(id).value.size == 1)
 
+      Then("overdue flag is set to true")
+      val queueItem = marathon.launchQueue().value.queue.find(_.app.id equals id.toString)
+      queueItem shouldBe defined
+      queueItem.get.delay.overdue shouldBe true
+
       When("the deployment is forcefully removed")
       val delete = marathon.deleteDeployment(deploymentId, force = true)
       delete should be(Accepted)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -672,9 +672,11 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       WaitTestSupport.validFor("deployment visible", 1.second)(marathon.listDeploymentsForPathId(id).value.size == 1)
 
       Then("overdue flag is set to true")
-      val queueItem = marathon.launchQueue().value.queue.find(_.app.id equals id.toString)
-      queueItem shouldBe defined
-      queueItem.get.delay.overdue shouldBe true
+      eventually {
+        val queueItem = marathon.launchQueue().value.queue.find(_.app.id equals id.toString)
+        queueItem shouldBe defined
+        queueItem.get.delay.overdue shouldBe true
+      }
 
       When("the deployment is forcefully removed")
       val delete = marathon.deleteDeployment(deploymentId, force = true)


### PR DESCRIPTION
- This was a regression introduced by making the `backOffUntil` to be an Option. It defaulted to `clock.now()` earlier.
- Also update the documentation to reflect the correct behavior of overdue flag.

JIRA issues: MARATHON-8612