### PR TITLE
Add simple troubleshooting sections for exit codes

### DIFF
--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -31,7 +31,7 @@ One or more configured plugins could not be initialized. Please check your plugi
 
 ### 108 Missing Framework ID
 
-The configured zookeeper path contains references to the launched app or pod instances but it does not contain a Framework ID for registration with Mesos. Marathon will not register without a Framework ID since this would orphan any existing app or pod instances. Please see the documentation on [Framework ID registration](framework-id.html).
+The configured zookeeper path contains references to any app or pod instances but it does not contain a Framework ID for registration with Mesos. Marathon will not register without a Framework ID since this would orphan any existing app or pod instances. Please see the documentation on [Framework ID registration](framework-id.html).
 
 ### 110 Framework Has Been Removed
 

--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -31,7 +31,7 @@ One or more configured plugins could not be initialized. Please check your plugi
 
 ### 108 Missing Framework ID
 
-The configured zookeeper path contains references to launched app or pod instances. However, it does not provide a Framework ID for registration with Mesos. Marathon will not register without a Framework ID, since this would orphan any existing app or pod instances. Please see the documentation on [Framework ID registration](framework-id.html).
+The configured zookeeper path contains references to the launched app or pod instances but it does not contain a Framework ID for registration with Mesos. Marathon will not register without a Framework ID since this would orphan any existing app or pod instances. Please see the documentation on [Framework ID registration](framework-id.html).
 
 ### 110 Framework Has Been Removed
 

--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -8,7 +8,7 @@ Marathon follows the [Let-it-crash](https://www.reactivedesignpatterns.com/patte
 of trying to fix an illegal state it will stop itself to be restarted by its supervisor. The following exit codes should
 help you figure out why the Marathon process stopped.
 
-| Exit Code | Reason                                                                       |
+| Exit Code | Reason                                                                        |
 |-----------|-------------------------------------------------------------------------------|
 |100        | `ZookeeperConnectionFailure` - Could not connect to Zookeeper                 |
 |101        | `ZookeeperConnectionLost` - Lost connect to Zookeeper                         |
@@ -22,3 +22,17 @@ help you figure out why the Marathon process stopped.
 |109        | `IncompatibleLibMesos` Provided LibMesos version is incompatible              |
 |110        | `FrameworkHasBeenRemoved` Framework has been removed via Mesos teardown call  |
 |137        | Killed by an external process or uncaught exception                           |
+
+## Troubleshooting Exit Codes
+
+### 102 Plugin Initialization Failure
+
+One or more configured plugins could not be initialized. Please check your plugin configuration and the compatibility of the loaded plugin.
+
+### 108 Missing Framework ID
+
+The configured zookeeper path contains references to launched app or pod instances. However, it does not provide a Framework ID for registration with Mesos. Marathon will not register without a Framework ID, since this would orphan any existing app or pod instances. Please see the documentation on [Framework ID registration](framework-id.html).
+
+### 110 Framework Has Been Removed
+
+The Framework ID stored in zookeeper is no longer valid for registration with Mesos. Most likely, it has been torn down via the Mesos Master `teardown` endpoint. You should clean up the existing zookeeper node that the Marathon is configured to use. Note that the state may not contain any instances, otherwise Marathon will crash with a `108` exit code. You may keep app or pod definitions, but do this at your own risk.


### PR DESCRIPTION
Summary:
The documentation about exit codes did not contain any help as to what a user can do to troubleshoot the underlying issues. This is an attempt at adding at least a little more guidance as to what the error codes really mean, and how to mitigate.

Co-authored-by: Aleksey Dukhovniy <adukhovniy@mesosphere.io>