### PR TITLE
Enable suppress by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,9 @@ The default GPU Scheduling Behavior has been changed to `restricted`, and `undef
 
 For more information on `gpu_scheduling_behavior`, please see [the docs](https://mesosphere.github.io/marathon/docs/preferential-gpu-scheduling.html)
 
+### Marathon is now suppressing offers by default
+The default for suppress offers changed in this release and it is now enabled by default. You can still disable suppressing via `--disable_suppress_offers` command line flag.
+
 ### Upgrades only from Marathon 1.6+
 
 You can only upgrade to Marathon 1.8 from 1.6.x and 1.7.x. If you'd like to upgrade from an earlier version you should

--- a/docs/docs/command-line-flags.md
+++ b/docs/docs/command-line-flags.md
@@ -192,7 +192,7 @@ When using Debian packages, the ideal way to customize Marathon is to specify co
     **Note:** This flag has no effect if `--disable_maintenance_mode` is specified.
 * <span class="label label-default">> v1.6.352</span>`--max_running_deployments` (Optional. Default: 100):
     Maximum number of concurrently running deployments. Should the user try to submit more updates than set by this flag a HTTP 403 Error is returned with an explanatory error message.
-* `--[disable_]suppress_offers` (Optional. Default: disabled)
+* `--[disable_]suppress_offers` (Optional. Default: enabled)
     Controls whether or not Marathon will suppress offers if there is nothing to launch. Enabling helps the performance
     of Mesos in larger clusters, but enabling this flag will cause Marathon to more slowly release reservations.
 * <span class="label label-default">v1.6.0</span>`--[disable]_maintenance_mode` (Optional. Default: enabled) Specifies

--- a/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/flow/ReviveOffersConfig.scala
@@ -25,7 +25,7 @@ trait ReviveOffersConfig extends ScallopConf {
 
   lazy val suppressOffers = toggle(
     "suppress_offers",
-    default = Some(false),
+    default = Some(true),
     noshort = true,
     descrYes = "Suppress Mesos offers if Marathon has nothing to launch.",
     descrNo = "(Default) Offers will be continually declined for declineOfferDuration.",


### PR DESCRIPTION
Summary:
We've decided to enable suppress by default even though it can slow down freeing the reservations. We've been running with suppress on our scale tests for a while and everything seems to be working great.

JIRA issues: MARATHON-8297
