### PR TITLE
Used wide and unlimited output when printing info about leaked processes during builds

### DIFF
--- a/ci/provision.sc
+++ b/ci/provision.sc
@@ -62,7 +62,7 @@ def eligibleProcess(proc: String): Boolean =
 /**
   * @return list of leaked process names.
   */
-def leakedProcesses() = %%('ps, 'aux).out.lines.filter { proc =>
+def leakedProcesses() = %%('ps, 'auxww).out.lines.filter { proc =>
   eligibleProcess(proc) && !protectedProcess(proc)
 }
 


### PR DESCRIPTION
```
$ man ps
...
-w     Wide output.  Use this option twice for unlimited width.
```