### PR TITLE
Introduce new exit error code when the framework was removed from Mesos

### DIFF
--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -8,17 +8,17 @@ Marathon follows the [Let-it-crash](https://www.reactivedesignpatterns.com/patte
 of trying to fix an illegal state it will stop itself to be restarted by its supervisor. The following exit codes should
 help you figure out why the Marathon process stopped.
 
-| Exit Code | Reason                                                               |
-|-----------|----------------------------------------------------------------------|
-|100        | `ZookeeperConnectionFailure` - Could not connect to Zookeeper        |
-|101        | `ZookeeperConnectionLost` - Lost connect to Zookeeper                |
-|102        | `PluginInitializationFailure` - Could not load plugin                |
-|103        | `LeadershipLoss` - Lost leadership                                   |
-|104        | `LeadershipEndedFaulty` - Leadership ended with an error             |
-|105        | `LeadershipEndedGracefully` - Leadership ended without an error      |
-|106        | `MesosSchedulerError` - The Mesos scheduler driver had an error      |
-|107        | `UncaughtException` - An internal unknown error could not be handled |
-|108        | The Framework ID could not be read                                   |
-|109        | Provided LibMesos version is incompatible                            |
-|110        | Framework has been removed via Mesos teardown call                   |
-|137        | Killed by an external process or uncaught exception                  |
+| Exit Code | Reason                                                                       |
+|-----------|-------------------------------------------------------------------------------|
+|100        | `ZookeeperConnectionFailure` - Could not connect to Zookeeper                 |
+|101        | `ZookeeperConnectionLost` - Lost connect to Zookeeper                         |
+|102        | `PluginInitializationFailure` - Could not load plugin                         |
+|103        | `LeadershipLoss` - Lost leadership                                            |
+|104        | `LeadershipEndedFaulty` - Leadership ended with an error                      |
+|105        | `LeadershipEndedGracefully` - Leadership ended without an error               |
+|106        | `MesosSchedulerError` - The Mesos scheduler driver had an error               |
+|107        | `UncaughtException` - An internal unknown error could not be handled          |
+|108        | `FrameworkIdMissing` The Framework ID could not be read                       |
+|109        | `IncompatibleLibMesos` Provided LibMesos version is incompatible              |
+|110        | `FrameworkHasBeenRemoved` Framework has been removed via Mesos teardown call  |
+|137        | Killed by an external process or uncaught exception                           |

--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -18,6 +18,7 @@ help you figure out why the Marathon process stopped.
 |105        | `LeadershipEndedGracefully` - Leadership ended without an error      |
 |106        | `MesosSchedulerError` - The Mesos scheduler driver had an error      |
 |107        | `UncaughtException` - An internal unknown error could not be handled |
-|108        | The Framework ID could not be read.                                  |
-|109        | Provided LibMesos version is incompatible.                           |
+|108        | The Framework ID could not be read                                   |
+|109        | Provided LibMesos version is incompatible                            |
+|110        | Framework has been removed via Mesos teardown call                   |
 |137        | Killed by an external process or uncaught exception                  |

--- a/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonScheduler.scala
@@ -116,7 +116,12 @@ class MarathonScheduler(
       "In case Mesos does not allow registration with the current frameworkId, " +
       "follow the instructions for recovery here: https://mesosphere.github.io/marathon/docs/framework-id.html")
 
-    crashStrategy.crash(CrashStrategy.MesosSchedulerError)
+    if (message.contains("Framework has been removed")) {
+      crashStrategy.crash(CrashStrategy.FrameworkHasBeenRemoved)
+    }
+    else {
+      crashStrategy.crash(CrashStrategy.MesosSchedulerError)
+    }
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -23,6 +23,7 @@ object CrashStrategy {
   case object UncaughtException extends Reason { override val code: Int = 107 }
   case object FrameworkIdMissing extends Reason { override val code: Int = 108 }
   case object IncompatibleLibMesos extends Reason { override val code: Int = 109 }
+  case object FrameworkHasBeenRemoved extends Reason { override val code: Int = 110 }
 }
 
 case object JvmExitsCrashStrategy extends CrashStrategy {


### PR DESCRIPTION
Summary:
new error code `110` covers the case when Marathon was removed via Mesos `teardown` call.