### PR TITLE
Queue instance queries with updates.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/base/RichRuntime.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/RichRuntime.scala
@@ -61,6 +61,5 @@ case class RichRuntime(runtime: Runtime) extends StrictLogging {
 object RichRuntime {
   val DefaultExitDelay = 10.seconds
 
-
   @volatile var ShutdownInProgress = false
 }

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -255,7 +255,7 @@ class TaskReplaceActor(
   /**
     * @return whether [[instance]] has the new run spec version or an old one.
     */
-  def isOldInstance(instance: Instance): Boolean = instance.runSpecVersion.before(runSpec.version)
+  def isOldInstance(instance: Instance): Boolean = instance.runSpecVersion != runSpec.version
 }
 
 object TaskReplaceActor extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -39,7 +39,7 @@ class TaskReplaceActor(
   // Killed resident tasks are not expunged from the instances list. Ignore
   // them. LaunchQueue takes care of launching instances against reservations
   // first
-  val currentInstances = instanceTracker.specInstancesSync(runSpec.id)
+  val currentInstances = instanceTracker.specInstancesAfterPendingUpdatesSync(runSpec.id)
 
   // In case previous master was abdicated while the deployment was still running we might have
   // already started some new tasks.

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -58,7 +58,7 @@ class TaskReplaceActor(
   val oldActiveInstances = oldInstances.filter(_.state.goal == Goal.Running)
 
   // All instances to kill as set for quick lookup
-  private[this] var oldInstanceIds: SortedSet[Id] = oldActiveInstances.map(_.instanceId).to[SortedSet]
+  private[this] var oldActiveInstanceIds: SortedSet[Id] = oldActiveInstances.map(_.instanceId).to[SortedSet]
 
   // All instances to kill queued up
   private[this] val toKill: mutable.Queue[Instance.Id] = oldActiveInstances.map(_.instanceId).to[mutable.Queue]
@@ -130,7 +130,7 @@ class TaskReplaceActor(
   def replaceBehavior: Receive = {
 
     // === An InstanceChanged event for the *new* instance ===
-    case ic: InstanceChanged if !oldInstanceIds(ic.id) =>
+    case ic: InstanceChanged if !isOldInstance(ic.instance) =>
       val id = ic.id
       val condition = ic.condition
       val instance = ic.instance
@@ -150,7 +150,7 @@ class TaskReplaceActor(
       }
 
     // === An InstanceChanged event for the *old* instance ===
-    case ic: InstanceChanged if oldInstanceIds(ic.id) =>
+    case ic: InstanceChanged if isOldInstance(ic.instance) =>
       val id = ic.id
       val condition = ic.condition
       val instance = ic.instance
@@ -159,8 +159,8 @@ class TaskReplaceActor(
       // 1) An old instance terminated out of band and was not yet chosen to be decommissioned or stopped.
       // We stop/decommission the instance and let it be rescheduled with new instance RunSpec
       if (considerTerminal(condition) && goal == Goal.Running) {
-        logger.info(s"Old instance $id became $condition during an upgrade but still has goal Running. We will decommission that instance and launch new one with the new RunSpec.")
-        oldInstanceIds -= id
+        logger.info(s"Old $id became $condition during an upgrade but still has goal Running. We will decommission that instance and launch new one with the new RunSpec.")
+        oldActiveInstanceIds -= id
         instanceTerminated(id)
         val goal = if (runSpec.isResident) Goal.Stopped else Goal.Decommissioned
         instanceTracker.setGoal(instance.instanceId, goal, GoalChangeReason.Upgrading)
@@ -168,7 +168,7 @@ class TaskReplaceActor(
       } // 2) An old and decommissioned instance was successfully killed (or was never launched in the first place if condition == Scheduled)
       else if ((considerTerminal(condition) || condition == Condition.Scheduled) && instance.state.goal.isTerminal()) {
         logger.info(s"Old $id became $condition. Launching more instances.")
-        oldInstanceIds -= id
+        oldActiveInstanceIds -= id
         instanceTerminated(id)
         launchInstances()
           .map(_ => CheckFinished)
@@ -196,14 +196,14 @@ class TaskReplaceActor(
 
   def reconcileAlreadyStartedInstances(): Unit = {
     logger.info(s"Reconciling instances during ${runSpec.id} deployment: found ${instancesAlreadyStarted.size} already started instances " +
-      s"and ${oldInstanceIds.size} old instances: ${if (currentInstances.size > 0) currentInstances.map{ i => i.instanceId -> i.state.condition } else "[]"}")
+      s"and ${oldActiveInstanceIds.size} old instances: ${if (currentInstances.size > 0) currentInstances.map{ i => i.instanceId -> i.state.condition } else "[]"}")
     instancesAlreadyStarted.foreach(reconcileHealthAndReadinessCheck)
   }
 
   // Careful not to make this method completely asynchronous - it changes local actor's state `instancesStarted`.
   // Only launching new instances needs to be asynchronous.
   def launchInstances(): Future[Done] = {
-    val leftCapacity = math.max(0, ignitionStrategy.maxCapacity - oldInstanceIds.size - instancesStarted)
+    val leftCapacity = math.max(0, ignitionStrategy.maxCapacity - oldActiveInstanceIds.size - instancesStarted)
     val instancesNotStartedYet = math.max(0, runSpec.instances - instancesStarted)
     val instancesToStartNow = math.min(instancesNotStartedYet, leftCapacity)
     if (instancesToStartNow > 0) {
@@ -240,17 +240,22 @@ class TaskReplaceActor(
   }
 
   def checkFinished(): Unit = {
-    if (targetCountReached(runSpec.instances) && oldInstanceIds.isEmpty) {
+    if (targetCountReached(runSpec.instances) && oldActiveInstanceIds.isEmpty) {
       logger.info(s"All new instances for $pathId are ready and all old instances have been killed")
       promise.trySuccess(())
       context.stop(self)
     } else {
       logger.info(s"For run spec: [${runSpec.id}] there are [${healthyInstances.size}] healthy and " +
         s"[${readyInstances.size}] ready new instances and " +
-        s"[${oldInstanceIds.size}] old instances (${oldInstanceIds.take(3).map(_.idString).mkString("[", ",", "]")}). " +
+        s"[${oldActiveInstanceIds.size}] old instances (${oldActiveInstanceIds.take(3).map(_.idString).mkString("[", ",", "]")}). " +
         s"Target count is ${runSpec.instances}.")
     }
   }
+
+  /**
+    * @return whether [[instance]] has the new run spec version or an old one.
+    */
+  def isOldInstance(instance: Instance): Boolean = instance.runSpecVersion.before(runSpec.version)
 }
 
 object TaskReplaceActor extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -42,7 +42,6 @@ trait InstanceTracker extends StrictLogging {
     *
     * @param pathId The id of the run spec.
     * @param readAfterWrite If true waits until all pending updates are written before returning instance.
-    * @param ec
     * @return A future sequence of all instances.
     */
   def specInstances(pathId: PathId, readAfterWrite: Boolean)(implicit ec: ExecutionContext): Future[Seq[Instance]]

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -30,6 +30,17 @@ trait InstanceTracker extends StrictLogging {
   def specInstancesSync(pathId: PathId): Seq[Instance]
   def specInstances(pathId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]]
 
+  /** Synchronous blocking version of [[InstanceTracker.specInstancesAfterPendingUpdates()]] */
+  def specInstancesAfterPendingUpdatesSync(appId: PathId): Seq[Instance]
+
+  /**
+    * Similar method to [[InstanceTracker.specInstances()]] but guaranties that all pending updates
+    * for app with {{appId}} are processed first.
+    *
+    * @param appId The app id for which all instances should be fetched.
+    * @return A future sequence of all instances belonging to app with given app id.
+    */
+  def specInstancesAfterPendingUpdates(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]]
   /**
     * List all instances for a run spec with given id.
     *

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -44,12 +44,10 @@ trait InstanceTracker extends StrictLogging {
     * @param readAfterWrite If true waits until all pending updates are written before returning instance.
     * @return A future sequence of all instances.
     */
-  def specInstances(pathId: PathId, readAfterWrite: Boolean)(implicit ec: ExecutionContext): Future[Seq[Instance]]
-  def specInstances(pathId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] = specInstances(pathId, false)
+  def specInstances(pathId: PathId, readAfterWrite: Boolean = false)(implicit ec: ExecutionContext): Future[Seq[Instance]]
 
   /** Synchronous blocking version of [[InstanceTracker.specInstances()]]. */
   def specInstancesSync(pathId: PathId, readAfterWrite: Boolean = false): Seq[Instance]
-  def specInstancesSync(pathId: PathId): Seq[Instance] = specInstancesSync(pathId, false)
 
   /**
     * Look up a specific instance by id.

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -71,11 +71,11 @@ private[tracker] class InstanceTrackerDelegate(
     val query = InstanceTrackerActor.ListBySpec(appId)
 
     val promise = Promise[Seq[Instance]]
-    queue.offer(QueuedQuery(query, promise)).map {
+    queue.offer(QueuedQuery(query, promise)).foreach {
       case QueueOfferResult.Enqueued => logger.info(s"Queued query ${query.appId}")
-      case QueueOfferResult.Dropped => throw new RuntimeException(s"Dropped instance query: $query")
-      case QueueOfferResult.Failure(ex) => throw new RuntimeException(s"Failed to process instance query $query because", ex)
-      case QueueOfferResult.QueueClosed => throw new RuntimeException(s"Failed to process instance query $query because the queue is closed")
+      case QueueOfferResult.Dropped => promise.failure(new RuntimeException(s"Dropped instance query: $query"))
+      case QueueOfferResult.Failure(ex) => promise.failure(new RuntimeException(s"Failed to process instance query $query because", ex))
+      case QueueOfferResult.QueueClosed => promise.failure(new RuntimeException(s"Failed to process instance query $query because the queue is closed"))
     }
     promise.future
   }
@@ -150,11 +150,11 @@ private[tracker] class InstanceTrackerDelegate(
     val update = InstanceTrackerActor.UpdateContext(deadline, stateOp)
 
     val promise = Promise[InstanceUpdateEffect]
-    queue.offer(QueuedUpdate(update, promise)).map {
+    queue.offer(QueuedUpdate(update, promise)).foreach {
       case QueueOfferResult.Enqueued => logger.info(s"Queued ${update.operation.shortString}")
-      case QueueOfferResult.Dropped => throw new RuntimeException(s"Dropped instance update: $update")
-      case QueueOfferResult.Failure(ex) => throw new RuntimeException(s"Failed to process instance update $update because", ex)
-      case QueueOfferResult.QueueClosed => throw new RuntimeException(s"Failed to process instance update $update because the queue is closed")
+      case QueueOfferResult.Dropped => promise.failure(new RuntimeException(s"Dropped instance update: $update"))
+      case QueueOfferResult.Failure(ex) => promise.failure(new RuntimeException(s"Failed to process instance update $update because", ex))
+      case QueueOfferResult.QueueClosed => promise.failure(new RuntimeException(s"Failed to process instance update $update because the queue is closed"))
     }
     promise.future
   }

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -11,9 +11,9 @@ import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult}
 import akka.util.Timeout
 import akka.{Done, NotUsed}
 import mesosphere.marathon.core.async.ExecutionContexts
-import mesosphere.marathon.core.instance.update.{InstancesSnapshot, InstanceChange, InstanceUpdateEffect, InstanceUpdateOperation}
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceUpdateEffect, InstanceUpdateOperation, InstancesSnapshot}
 import mesosphere.marathon.core.instance.{Goal, GoalChangeReason, Instance}
-import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.UpdateContext
+import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.{ListBySpec, UpdateContext}
 import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerConfig}
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.state.{PathId, Timestamp}
@@ -67,8 +67,18 @@ private[tracker] class InstanceTrackerDelegate(
     Await.result(specInstances(appId), instanceTrackerQueryTimeout.duration)
   }
 
-  override def specInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] =
-    (instanceTrackerRef ? InstanceTrackerActor.ListBySpec(appId)).mapTo[Seq[Instance]]
+  override def specInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] = {
+    val query = InstanceTrackerActor.ListBySpec(appId)
+
+    val promise = Promise[Seq[Instance]]
+    queue.offer(QueuedQuery(query, promise)).map {
+      case QueueOfferResult.Enqueued => logger.info(s"Queued query ${query.appId}")
+      case QueueOfferResult.Dropped => throw new RuntimeException(s"Dropped instance query: $query")
+      case QueueOfferResult.Failure(ex) => throw new RuntimeException(s"Failed to process instance query $query because", ex)
+      case QueueOfferResult.QueueClosed => throw new RuntimeException(s"Failed to process instance query $query because the queue is closed")
+    }
+    promise.future
+  }
 
   override def instance(taskId: Instance.Id): Future[Option[Instance]] =
     (instanceTrackerRef ? InstanceTrackerActor.Get(taskId)).mapTo[Option[Instance]]
@@ -80,7 +90,15 @@ private[tracker] class InstanceTrackerDelegate(
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  case class QueuedUpdate(update: UpdateContext, promise: Promise[InstanceUpdateEffect])
+  sealed trait Queued {
+    val idString: String
+  }
+  case class QueuedUpdate(update: UpdateContext, promise: Promise[InstanceUpdateEffect]) extends Queued {
+    override val idString: String = update.appId.toString
+  }
+  case class QueuedQuery(query: ListBySpec, promise: Promise[Seq[Instance]]) extends Queued {
+    override val idString: String = query.appId.toString
+  }
 
   /**
     * Important:
@@ -94,8 +112,8 @@ private[tracker] class InstanceTrackerDelegate(
     */
   // format: OFF
   val queue = Source
-    .queue[QueuedUpdate](config.internalInstanceTrackerUpdateQueueSize(), OverflowStrategy.dropNew)
-    .groupBy(config.internalInstanceTrackerNumParallelUpdates(), queued => Math.abs(queued.update.instanceId.idString.hashCode) % config.internalInstanceTrackerNumParallelUpdates())
+    .queue[Queued](config.internalInstanceTrackerUpdateQueueSize(), OverflowStrategy.dropNew)
+    .groupBy(config.internalInstanceTrackerNumParallelUpdates(), queued => Math.abs(queued.idString.hashCode) % config.internalInstanceTrackerNumParallelUpdates())
     .mapAsync(1){
       case QueuedUpdate(update, promise) =>
         logger.debug(s"Sending update to instance tracker: ${update.operation.shortString}")
@@ -110,6 +128,18 @@ private[tracker] class InstanceTrackerDelegate(
 
         effectF // We already completed the sender promise with the future result (failed or not)
           .transform(_ => Success(Done)) // so here we map the future to a successful one to preserve the stream
+      case QueuedQuery(query, promise) =>
+        logger.debug(s"Sending query to instance tracker: ${query.appId}")
+        val effectF = (instanceTrackerRef ? query)
+          .mapTo[Seq[Instance]]
+          .transform {
+            case s @ Success(_) => logger.info(s"Completed processing instance query ${query.appId}"); s
+            case f @ Failure(e: AskTimeoutException) => logger.error(s"Timed out waiting for response for query $query", e); f
+            case f @ Failure(t: Throwable) => logger.error(s"An unexpected error occurred during query processing of: $query", t); f
+          }
+        promise.completeWith(effectF)
+        effectF
+          .transform(_ => Success(Done))
     }
     .mergeSubstreams
     .toMat(Sink.ignore)(Keep.left)

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -67,7 +67,15 @@ private[tracker] class InstanceTrackerDelegate(
     Await.result(specInstances(appId), instanceTrackerQueryTimeout.duration)
   }
 
-  override def specInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] = {
+  override def specInstances(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] =
+    (instanceTrackerRef ? InstanceTrackerActor.ListBySpec(appId)).mapTo[Seq[Instance]]
+
+  override def specInstancesAfterPendingUpdatesSync(appId: PathId): Seq[Instance] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    Await.result(specInstances(appId), instanceTrackerQueryTimeout.duration)
+  }
+
+  override def specInstancesAfterPendingUpdates(appId: PathId)(implicit ec: ExecutionContext): Future[Seq[Instance]] = {
     val query = InstanceTrackerActor.ListBySpec(appId)
 
     val promise = Promise[Seq[Instance]]

--- a/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
+++ b/src/test/scala/mesosphere/marathon/LaunchQueueModuleTest.scala
@@ -38,7 +38,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     "adding a queue item registers new offer matcher" in fixture { f =>
       import f._
       Given("An empty task tracker")
-      instanceTracker.specInstances(any[PathId])(any) returns Future.successful(Seq.empty)
+      instanceTracker.specInstances(any[PathId], Matchers.eq(false))(any) returns Future.successful(Seq.empty)
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(Instance.scheduled(app))
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))
@@ -57,7 +57,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
 
       Given("An app in the queue")
       val scheduledInstance = Instance.scheduled(app)
-      instanceTracker.specInstances(any[PathId])(any) returns Future.successful(Seq.empty)
+      instanceTracker.specInstances(any[PathId], Matchers.eq(false))(any) returns Future.successful(Seq.empty)
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduledInstance)
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
@@ -81,7 +81,7 @@ class LaunchQueueModuleTest extends AkkaUnitTest with OfferMatcherSpec {
     "an offer gets successfully matched against an item in the queue" in fixture { f =>
       import f._
       Given("An app in the queue")
-      instanceTracker.specInstances(any[PathId])(any) returns Future.successful(Seq.empty)
+      instanceTracker.specInstances(any[PathId], Matchers.eq(false))(any) returns Future.successful(Seq.empty)
       instanceTracker.instancesBySpecSync returns InstanceTracker.InstancesBySpec.forInstances(scheduledInstance)
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -29,7 +29,7 @@ import mesosphere.marathon.stream.Subject
 import mesosphere.marathon.test.GroupCreation
 import org.apache.mesos.Protos.{Status, TaskStatus}
 import org.apache.mesos.SchedulerDriver
-import org.mockito
+import org.mockito.{Matchers => M}
 import org.scalatest.concurrent.Eventually
 
 import scala.collection.immutable.Set
@@ -192,7 +192,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       val instances = Seq(TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance())
 
-      instanceTracker.specInstances(mockito.Matchers.eq("nope".toPath))(mockito.Matchers.any[ExecutionContext]) returns Future.successful(instances)
+      instanceTracker.specInstances(M.eq("nope".toPath), M.eq(false))(M.any[ExecutionContext]) returns Future.successful(instances)
       groupRepo.root() returns Future.successful(createRootGroup(apps = Map(app.id -> app)))
 
       leadershipTransitionInput.offer(LeadershipTransition.ElectedAsLeaderAndReady)
@@ -269,7 +269,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       val plan = DeploymentPlan("d2", origGroup, targetGroup, List(DeploymentStep(List(StopApplication(app)))), Timestamp.now())
 
-      instanceTracker.specInstances(mockito.Matchers.eq(app.id))(any[ExecutionContext]) returns Future.successful(Seq(instance))
+      instanceTracker.specInstances(M.eq(app.id), M.eq(false))(any[ExecutionContext]) returns Future.successful(Seq(instance))
       system.eventStream.subscribe(probe.ref, classOf[UpgradeEvent])
 
       leadershipTransitionInput.offer(LeadershipTransition.ElectedAsLeaderAndReady)
@@ -418,8 +418,8 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     val hcManager: HealthCheckManager = mock[HealthCheckManager]
 
     val instanceTracker: InstanceTracker = mock[InstanceTracker]
-    instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty[Instance])
-    instanceTracker.specInstancesSync(any) returns Seq.empty[Instance]
+    instanceTracker.specInstances(any, M.eq(false))(any) returns Future.successful(Seq.empty[Instance])
+    instanceTracker.specInstancesSync(any, M.eq(false)) returns Seq.empty[Instance]
     instanceTracker.setGoal(any, any, any) returns Future.successful(Done)
     instanceTracker.instanceUpdates returns Source.empty
     val killService = new KillServiceMock(system)

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -88,7 +88,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
 
       val unreachableInstances = Seq.fill(5)(TestInstanceBuilder.newBuilder(app.id).addTaskUnreachableInactive().getInstance())
       val runnningInstances = Seq.fill(10)(TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance())
-      f.instanceTracker.specInstances(eq(app.id))(any[ExecutionContext]) returns Future.successful(unreachableInstances ++ runnningInstances)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any[ExecutionContext]) returns Future.successful(unreachableInstances ++ runnningInstances)
 
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
@@ -104,7 +104,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       val app = MarathonTestHelper.makeBasicApp().copy(instances = 10)
 
       val scheduledInstances = Seq.fill(4)(Instance.scheduled(app))
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(scheduledInstances)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(scheduledInstances)
 
       When("app is scaled")
       f.scheduler.scale(app).futureValue
@@ -119,7 +119,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       Given("an app with 10 instances and an active queue with 10 tasks")
       val app = MarathonTestHelper.makeBasicApp().copy(instances = 10)
       val scheduledInstances = Seq.fill(10)(Instance.scheduled(app))
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(scheduledInstances)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(scheduledInstances)
 
       When("app is scaled")
       f.scheduler.scale(app).futureValue
@@ -135,7 +135,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       Given("an app with 10 instances and an active queue with 10 tasks")
       val app = MarathonTestHelper.makeBasicApp().copy(instances = 10)
       val scheduledInstances = Seq.fill(15)(Instance.scheduled(app))
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(scheduledInstances)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(scheduledInstances)
 
       When("app is scaled")
       f.scheduler.scale(app).futureValue
@@ -170,7 +170,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance()
       )
 
-      f.instanceTracker.specInstances(app.id) returns Future.successful(tasks)
+      f.instanceTracker.specInstances(app.id, false) returns Future.successful(tasks)
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
 
@@ -203,7 +203,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance(stagedAt = 2L)
       )
 
-      f.instanceTracker.specInstances(app.id) returns Future.successful(instances)
+      f.instanceTracker.specInstances(app.id, false) returns Future.successful(instances)
       When("the app is scaled")
       f.scheduler.scale(app).futureValue
 
@@ -240,7 +240,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance(stagedAt = 2L)
       )
 
-      f.instanceTracker.specInstances(app.id) returns Future.successful(tasks)
+      f.instanceTracker.specInstances(app.id, false) returns Future.successful(tasks)
 
       When("the app is scaled")
       f.scheduler.scale(app).futureValue

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -203,7 +203,6 @@ class SchedulerActionsTest extends AkkaUnitTest {
         runningInstance(stagedAt = 2L)
       )
 
-      f.instanceTracker.list(app.id) returns Future.successful(instances)
       f.instanceTracker.specInstances(app.id) returns Future.successful(instances)
       When("the app is scaled")
       f.scheduler.scale(app).futureValue

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -15,6 +15,7 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.test.{JerseyTest, MarathonTestHelper, SettableClock}
 import mesosphere.mesos.NoOfferMatchReason
+import org.mockito.Matchers
 import play.api.libs.json._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -126,7 +127,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
 
     "unknown application backoff can not be removed from the launch queue" in new Fixture {
       //given
-      instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty)
+      instanceTracker.specInstances(any, Matchers.eq(false))(any) returns Future.successful(Seq.empty)
 
       //when
       val response = asyncRequest { r => queueResource.resetDelay("unknown", auth.request, r) }
@@ -139,7 +140,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       //given
       val app = AppDefinition(id = "app".toRootPath)
       val instances = Seq.fill(23)(Instance.scheduled(app))
-      instanceTracker.specInstances(any)(any) returns Future.successful(instances)
+      instanceTracker.specInstances(any, Matchers.eq(false))(any) returns Future.successful(instances)
       groupManager.runSpec(app.id) returns Some(app)
 
       //when
@@ -175,7 +176,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       When("one delay is reset")
       val app = AppDefinition(id = "app".toRootPath)
       val instances = Seq.fill(23)(Instance.scheduled(app))
-      instanceTracker.specInstances(any)(any) returns Future.successful(instances)
+      instanceTracker.specInstances(any, Matchers.eq(false))(any) returns Future.successful(instances)
       groupManager.runSpec(app.id) returns Some(app)
 
       val resetDelay = asyncRequest { r => queueResource.resetDelay("app", req, r) }
@@ -190,7 +191,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       When("one delay is reset")
-      instanceTracker.specInstances(any)(any) returns Future.successful(Seq.empty)
+      instanceTracker.specInstances(any, Matchers.eq(false))(any) returns Future.successful(Seq.empty)
 
       val resetDelay = asyncRequest { r => queueResource.resetDelay("appId", req, r) }
       Then("we receive a not authorized response")

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -140,11 +140,11 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan(origGroup, targetGroup)
 
-      tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
+      tracker.specInstances(Matchers.eq(app1.id), Matchers.eq(false))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
       tracker.specInstancesSync(app2.id, readAfterWrite = true) returns Seq(instance2_1)
-      tracker.specInstances(Matchers.eq(app2.id))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
-      tracker.specInstances(Matchers.eq(app3.id))(any[ExecutionContext]) returns Future.successful(Seq(instance3_1))
-      tracker.specInstances(Matchers.eq(app4.id))(any[ExecutionContext]) returns Future.successful(Seq(instance4_1))
+      tracker.specInstances(Matchers.eq(app2.id), Matchers.eq(false))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
+      tracker.specInstances(Matchers.eq(app3.id), Matchers.eq(false))(any[ExecutionContext]) returns Future.successful(Seq(instance3_1))
+      tracker.specInstances(Matchers.eq(app4.id), Matchers.eq(false))(any[ExecutionContext]) returns Future.successful(Seq(instance4_1))
       tracker.get(instance1_1.instanceId) returns Future.successful(Some(instance1_1))
       tracker.get(instance1_2.instanceId) returns Future.successful(Some(instance1_2))
       tracker.get(instance2_1.instanceId) returns Future.successful(Some(instance2_1))
@@ -188,7 +188,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instance1_1, instance1_2)
       tracker.get(instance1_1.instanceId) returns Future.successful(Some(instance1_1))
       tracker.get(instance1_2.instanceId) returns Future.successful(Some(instance1_2))
-      tracker.specInstances(app.id) returns Future.successful(Seq(instance1_1, instance1_2))
+      tracker.specInstances(app.id, false) returns Future.successful(Seq(instance1_1, instance1_2))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
@@ -249,7 +249,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
       val plan = DeploymentPlan(original = origGroup, target = targetGroup, toKill = Map(app1.id -> Seq(instance1_2)))
 
-      tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2, instance1_3))
+      tracker.specInstances(Matchers.eq(app1.id), Matchers.eq(false))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2, instance1_3))
       tracker.get(instance1_1.instanceId).returns(Future.successful(Some(instance1_1)))
       tracker.get(instance1_2.instanceId).returns(Future.successful(Some(instance1_2)))
       tracker.get(instance1_3.instanceId).returns(Future.successful(Some(instance1_3)))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -141,7 +141,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val plan = DeploymentPlan(origGroup, targetGroup)
 
       tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
-      tracker.specInstancesSync(app2.id) returns Seq(instance2_1)
+      tracker.specInstancesAfterPendingUpdatesSync(app2.id) returns Seq(instance2_1)
       tracker.specInstances(Matchers.eq(app2.id))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
       tracker.specInstances(Matchers.eq(app3.id))(any[ExecutionContext]) returns Future.successful(Seq(instance3_1))
       tracker.specInstances(Matchers.eq(app4.id))(any[ExecutionContext]) returns Future.successful(Seq(instance4_1))
@@ -185,7 +185,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val instance1_1 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp(1000)).getInstance()
 
-      tracker.specInstancesSync(app.id) returns Seq(instance1_1, instance1_2)
+      tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance1_1, instance1_2)
       tracker.get(instance1_1.instanceId) returns Future.successful(Some(instance1_1))
       tracker.get(instance1_2.instanceId) returns Future.successful(Some(instance1_2))
       tracker.specInstances(app.id) returns Future.successful(Seq(instance1_1, instance1_2))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -93,11 +93,10 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
   "DeploymentActor" should {
     "Deploy" in new Fixture {
       val managerProbe = TestProbe()
-      val version1 = VersionInfo.forNewConfig(Timestamp(500))
-      val app1 = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2, versionInfo = version1)
-      val app2 = AppDefinition(id = PathId("/foo/app2"), cmd = Some("cmd"), instances = 1, versionInfo = version1)
-      val app3 = AppDefinition(id = PathId("/foo/app3"), cmd = Some("cmd"), instances = 1, versionInfo = version1)
-      val app4 = AppDefinition(id = PathId("/foo/app4"), cmd = Some("cmd"), versionInfo = version1)
+      val app1 = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2)
+      val app2 = AppDefinition(id = PathId("/foo/app2"), cmd = Some("cmd"), instances = 1)
+      val app3 = AppDefinition(id = PathId("/foo/app3"), cmd = Some("cmd"), instances = 1)
+      val app4 = AppDefinition(id = PathId("/foo/app4"), cmd = Some("cmd"))
       val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(
         app1.id -> app1,
         app2.id -> app2,
@@ -175,8 +174,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
     "Restart app" in new Fixture {
       val managerProbe = TestProbe()
-      val version1 = VersionInfo.forNewConfig(Timestamp(500))
-      val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2, versionInfo = version1)
+      val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2)
       val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -93,10 +93,11 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
   "DeploymentActor" should {
     "Deploy" in new Fixture {
       val managerProbe = TestProbe()
-      val app1 = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2)
-      val app2 = AppDefinition(id = PathId("/foo/app2"), cmd = Some("cmd"), instances = 1)
-      val app3 = AppDefinition(id = PathId("/foo/app3"), cmd = Some("cmd"), instances = 1)
-      val app4 = AppDefinition(id = PathId("/foo/app4"), cmd = Some("cmd"))
+      val version1 = VersionInfo.forNewConfig(Timestamp(500))
+      val app1 = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2, versionInfo = version1)
+      val app2 = AppDefinition(id = PathId("/foo/app2"), cmd = Some("cmd"), instances = 1, versionInfo = version1)
+      val app3 = AppDefinition(id = PathId("/foo/app3"), cmd = Some("cmd"), instances = 1, versionInfo = version1)
+      val app4 = AppDefinition(id = PathId("/foo/app4"), cmd = Some("cmd"), versionInfo = version1)
       val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(
         app1.id -> app1,
         app2.id -> app2,
@@ -174,7 +175,8 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
 
     "Restart app" in new Fixture {
       val managerProbe = TestProbe()
-      val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2)
+      val version1 = VersionInfo.forNewConfig(Timestamp(500))
+      val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2, versionInfo = version1)
       val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -141,7 +141,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val plan = DeploymentPlan(origGroup, targetGroup)
 
       tracker.specInstances(Matchers.eq(app1.id))(any[ExecutionContext]) returns Future.successful(Seq(instance1_1, instance1_2))
-      tracker.specInstancesAfterPendingUpdatesSync(app2.id) returns Seq(instance2_1)
+      tracker.specInstancesSync(app2.id, readAfterWrite = true) returns Seq(instance2_1)
       tracker.specInstances(Matchers.eq(app2.id))(any[ExecutionContext]) returns Future.successful(Seq(instance2_1))
       tracker.specInstances(Matchers.eq(app3.id))(any[ExecutionContext]) returns Future.successful(Seq(instance3_1))
       tracker.specInstances(Matchers.eq(app4.id))(any[ExecutionContext]) returns Future.successful(Seq(instance4_1))
@@ -185,14 +185,12 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val instance1_1 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp(1000)).getInstance()
 
-      tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance1_1, instance1_2)
+      tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instance1_1, instance1_2)
       tracker.get(instance1_1.instanceId) returns Future.successful(Some(instance1_1))
       tracker.get(instance1_2.instanceId) returns Future.successful(Some(instance1_2))
       tracker.specInstances(app.id) returns Future.successful(Seq(instance1_1, instance1_2))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
-
-      tracker.list(appNew.id) returns Future.successful(Seq(instance1_1, instance1_2))
 
       when(queue.add(same(appNew), any[Int])).thenAnswer(new Answer[Future[Done]] {
         def answer(invocation: InvocationOnMock): Future[Done] = {

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -38,7 +38,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
 
@@ -75,7 +75,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       val instanceC = f.runningInstance(newApp)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceC)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
 
@@ -105,7 +105,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      when(f.tracker.specInstancesSync(app.id)).thenReturn(Seq(instanceA, instanceB))
+      when(f.tracker.specInstancesAfterPendingUpdatesSync(app.id)).thenReturn(Seq(instanceA, instanceB))
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
 
@@ -138,7 +138,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      when(f.tracker.specInstancesSync(app.id)).thenReturn(Seq(instanceA, instanceB, instanceC))
+      when(f.tracker.specInstancesAfterPendingUpdatesSync(app.id)).thenReturn(Seq(instanceA, instanceB, instanceC))
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -186,7 +186,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -244,7 +244,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -312,7 +312,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -378,7 +378,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -446,7 +446,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB, instanceC, instanceD)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC, instanceD)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -508,7 +508,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition(id = "/myApp".toPath, instances = 2)
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       val promise = Promise[Unit]()
@@ -529,7 +529,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val port = PortDefinition(0, name = Some(check.portName))
       val app = AppDefinition(id = "/myApp".toPath, instances = 1, portDefinitions = Seq(port), readinessChecks = Seq(check))
       val instance = f.runningInstance(app)
-      f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance)
       f.tracker.get(instance.instanceId) returns Future.successful(Some(instance))
       val (_, readyCheck) = f.readinessResults(instance, check.name, ready = true)
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
@@ -556,7 +556,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         healthChecks = Set(MarathonHttpHealthCheck())
       )
       val instance = f.runningInstance(app)
-      f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance)
       f.tracker.get(instance.instanceId) returns Future.successful(Some(instance))
       val (_, readyCheck) = f.readinessResults(instance, ready.name, ready = true)
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
@@ -582,7 +582,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
 
@@ -617,7 +617,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       val instance = f.runningInstance(app)
 
-      f.tracker.specInstancesSync(app.id) returns Seq(instance)
+      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance)
       f.tracker.get(instance.instanceId) returns Future.successful(Some(instance))
 
       val promise = Promise[Unit]()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -38,7 +38,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
 
@@ -75,7 +75,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       val instanceC = f.runningInstance(newApp)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceC)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
 
@@ -105,7 +105,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      when(f.tracker.specInstancesAfterPendingUpdatesSync(app.id)).thenReturn(Seq(instanceA, instanceB))
+      when(f.tracker.specInstancesSync(app.id, readAfterWrite = true)).thenReturn(Seq(instanceA, instanceB))
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
 
@@ -138,7 +138,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      when(f.tracker.specInstancesAfterPendingUpdatesSync(app.id)).thenReturn(Seq(instanceA, instanceB, instanceC))
+      when(f.tracker.specInstancesSync(app.id, readAfterWrite = true)).thenReturn(Seq(instanceA, instanceB, instanceC))
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -186,7 +186,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -244,7 +244,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -312,7 +312,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -378,7 +378,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceB = f.runningInstance(app)
       val instanceC = f.runningInstance(app)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB, instanceC)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -446,7 +446,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB, instanceC, instanceD)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB, instanceC, instanceD)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       f.tracker.get(instanceC.instanceId) returns Future.successful(Some(instanceC))
@@ -508,7 +508,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition(id = "/myApp".toPath, instances = 2)
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
       val promise = Promise[Unit]()
@@ -529,7 +529,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val port = PortDefinition(0, name = Some(check.portName))
       val app = AppDefinition(id = "/myApp".toPath, instances = 1, portDefinitions = Seq(port), readinessChecks = Seq(check))
       val instance = f.runningInstance(app)
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instance)
       f.tracker.get(instance.instanceId) returns Future.successful(Some(instance))
       val (_, readyCheck) = f.readinessResults(instance, check.name, ready = true)
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
@@ -556,7 +556,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         healthChecks = Set(MarathonHttpHealthCheck())
       )
       val instance = f.runningInstance(app)
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instance)
       f.tracker.get(instance.instanceId) returns Future.successful(Some(instance))
       val (_, readyCheck) = f.readinessResults(instance, ready.name, ready = true)
       f.readinessCheckExecutor.execute(any[ReadinessCheckExecutor.ReadinessCheckSpec]) returns readyCheck
@@ -582,7 +582,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       val instanceA = f.runningInstance(app)
       val instanceB = f.runningInstance(app)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instanceA, instanceB)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB)
       f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
       f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
 
@@ -617,7 +617,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       val instance = f.runningInstance(app)
 
-      f.tracker.specInstancesAfterPendingUpdatesSync(app.id) returns Seq(instance)
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instance)
       f.tracker.get(instance.instanceId) returns Future.successful(Some(instance))
 
       val promise = Promise[Unit]()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -542,7 +542,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       promise.future.futureValue
     }
 
-    " wait for the readiness checks and health checks if all tasks are replaced already" in {
+    "wait for the readiness checks and health checks if all tasks are replaced already" in {
       Given("An app without health checks but readiness checks, as well as 1 task of this version")
       val f = new Fixture
       val ready = ReadinessCheck()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -30,7 +30,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(Seq.empty)
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
 
@@ -50,7 +50,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
       val instances: Seq[Instance] = Seq(Instance.scheduled(app))
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(instances)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(instances)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -71,7 +71,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val app = AppDefinition("/myApp".toPath, instances = 5)
 
       val instances: Seq[Instance] = Seq(TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance())
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(instances)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(instances)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -91,7 +91,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 0)
 
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -109,7 +109,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         instances = 5,
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -132,7 +132,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
         instances = 0,
         healthChecks = Set(MesosCommandHealthCheck(command = Command("true")))
       )
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -147,7 +147,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 2)
 
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -173,7 +173,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 2)
 
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)
@@ -198,7 +198,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       val promise = Promise[Unit]()
       val app = AppDefinition("/myApp".toPath, instances = 2)
 
-      f.instanceTracker.specInstances(eq(app.id))(any) returns Future.successful(Seq.empty)
+      f.instanceTracker.specInstances(eq(app.id), eq(false))(any) returns Future.successful(Seq.empty)
 
       val ref = f.startActor(app, app.instances, promise)
       watch(ref)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -74,7 +74,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
   "HealthCheckActor" should {
     //regression test for #934
     "should not dispatch health checks for staging tasks" in new Fixture {
-      instanceTracker.specInstances(any)(any) returns Future.successful(Seq(instance))
+      instanceTracker.specInstances(any, anyBoolean)(any) returns Future.successful(Seq(instance))
 
       val actor = healthCheckActor()
 
@@ -82,7 +82,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
     }
 
     "should not dispatch health checks for lost tasks" in new Fixture {
-      instanceTracker.specInstances(any)(any) returns Future.successful(Seq(lostInstance))
+      instanceTracker.specInstances(any, anyBoolean)(any) returns Future.successful(Seq(lostInstance))
 
       val actor = healthCheckActor()
 
@@ -90,7 +90,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
     }
 
     "should not dispatch health checks for unreachable tasks" in new Fixture {
-      instanceTracker.specInstances(any)(any) returns Future.successful(Seq(unreachableInstance))
+      instanceTracker.specInstances(any, anyBoolean)(any) returns Future.successful(Seq(unreachableInstance))
 
       val actor = healthCheckActor()
 

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/LaunchQueueActorTest.scala
@@ -39,7 +39,7 @@ class LaunchQueueActorTest extends AkkaUnitTest with ImplicitSender {
       Given("A LaunchQueueActor with a task launcher for app /foo")
       instanceTracker.process(any[InstanceUpdateOperation]) returns Future.successful[InstanceUpdateEffect](InstanceUpdateEffect.Noop(null))
       instanceTracker.schedule(any[Seq[Instance]])(any) returns Future.successful(Done)
-      instanceTracker.specInstances(any[PathId])(any) returns Future.successful(Seq.empty)
+      instanceTracker.specInstances(any[PathId], anyBoolean)(any) returns Future.successful(Seq.empty)
       launchQueue.ask(LaunchQueueDelegate.Add(app, 3)).futureValue
 
       When("An InstanceChange is send to the task launcher actor")

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -181,17 +181,17 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       lazy val delegate = new InstanceTrackerDelegate(f.metrics, f.clock, config, f.instanceTrackerProbe.ref)
 
       And("three queued queries")
-      delegate.specInstances(appId) // On way to instance tracker
-      delegate.specInstances(appId) // In mapAsync
-      delegate.specInstances(appId) // In queue buffer
+      delegate.specInstancesAfterPendingUpdates(appId) // On way to instance tracker
+      delegate.specInstancesAfterPendingUpdates(appId) // In mapAsync
+      delegate.specInstancesAfterPendingUpdates(appId) // In queue buffer
 
       When("we query a fourth time")
-      val result = delegate.specInstances(appId)
+      val result = delegate.specInstancesAfterPendingUpdates(appId)
 
       Then("the query fails")
       val failure = result.failed.futureValue
       failure shouldBe a[RuntimeException]
-      failure should have message("Dropped instance query: ListBySpec(/test)")
+      failure should have message ("Dropped instance query: ListBySpec(/test)")
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -180,15 +180,18 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
         "--instance_tracker_num_parallel_updates", "1")
       lazy val delegate = new InstanceTrackerDelegate(f.metrics, f.clock, config, f.instanceTrackerProbe.ref)
 
-      And("two queued queries")
-      delegate.specInstances(appId)
-      delegate.specInstances(appId)
+      And("three queued queries")
+      delegate.specInstances(appId) // On way to instance tracker
+      delegate.specInstances(appId) // In mapAsync
+      delegate.specInstances(appId) // In queue buffer
 
-      When("we query a third time")
+      When("we query a fourth time")
       val result = delegate.specInstances(appId)
 
       Then("the query fails")
-      result.failed.futureValue shouldBe a[RuntimeException]
+      val failure = result.failed.futureValue
+      failure shouldBe a[RuntimeException]
+      failure should have message("Dropped instance query: ListBySpec(/test)")
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegateTest.scala
@@ -181,12 +181,12 @@ class InstanceTrackerDelegateTest extends AkkaUnitTest {
       lazy val delegate = new InstanceTrackerDelegate(f.metrics, f.clock, config, f.instanceTrackerProbe.ref)
 
       And("three queued queries")
-      delegate.specInstancesAfterPendingUpdates(appId) // On way to instance tracker
-      delegate.specInstancesAfterPendingUpdates(appId) // In mapAsync
-      delegate.specInstancesAfterPendingUpdates(appId) // In queue buffer
+      delegate.specInstances(appId, readAfterWrite = true) // On way to instance tracker
+      delegate.specInstances(appId, readAfterWrite = true) // In mapAsync
+      delegate.specInstances(appId, readAfterWrite = true) // In queue buffer
 
       When("we query a fourth time")
-      val result = delegate.specInstancesAfterPendingUpdates(appId)
+      val result = delegate.specInstances(appId, readAfterWrite = true)
 
       Then("the query fails")
       val failure = result.failed.futureValue

--- a/tests/shakedown/shakedown/clients/marathon.py
+++ b/tests/shakedown/shakedown/clients/marathon.py
@@ -512,17 +512,13 @@ class Client(object):
         :rtype: [dict]
         """
 
-        response = self._rpc.session.get('v2/tasks')
-
         if app_id is not None:
             app_id = util.normalize_marathon_id_path(app_id)
-            tasks = [
-                task for task in response.json()['tasks']
-                if app_id == task['appId']
-            ]
+            response = self._rpc.session.get('v2/{}/tasks'.format(app_id))
         else:
-            tasks = response.json()['tasks']
+            response = self._rpc.session.get('v2/tasks')
 
+        tasks = response.json()['tasks']
         return tasks
 
     def get_task(self, task_id):

--- a/tests/shakedown/shakedown/clients/marathon.py
+++ b/tests/shakedown/shakedown/clients/marathon.py
@@ -512,13 +512,17 @@ class Client(object):
         :rtype: [dict]
         """
 
+        response = self._rpc.session.get('v2/tasks')
+
         if app_id is not None:
             app_id = util.normalize_marathon_id_path(app_id)
-            response = self._rpc.session.get('v2/{}/tasks'.format(app_id))
+            tasks = [
+                task for task in response.json()['tasks']
+                if app_id == task['appId']
+            ]
         else:
-            response = self._rpc.session.get('v2/tasks')
+            tasks = response.json()['tasks']
 
-        tasks = response.json()['tasks']
         return tasks
 
     def get_task(self, task_id):


### PR DESCRIPTION
Summary:
A deployment cancellation can lead to a instance leak. This happens when
and update by the cancelled deployment is queued or saved in Zookeeper
while the new deployment, eg a rollback, is querying the instances from
the instance tracker. The instance tracker did not see the effect of the
update yet. So far queries by-pass updates. This change queues the
`ListBySpec` queries with instance update operations. This way a query
is guranteed to see all pending updates. We might still run into issues
when updates follow a query. Also, this works only on a run spec level
and not when all specs are queried.

JIRA issues: DCOS-51375