### PR TITLE
Prevent a rare but benign NPE when a deployment is canceled

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentActor.scala
@@ -173,9 +173,12 @@ private class DeploymentActor(
       def startInstancesIfNeeded: Future[Done] = {
         logger.debug(s"Start next $tasksToStart tasks")
         val promise = Promise[Unit]()
-        context.actorOf(childSupervisor(TaskStartActor.props(deploymentManagerActor, status, launchQueue, instanceTracker, eventBus,
+        val startActor = context.actorOf(childSupervisor(TaskStartActor.props(deploymentManagerActor, status, launchQueue, instanceTracker, eventBus,
           readinessCheckExecutor, runnableSpec, scaleTo, promise), s"TaskStart-${plan.id}"))
-        promise.future.map(_ => Done)
+        promise.future.map(_ => {
+          context.stop(startActor)
+          Done
+        })
       }
       await(startInstancesIfNeeded)
     }

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskStartActor.scala
@@ -110,7 +110,6 @@ class TaskStartActor(
     // Since a lot of actor's code happens asynchronously now
     // it can happen that this promise might succeed twice.
     promise.trySuccess(())
-    context.stop(self)
   }
 }
 

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskStartActorTest.scala
@@ -41,6 +41,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -62,6 +63,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -83,6 +85,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -98,6 +101,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -121,6 +125,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -139,6 +144,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -165,6 +171,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
       // that is now handled within the scheduler itself so if the goal is running, orchestrator should not do anything
       verify(f.launchQueue, never).add(app, 1)
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -190,6 +197,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
 
@@ -215,6 +223,7 @@ class TaskStartActorTest extends AkkaUnitTest with Eventually {
 
       promise.future.futureValue should be(())
 
+      system.stop(ref)
       expectTerminated(ref)
     }
   }


### PR DESCRIPTION
Summary:
This is causing NPE being thrown when `TaskStartActor` is stopped before while some internal asynchronous call is in flight. See JIRA for full context.

JIRA issues: MARATHON-8616