### PR TITLE
Better handle invalid state command exceptions in InstanceTrackerActor

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/CoreModuleImpl.scala
@@ -96,7 +96,7 @@ class CoreModuleImpl @Inject() (
   val storageExecutionContext = NamedExecutionContext.fixedThreadPoolExecutionContext(marathonConf.asInstanceOf[StorageConf].storageExecutionContextSize(), "storage-module")
   override lazy val instanceTrackerModule =
     new InstanceTrackerModule(metricsModule.metrics, clock, marathonConf, leadershipModule,
-      storageModule.instanceRepository, storageModule.groupRepository, instanceUpdateSteps)(actorsModule.materializer)
+      storageModule.instanceRepository, storageModule.groupRepository, instanceUpdateSteps, crashStrategy)(actorsModule.materializer)
   override lazy val taskJobsModule = new TaskJobsModule(marathonConf, leadershipModule, clock)
 
   override lazy val storageModule = StorageModule(

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -16,14 +16,14 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation, InstanceUpdated, InstancesSnapshot}
 import mesosphere.marathon.core.leadership.LeaderDeferrable
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.{RepositoryStateUpdated, UpdateContext}
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor, impl}
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor}
 import mesosphere.marathon.metrics.{Metrics, SettableGauge}
 import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.storage.repository.InstanceView
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 object InstanceTrackerActor {
   def props(

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -11,18 +11,19 @@ import akka.event.LoggingReceive
 import akka.pattern.pipe
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.TaskCounts
+import mesosphere.marathon.core.base.CrashStrategy
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation, InstancesSnapshot, InstanceUpdated}
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation, InstanceUpdated, InstancesSnapshot}
 import mesosphere.marathon.core.leadership.LeaderDeferrable
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.{RepositoryStateUpdated, UpdateContext}
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor}
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor, impl}
 import mesosphere.marathon.metrics.{Metrics, SettableGauge}
 import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.storage.repository.InstanceView
 
 import scala.concurrent.Future
 import scala.util.control.NonFatal
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 object InstanceTrackerActor {
   def props(
@@ -31,8 +32,9 @@ object InstanceTrackerActor {
     updateStepProcessor: InstanceTrackerUpdateStepProcessor,
     stateOpResolver: InstanceUpdateOpResolver,
     repository: InstanceView,
-    clock: Clock): Props = {
-    Props(new InstanceTrackerActor(metrics, taskLoader, updateStepProcessor, stateOpResolver, repository, clock))
+    clock: Clock,
+    crashStrategy: CrashStrategy): Props = {
+    Props(new InstanceTrackerActor(metrics, taskLoader, updateStepProcessor, stateOpResolver, repository, clock, crashStrategy))
   }
 
   /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]]. */
@@ -75,7 +77,8 @@ private[impl] class InstanceTrackerActor(
     updateStepProcessor: InstanceTrackerUpdateStepProcessor,
     updateOperationResolver: InstanceUpdateOpResolver,
     repository: InstanceView,
-    clock: Clock) extends Actor with Stash with StrictLogging {
+    clock: Clock,
+    crashStrategy: CrashStrategy) extends Actor with Stash with StrictLogging {
 
   // Internal state of the tracker. It is set after initialization.
   var instancesBySpec: InstanceTracker.InstancesBySpec = _
@@ -97,6 +100,17 @@ private[impl] class InstanceTrackerActor(
     metrics.resetMetrics()
 
     super.postStop()
+  }
+
+  override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
+    /* Recovering instanceTracker leads to increased complexity for components that depend on InstanceTracker; for
+     * example, instanceTrackerState subscriptions become invalid and have to recover.
+     *
+     * Instead, we'd prefer to handle exceptions as best we can locally, and then treat unforeseen exceptions as a panic.
+     */
+    logger.error("InstanceTrackerActor had an unexpected exception! Crashing", reason)
+    crashStrategy.crash(CrashStrategy.UncaughtException)
+    super.preRestart(reason, message)
   }
 
   override def receive: Receive = initializing
@@ -153,7 +167,9 @@ private[impl] class InstanceTrackerActor(
         logger.info(s"Processing ${update.operation.shortString}")
 
         val originalSender = sender
-        val updateEffect = resolveUpdateEffect(update)
+        val updateEffect = try {
+          resolveUpdateEffect(update)
+        } catch { case ex => InstanceUpdateEffect.Failure(ex) }
         import scala.concurrent.ExecutionContext.Implicits.global
 
         updateEffect match {

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -40,28 +40,28 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val f = new Fixture
 
         Given("a failing task loader")
-        f.taskLoader.load() returns Future.failed(new RuntimeException("severe simulated loading failure"))
+        f.instancesLoader.load() returns Future.failed(new RuntimeException("severe simulated loading failure"))
 
         When("the task tracker starts")
-        f.taskTrackerActor
+        f.instanceTrackerActor
 
         Then("it will call the failing load method")
-        verify(f.taskLoader).load()
+        verify(f.instancesLoader).load()
 
         And("it will eventually die")
-        watch(f.taskTrackerActor)
-        expectMsgClass(classOf[Terminated]).getActor should be(f.taskTrackerActor)
+        watch(f.instanceTrackerActor)
+        expectMsgClass(classOf[Terminated]).getActor should be(f.instanceTrackerActor)
       }
 
       "answers with loaded data (empty)" in {
         val f = new Fixture
         Given("an empty task loader result")
         val appDataMap = InstanceTracker.InstancesBySpec.empty
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("the task tracker actor gets a List query")
         val probe = TestProbe()
-        probe.send(f.taskTrackerActor, InstanceTrackerActor.List)
+        probe.send(f.instanceTrackerActor, InstanceTrackerActor.List)
 
         Then("it will eventually answer")
         probe.expectMsg(appDataMap)
@@ -73,11 +73,11 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val appId: PathId = PathId("/app")
         val instance = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(instance)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("the task tracker actor gets a List query")
         val probe = TestProbe()
-        probe.send(f.taskTrackerActor, InstanceTrackerActor.List)
+        probe.send(f.instanceTrackerActor, InstanceTrackerActor.List)
 
         Then("it will eventually answer")
         probe.expectMsg(appDataMap)
@@ -91,11 +91,11 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val runningOne = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningTwo = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("the task tracker has started up")
         val probe = TestProbe()
-        probe.send(f.taskTrackerActor, InstanceTrackerActor.List)
+        probe.send(f.instanceTrackerActor, InstanceTrackerActor.List)
         probe.expectMsg(appDataMap)
 
         Then("it will have set the correct metric counts")
@@ -111,14 +111,14 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val runningOne = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningTwo = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("staged task gets deleted")
         val probe = TestProbe()
         val helper = TaskStatusUpdateTestHelper.killed(staged)
         val update = helper.operation.asInstanceOf[InstanceUpdateOperation.MesosUpdate]
 
-        probe.send(f.taskTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
+        probe.send(f.instanceTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
         probe.expectMsg(helper.effect)
 
         Then("it will have set the correct metric counts")
@@ -134,14 +134,14 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val runningOne = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningTwo = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("running task gets deleted")
         val probe = TestProbe()
         val helper = TaskStatusUpdateTestHelper.killed(runningOne)
         val update = helper.operation.asInstanceOf[InstanceUpdateOperation.MesosUpdate]
 
-        probe.send(f.taskTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
+        probe.send(f.instanceTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
         probe.expectMsg(helper.effect)
 
         Then("it will have set the correct metric counts")
@@ -160,7 +160,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val runningOne = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningTwo = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("staged task transitions to running")
         val probe = TestProbe()
@@ -170,7 +170,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val helper = TaskStatusUpdateTestHelper.taskUpdateFor(staged, TaskCondition(mesosStatus), mesosStatus)
         val update = helper.operation
 
-        probe.send(f.taskTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
+        probe.send(f.instanceTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
         probe.expectMsg(helper.effect)
 
         Then("it will have set the correct metric counts")
@@ -190,14 +190,14 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val runningOne = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningTwo = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo, scheduled)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("a new staged task gets added")
         val probe = TestProbe()
         val helper = TaskStatusUpdateTestHelper.provision(scheduled, f.clock.now())
         val update = helper.operation
 
-        probe.send(f.taskTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
+        probe.send(f.instanceTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
         probe.expectMsg(helper.effect)
 
         Then("it will have set the correct metric counts")
@@ -219,21 +219,21 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val runningOne = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningTwo = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo, scheduled)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         val probe = TestProbe()
         val helper = TaskStatusUpdateTestHelper.provision(scheduled, f.clock.now())
         val update = UpdateContext(f.clock.now() + 3.days, helper.operation)
 
         When("Instance update is received")
-        probe.send(f.taskTrackerActor, update)
+        probe.send(f.instanceTrackerActor, update)
         probe.expectMsg(helper.effect)
 
         Then("instance repository save is called")
         verify(f.repository).store(helper.wrapped.instance)
 
         And("internal state is updated")
-        probe.send(f.taskTrackerActor, InstanceTrackerActor.List)
+        probe.send(f.instanceTrackerActor, InstanceTrackerActor.List)
         probe.expectMsg(InstanceTracker.InstancesBySpec.forInstances(staged, runningOne, runningTwo, helper.wrapped.instance))
       }
 
@@ -243,7 +243,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val appId: PathId = PathId("/app")
         val scheduled = Instance.scheduled(AppDefinition(appId))
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(scheduled)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         And("repository that returns error for store operation")
         f.repository.store(any) returns Future.failed(new RuntimeException("fail"))
@@ -253,7 +253,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val helper = TaskStatusUpdateTestHelper.provision(scheduled, f.clock.now())
         val update = UpdateContext(f.clock.now() + 3.days, helper.operation)
 
-        probe.send(f.taskTrackerActor, update)
+        probe.send(f.instanceTrackerActor, update)
 
         Then("Failure message is received")
         probe.fishForSpecificMessage() {
@@ -262,7 +262,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         }
 
         And("Internal state did not change")
-        probe.send(f.taskTrackerActor, InstanceTrackerActor.List)
+        probe.send(f.instanceTrackerActor, InstanceTrackerActor.List)
         probe.expectMsg(appDataMap)
       }
 
@@ -273,7 +273,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val running = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningDecommissioned = running.copy(state = running.state.copy(goal = Goal.Decommissioned))
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(runningDecommissioned)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("a running and decommissioned task is killed")
         val probe = TestProbe()
@@ -281,14 +281,14 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val update = helper.operation.asInstanceOf[InstanceUpdateOperation.MesosUpdate]
 
         And("and expunged")
-        probe.send(f.taskTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
+        probe.send(f.instanceTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
         probe.expectMsg(helper.effect)
 
         Then("repository is updated")
         verify(f.repository).delete(helper.wrapped.id)
 
         And("internal state is updated")
-        probe.send(f.taskTrackerActor, InstanceTrackerActor.List)
+        probe.send(f.instanceTrackerActor, InstanceTrackerActor.List)
         probe.expectMsg(InstanceTracker.InstancesBySpec.empty)
       }
 
@@ -299,7 +299,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         val running = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
         val runningDecommissioned = running.copy(state = running.state.copy(goal = Goal.Decommissioned))
         val appDataMap = InstanceTracker.InstancesBySpec.forInstances(runningDecommissioned)
-        f.taskLoader.load() returns Future.successful(appDataMap)
+        f.instancesLoader.load() returns Future.successful(appDataMap)
 
         When("a task in decommissioned gets killed")
         val probe = TestProbe()
@@ -310,7 +310,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         And("repository store operation fails")
         f.repository.delete(instance.instanceId) returns Future.failed(new RuntimeException("fail"))
 
-        probe.send(f.taskTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
+        probe.send(f.instanceTrackerActor, UpdateContext(f.clock.now() + 3.days, update))
 
         Then("failure message is sent")
         probe.fishForSpecificMessage() {
@@ -319,7 +319,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
         }
 
         And("internal state did not change")
-        probe.send(f.taskTrackerActor, InstanceTrackerActor.List)
+        probe.send(f.instanceTrackerActor, InstanceTrackerActor.List)
         probe.expectMsg(appDataMap)
       }
     }
@@ -328,7 +328,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
       val clock = SettableClock.ofNow()
 
       val updateResolver = new InstanceUpdateOpResolver(clock)
-      lazy val taskLoader = mock[InstancesLoader]
+      lazy val instancesLoader = mock[InstancesLoader]
       lazy val stepProcessor = mock[InstanceTrackerUpdateStepProcessor]
       lazy val metrics = metricsModule.metrics
       lazy val actorMetrics = new InstanceTrackerActor.ActorMetrics(metrics)
@@ -336,13 +336,16 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
       repository.store(any) returns Future.successful(Done)
       repository.delete(any) returns Future.successful(Done)
 
+      val emptyInstances = InstanceTracker.InstancesBySpec.empty
+      instancesLoader.load() returns Future.successful(emptyInstances)
+
       stepProcessor.process(any)(any[ExecutionContext]) returns Future.successful(Done)
 
-      lazy val taskTrackerActor = TestActorRef[InstanceTrackerActor](InstanceTrackerActor.props(actorMetrics, taskLoader, stepProcessor, updateResolver, repository, clock))
+      lazy val instanceTrackerActor = TestActorRef[InstanceTrackerActor](InstanceTrackerActor.props(actorMetrics, instancesLoader, stepProcessor, updateResolver, repository, clock))
 
       def verifyNoMoreInteractions(): Unit = {
-        noMoreInteractions(taskLoader)
-        reset(taskLoader)
+        noMoreInteractions(instancesLoader)
+        reset(instancesLoader)
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -14,7 +14,7 @@ import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.UpdateCon
 import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor}
 import mesosphere.marathon.state.{AppDefinition, PathId}
 import mesosphere.marathon.storage.repository.InstanceView
-import mesosphere.marathon.test.SettableClock
+import mesosphere.marathon.test.{SettableClock, TestCrashStrategy}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.prop.TableDrivenPropertyChecks.{Table, forAll}
 
@@ -337,11 +337,12 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
       repository.delete(any) returns Future.successful(Done)
 
       val emptyInstances = InstanceTracker.InstancesBySpec.empty
+      val crashStrategy = new TestCrashStrategy
       instancesLoader.load() returns Future.successful(emptyInstances)
 
       stepProcessor.process(any)(any[ExecutionContext]) returns Future.successful(Done)
 
-      lazy val instanceTrackerActor = TestActorRef[InstanceTrackerActor](InstanceTrackerActor.props(actorMetrics, instancesLoader, stepProcessor, updateResolver, repository, clock))
+      lazy val instanceTrackerActor = TestActorRef[InstanceTrackerActor](InstanceTrackerActor.props(actorMetrics, instancesLoader, stepProcessor, updateResolver, repository, clock, crashStrategy))
 
       def verifyNoMoreInteractions(): Unit = {
         noMoreInteractions(instancesLoader)

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -382,7 +382,8 @@ object MarathonTestHelper {
     }
     val updateSteps = Seq.empty[InstanceChangeHandler]
 
-    new InstanceTrackerModule(metrics, clock, defaultConfig(), leadershipModule, instanceRepo, groupRepo, updateSteps) {
+    val crashStrategy = new TestCrashStrategy
+    new InstanceTrackerModule(metrics, clock, defaultConfig(), leadershipModule, instanceRepo, groupRepo, updateSteps, crashStrategy) {
       // some tests create only one actor system but create multiple task trackers
       override protected lazy val instanceTrackerActorName: String = s"taskTracker_${Random.alphanumeric.take(10).mkString}"
     }


### PR DESCRIPTION
Further, we change InstanceTrackerActor crashes, then crash Marathon. The motivation here is the instance state subscription streams would become invalid in the event of a InstanceTrackerActor restart, and it is simpler to not have to write recovery logic for those streams and everything that might depend on instance tracker actor.

JIRA Issues: MARATHON-8623