### PR TITLE
Verify task and instance id in health check test.

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -377,7 +377,7 @@ class TaskLauncherActorTest extends AkkaUnitTest with Eventually {
 
       val launcherRef = createLauncherRef()
       launcherRef ! RateLimiter.DelayUpdate(f.app.configRef, None)
-     instanceOpFactory.matchOfferRequest(m.any()) returns f.launchResult
+      instanceOpFactory.matchOfferRequest(m.any()) returns f.launchResult
 
       val promise = Promise[MatchedInstanceOps]
       val offer = MarathonTestHelper.makeBasicOffer().build()

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -4,6 +4,9 @@ package integration
 import java.util.UUID
 
 import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.core.event.UnhealthyInstanceKillEvent
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
 import mesosphere.marathon.raml.{AppHealthCheck, AppHealthCheckProtocol}
 import mesosphere.marathon.state.PathId
@@ -30,7 +33,10 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
       check.afterDelay(1.seconds, false)
 
       Then("the unhealthy instance is killed")
-      waitForEvent("unhealthy_instance_kill_event")
+      waitForEventWith(
+        "unhealthy_instance_kill_event",
+        { event => event.info("taskId") == oldTaskId },
+        "Unhealthy instance killed event was not sent.")
 
       And("a replacement is started")
       check.afterDelay(1.seconds, true)
@@ -53,10 +59,14 @@ class HealthCheckIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
 
       When("the app becomes unhealthy")
       val oldTaskId = marathon.tasks(id).value.head.id
+      val oldInstanceId = Task.Id.parse(oldTaskId).instanceId.idString
       check.afterDelay(1.seconds, false)
 
       Then("the unhealthy instance is killed")
-      waitForEvent("unhealthy_instance_kill_event")
+      waitForEventWith(
+        "instance_changed_event",
+        { event => event.info("condition") == "Killed" && event.info("instanceId") == oldInstanceId },
+        "Unhealthy instance killed event was not sent.")
 
       And("a replacement is started")
       check.afterDelay(1.seconds, true)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -4,8 +4,6 @@ package integration
 import java.util.UUID
 
 import mesosphere.AkkaIntegrationTest
-import mesosphere.marathon.core.event.UnhealthyInstanceKillEvent
-import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
 import mesosphere.marathon.raml.{AppHealthCheck, AppHealthCheckProtocol}


### PR DESCRIPTION
Summary:
The helath check integration tests should verify the tasks
that are killed and not that any event arrived. Also, the
Mesos health checks are not sending the kill unhealthy instance
event.