### PR TITLE
Add seccomp integration test

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -258,7 +258,7 @@ class TaskReplaceActor(
     * @return whether [[Instance]] has the new run spec version or an old one.
     */
   def isOldInstance(instance: Instance): Boolean = {
-    require(instance.runSpecId == runSpec.id)   // sanity check
+    require(instance.runSpecId == runSpec.id) // sanity check
     instance.runSpecVersion != runSpec.version
   }
 }

--- a/tests/integration/src/test/resources/mesos/seccomp/default.json
+++ b/tests/integration/src/test/resources/mesos/seccomp/default.json
@@ -1,0 +1,782 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    }
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "accept",
+        "accept4",
+        "access",
+        "adjtimex",
+        "alarm",
+        "bind",
+        "brk",
+        "capget",
+        "capset",
+        "chdir",
+        "chmod",
+        "chown",
+        "chown32",
+        "clock_getres",
+        "clock_gettime",
+        "clock_nanosleep",
+        "close",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup",
+        "dup2",
+        "dup3",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_ctl_old",
+        "epoll_pwait",
+        "epoll_wait",
+        "epoll_wait_old",
+        "eventfd",
+        "eventfd2",
+        "execve",
+        "execveat",
+        "exit",
+        "exit_group",
+        "faccessat",
+        "fadvise64",
+        "fadvise64_64",
+        "fallocate",
+        "fanotify_mark",
+        "fchdir",
+        "fchmod",
+        "fchmodat",
+        "fchown",
+        "fchown32",
+        "fchownat",
+        "fcntl",
+        "fcntl64",
+        "fdatasync",
+        "fgetxattr",
+        "flistxattr",
+        "flock",
+        "fork",
+        "fremovexattr",
+        "fsetxattr",
+        "fstat",
+        "fstat64",
+        "fstatat64",
+        "fstatfs",
+        "fstatfs64",
+        "fsync",
+        "ftruncate",
+        "ftruncate64",
+        "futex",
+        "futimesat",
+        "getcpu",
+        "getcwd",
+        "getdents",
+        "getdents64",
+        "getegid",
+        "getegid32",
+        "geteuid",
+        "geteuid32",
+        "getgid",
+        "getgid32",
+        "getgroups",
+        "getgroups32",
+        "getitimer",
+        "getpeername",
+        "getpgid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getpriority",
+        "getrandom",
+        "getresgid",
+        "getresgid32",
+        "getresuid",
+        "getresuid32",
+        "getrlimit",
+        "get_robust_list",
+        "getrusage",
+        "getsid",
+        "getsockname",
+        "getsockopt",
+        "get_thread_area",
+        "gettid",
+        "gettimeofday",
+        "getuid",
+        "getuid32",
+        "getxattr",
+        "inotify_add_watch",
+        "inotify_init",
+        "inotify_init1",
+        "inotify_rm_watch",
+        "io_cancel",
+        "ioctl",
+        "io_destroy",
+        "io_getevents",
+        "ioprio_get",
+        "ioprio_set",
+        "io_setup",
+        "io_submit",
+        "ipc",
+        "kill",
+        "lchown",
+        "lchown32",
+        "lgetxattr",
+        "link",
+        "linkat",
+        "listen",
+        "listxattr",
+        "llistxattr",
+        "_llseek",
+        "lremovexattr",
+        "lseek",
+        "lsetxattr",
+        "lstat",
+        "lstat64",
+        "madvise",
+        "memfd_create",
+        "mincore",
+        "mkdir",
+        "mkdirat",
+        "mknod",
+        "mknodat",
+        "mlock",
+        "mlock2",
+        "mlockall",
+        "mmap",
+        "mmap2",
+        "mprotect",
+        "mq_getsetattr",
+        "mq_notify",
+        "mq_open",
+        "mq_timedreceive",
+        "mq_timedsend",
+        "mq_unlink",
+        "mremap",
+        "msgctl",
+        "msgget",
+        "msgrcv",
+        "msgsnd",
+        "msync",
+        "munlock",
+        "munlockall",
+        "munmap",
+        "nanosleep",
+        "newfstatat",
+        "_newselect",
+        "open",
+        "openat",
+        "pause",
+        "pipe",
+        "pipe2",
+        "poll",
+        "ppoll",
+        "prctl",
+        "pread64",
+        "preadv",
+        "preadv2",
+        "prlimit64",
+        "pselect6",
+        "pwrite64",
+        "pwritev",
+        "pwritev2",
+        "read",
+        "readahead",
+        "readlink",
+        "readlinkat",
+        "readv",
+        "recv",
+        "recvfrom",
+        "recvmmsg",
+        "recvmsg",
+        "remap_file_pages",
+        "removexattr",
+        "rename",
+        "renameat",
+        "renameat2",
+        "restart_syscall",
+        "rmdir",
+        "rt_sigaction",
+        "rt_sigpending",
+        "rt_sigprocmask",
+        "rt_sigqueueinfo",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "rt_sigtimedwait",
+        "rt_tgsigqueueinfo",
+        "sched_getaffinity",
+        "sched_getattr",
+        "sched_getparam",
+        "sched_get_priority_max",
+        "sched_get_priority_min",
+        "sched_getscheduler",
+        "sched_rr_get_interval",
+        "sched_setaffinity",
+        "sched_setattr",
+        "sched_setparam",
+        "sched_setscheduler",
+        "sched_yield",
+        "seccomp",
+        "select",
+        "semctl",
+        "semget",
+        "semop",
+        "semtimedop",
+        "send",
+        "sendfile",
+        "sendfile64",
+        "sendmmsg",
+        "sendmsg",
+        "sendto",
+        "setfsgid",
+        "setfsgid32",
+        "setfsuid",
+        "setfsuid32",
+        "setgid",
+        "setgid32",
+        "setgroups",
+        "setgroups32",
+        "setitimer",
+        "setpgid",
+        "setpriority",
+        "setregid",
+        "setregid32",
+        "setresgid",
+        "setresgid32",
+        "setresuid",
+        "setresuid32",
+        "setreuid",
+        "setreuid32",
+        "setrlimit",
+        "set_robust_list",
+        "setsid",
+        "setsockopt",
+        "set_thread_area",
+        "set_tid_address",
+        "setuid",
+        "setuid32",
+        "setxattr",
+        "shmat",
+        "shmctl",
+        "shmdt",
+        "shmget",
+        "shutdown",
+        "sigaltstack",
+        "signalfd",
+        "signalfd4",
+        "sigreturn",
+        "socket",
+        "socketcall",
+        "socketpair",
+        "splice",
+        "stat",
+        "stat64",
+        "statfs",
+        "statfs64",
+        "statx",
+        "symlink",
+        "symlinkat",
+        "sync",
+        "sync_file_range",
+        "syncfs",
+        "sysinfo",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create",
+        "timer_delete",
+        "timerfd_create",
+        "timerfd_gettime",
+        "timerfd_settime",
+        "timer_getoverrun",
+        "timer_gettime",
+        "timer_settime",
+        "times",
+        "tkill",
+        "truncate",
+        "truncate64",
+        "ugetrlimit",
+        "umask",
+        "uname",
+        "unlink",
+        "unlinkat",
+        "utime",
+        "utimensat",
+        "utimes",
+        "vfork",
+        "vmsplice",
+        "wait4",
+        "waitid",
+        "waitpid",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 0,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 8,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131072,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131080,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 4294967295,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "sync_file_range2"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "ppc64le"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "arm_fadvise64_64",
+        "arm_sync_file_range",
+        "sync_file_range2",
+        "breakpoint",
+        "cacheflush",
+        "set_tls"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "arm",
+          "arm64"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "arch_prctl"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "modify_ldt"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32",
+          "x86"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "s390_pci_mmio_read",
+        "s390_pci_mmio_write",
+        "s390_runtime_instr"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "open_by_handle_at"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_DAC_READ_SEARCH"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "bpf",
+        "clone",
+        "fanotify_init",
+        "lookup_dcookie",
+        "mount",
+        "name_to_handle_at",
+        "perf_event_open",
+        "quotactl",
+        "setdomainname",
+        "sethostname",
+        "setns",
+        "syslog",
+        "umount",
+        "umount2",
+        "unshare"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 2080505856,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ],
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      }
+    },
+    {
+      "names": [
+        "clone"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 1,
+          "value": 2080505856,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_MASKED_EQ"
+        }
+      ],
+      "comment": "s390 parameter ordering for clone is different",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      }
+    },
+    {
+      "names": [
+        "reboot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_BOOT"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "chroot",
+        "pivot_root"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_CHROOT"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "delete_module",
+        "init_module",
+        "finit_module",
+        "query_module"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_MODULE"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "acct"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PACCT"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "kcmp",
+        "process_vm_readv",
+        "process_vm_writev",
+        "ptrace"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PTRACE"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "iopl",
+        "ioperm"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_RAWIO"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "settimeofday",
+        "stime",
+        "clock_settime"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TIME"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "vhangup"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TTY_CONFIG"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "get_mempolicy",
+        "mbind",
+        "set_mempolicy"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_NICE"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "syslog"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYSLOG"
+        ]
+      },
+      "excludes": {}
+    }
+  ]
+}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AgentGoneByOperatorIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AgentGoneByOperatorIntegrationTest.scala
@@ -5,13 +5,16 @@ import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.TaskIdWithIncarnation
 import mesosphere.marathon.integration.facades.MarathonFacade._
-import mesosphere.marathon.integration.setup.{EmbeddedMarathonTest, RestResult}
+import mesosphere.marathon.integration.setup.{EmbeddedMarathonTest, MesosConfig, RestResult}
 import mesosphere.marathon.raml.App
 import mesosphere.marathon.state.PathId
 import org.scalatest.Inside
 
 class AgentGoneByOperatorIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
-  override lazy val mesosNumSlaves = 2
+
+  override val mesosConfig = MesosConfig(
+    numAgents = 2
+  )
 
   "resident task will be expunged and a new instance will be created in response to TASK_GONE_BY_OPERATOR" in {
     Given("An app with a persistent volume")

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AgentGoneByOperatorIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AgentGoneByOperatorIntegrationTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.Inside
 
 class AgentGoneByOperatorIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
 
-  override val mesosConfig = MesosConfig(
+  override lazy val mesosConfig = MesosConfig(
     numAgents = 2
   )
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/GpuSchedulingIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/GpuSchedulingIntegrationTest.scala
@@ -15,7 +15,9 @@ import scala.collection.immutable.Seq
 
 class GpuSchedulingIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
-  override def agentsGpus = Some(4)
+  override lazy val mesosConfig = MesosConfig(
+    agentsGpus = Some(4)
+  )
 
   override val marathonArgs: Map[String, String] = Map(
     "enable_features" -> "gpu_resources",

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -10,9 +10,6 @@ import org.scalatest.Inside
 
 class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
 
-  override lazy val mesosNumMasters = 1
-  override lazy val mesosNumSlaves = 3
-
   class Fixture {
     val homeRegion = Region("home_region")
     val homeZone = Zone("home_zone")
@@ -24,12 +21,16 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
 
   val f = new Fixture
 
-  override def mastersFaultDomains = Seq(Some(FaultDomain(region = f.homeRegion, zone = f.homeZone)))
+  override lazy val mesosConfig = MesosConfig(
+    numAgents = 3,
+    mastersFaultDomains = Seq(
+      Some(FaultDomain(region = f.homeRegion, zone = f.homeZone))),
+    agentsFaultDomains = Seq(
+      Some(FaultDomain(region = f.remoteRegion, zone = f.remoteZone1)),
+      Some(FaultDomain(region = f.remoteRegion, zone = f.remoteZone2)),
+      Some(FaultDomain(region = f.homeRegion, zone = f.homeZone)))
 
-  override def agentsFaultDomains = Seq(
-    Some(FaultDomain(region = f.remoteRegion, zone = f.remoteZone1)),
-    Some(FaultDomain(region = f.remoteRegion, zone = f.remoteZone2)),
-    Some(FaultDomain(region = f.homeRegion, zone = f.homeZone)))
+  )
 
   def appId(suffix: String): PathId = testBasePath / s"app-${suffix}"
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
@@ -1,4 +1,5 @@
-package mesosphere.marathon.integration
+package mesosphere.marathon
+package integration
 
 import java.io.File
 import java.nio.file.Paths

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
@@ -1,28 +1,40 @@
 package mesosphere.marathon
 package integration
 
-import java.io.File
-import java.nio.file.Paths
-
-import scala.io.Source
-import mesosphere.AkkaIntegrationTest
+import mesosphere.{AkkaIntegrationTest, WhenEnvSet}
 import mesosphere.marathon.integration.setup.{EmbeddedMarathonTest, MesosConfig}
 import mesosphere.marathon.raml.{App, Container, DockerContainer, EngineType, LinuxInfo, Seccomp}
 import mesosphere.marathon.state.PathId
 import mesosphere.marathon.state.PathId._
 
+import scala.io.Source
+
 class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
   override lazy val mesosConfig = MesosConfig(isolation = Some("linux/seccomp"))
 
-  override lazy val agentSeccompConfigDir = Some(Paths.get(sys.props.getOrElse("user.dir", "."), "tests/integration/src/test/resources/mesos/seccomp").toString)
-  override lazy val agentSeccompDefaultProfile = Some(new File(agentSeccompConfigDir.get, "default.json").getAbsolutePath)
+  val projectDir = sys.props.getOrElse("user.dir", ".")
+  override lazy val agentSeccompConfigDir = Some(s"$projectDir/src/test/resources/mesos/seccomp")
+  override lazy val agentSeccompProfileName = Some("default.json")
 
   logger.info(s"--seccomp_config_dir = ${agentSeccompConfigDir.get}")
-  logger.info(s"--seccomp_profile_name = ${agentSeccompDefaultProfile.get}")
-  logger.info(s"Seccomp profile: ${Source.fromFile(agentSeccompDefaultProfile.get).getLines.mkString("\n")}")
+  logger.info(s"--seccomp_profile_name = ${agentSeccompProfileName.get}")
+  logger.debug(s"Seccomp profile: ${Source.fromFile(s"$projectDir/src/test/resources/mesos/seccomp/default.json").getLines.mkString("\n")}")
 
-  "An app definition WITHOUT seccomp profile and unconfined = true" in {
+  "An app definition WITH seccomp profile defined and unconfined = false" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
+    Given("an app WITH seccomp profile defined and unconfined = false")
+    val app = seccompApp(PathId("app-with-seccomp-profile-and-unconfined-false"), unconfined = false, profileName = agentSeccompProfileName)
+
+    When("the app is successfully deployed")
+    val result = marathon.createAppV2(app)
+    result should be(Created)
+    waitForDeployment(result)
+
+    And("the task is running")
+    waitForTasks(app.id.toPath, 1)
+  }
+
+  "An app definition WITHOUT seccomp profile and unconfined = true" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
     Given("an app WITHOUT seccomp profile and unconfined = true")
     val app = seccompApp(PathId("app-without-seccomp-profile-and-unconfined-true"), unconfined = true)
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
@@ -13,8 +13,10 @@ class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTes
 
   val projectDir = sys.props.getOrElse("user.dir", ".")
   override lazy val mesosConfig = MesosConfig(
+    launcher = "linux",
     containerizers = "docker,mesos",
-    isolation = Some("linux/seccomp"),
+    isolation = Some("filesystem/linux,docker/runtime,linux/seccomp"),
+    imageProviders = Some("docker"),
     agentSeccompConfigDir = Some(s"$projectDir/src/test/resources/mesos/seccomp"),
     agentSeccompProfileName = Some("default.json")
   )
@@ -59,9 +61,9 @@ class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTes
       container = Some(
         Container(
           `type` = EngineType.Mesos,
-          docker = Option(DockerContainer(image = "busybox")),
-          linuxInfo = Option(LinuxInfo(
-            seccomp = Option(Seccomp(
+          docker = Some(DockerContainer(image = "busybox")),
+          linuxInfo = Some(LinuxInfo(
+            seccomp = Some(Seccomp(
               unconfined = unconfined,
               profileName = profileName
             ))

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
@@ -11,7 +11,7 @@ import scala.io.Source
 
 class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
 
-  val projectDir = sys.props.getOrElse("user.dir", ".")
+  val projectDir: String = sys.props.getOrElse("user.dir", ".")
   override lazy val mesosConfig = MesosConfig(
     launcher = "linux",
     containerizers = "docker,mesos",
@@ -27,7 +27,7 @@ class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTes
 
   "An app definition WITH seccomp profile defined and unconfined = false" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
     Given("an app WITH seccomp profile defined and unconfined = false")
-    val app = seccompApp(PathId("app-with-seccomp-profile-and-unconfined-false"), unconfined = false, profileName = mesosConfig.agentSeccompProfileName)
+    val app = seccompApp(PathId("/app-with-seccomp-profile-and-unconfined-false"), unconfined = false, profileName = mesosConfig.agentSeccompProfileName)
 
     When("the app is successfully deployed")
     val result = marathon.createAppV2(app)
@@ -35,12 +35,12 @@ class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTes
     waitForDeployment(result)
 
     And("the task is running")
-    waitForTasks(app.id.toPath, 1)
+    waitForTasks(app.id.toPath, app.instances)
   }
 
   "An app definition WITHOUT seccomp profile and unconfined = true" taggedAs WhenEnvSet(envVarRunMesosTests, default = "true") in {
     Given("an app WITHOUT seccomp profile and unconfined = true")
-    val app = seccompApp(PathId("app-without-seccomp-profile-and-unconfined-true"), unconfined = true)
+    val app = seccompApp(PathId("/app-without-seccomp-profile-and-unconfined-true"), unconfined = true)
 
     When("the app is successfully deployed")
     val result = marathon.createAppV2(app)
@@ -48,14 +48,13 @@ class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTes
     waitForDeployment(result)
 
     And("the task is running")
-    waitForTasks(app.id.toPath, 1)
+    waitForTasks(app.id.toPath, app.instances)
   }
 
   def seccompApp(appId: PathId, unconfined: Boolean, profileName: Option[String] = None): App = {
     App(
       id = appId.toString,
       cmd = Some("sleep 232323"),
-      instances = 1,
       cpus = 0.01,
       mem = 32.0,
       container = Some(

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/SeccompIntegratonTest.scala
@@ -1,0 +1,58 @@
+package mesosphere.marathon.integration
+
+import java.io.File
+import java.nio.file.Paths
+
+import scala.io.Source
+import mesosphere.AkkaIntegrationTest
+import mesosphere.marathon.integration.setup.{EmbeddedMarathonTest, MesosConfig}
+import mesosphere.marathon.raml.{App, Container, DockerContainer, EngineType, LinuxInfo, Seccomp}
+import mesosphere.marathon.state.PathId
+import mesosphere.marathon.state.PathId._
+
+class SeccompIntegratonTest extends AkkaIntegrationTest with EmbeddedMarathonTest {
+
+  override lazy val mesosConfig = MesosConfig(isolation = Some("linux/seccomp"))
+
+  override lazy val agentSeccompConfigDir = Some(Paths.get(sys.props.getOrElse("user.dir", "."), "tests/integration/src/test/resources/mesos/seccomp").toString)
+  override lazy val agentSeccompDefaultProfile = Some(new File(agentSeccompConfigDir.get, "default.json").getAbsolutePath)
+
+  logger.info(s"--seccomp_config_dir = ${agentSeccompConfigDir.get}")
+  logger.info(s"--seccomp_profile_name = ${agentSeccompDefaultProfile.get}")
+  logger.info(s"Seccomp profile: ${Source.fromFile(agentSeccompDefaultProfile.get).getLines.mkString("\n")}")
+
+  "An app definition WITHOUT seccomp profile and unconfined = true" in {
+    Given("an app WITHOUT seccomp profile and unconfined = true")
+    val app = seccompApp(PathId("app-without-seccomp-profile-and-unconfined-true"), unconfined = true)
+
+    When("the app is successfully deployed")
+    val result = marathon.createAppV2(app)
+    result should be(Created)
+    waitForDeployment(result)
+
+    And("the task is running")
+    waitForTasks(app.id.toPath, 1)
+  }
+
+  def seccompApp(appId: PathId, unconfined: Boolean, profileName: Option[String] = None): App = {
+    App(
+      id = appId.toString,
+      cmd = Some("sleep 232323"),
+      instances = 1,
+      cpus = 0.01,
+      mem = 32.0,
+      container = Some(
+        Container(
+          `type` = EngineType.Mesos,
+          docker = Option(DockerContainer(image = "busybox")),
+          linuxInfo = Option(LinuxInfo(
+            seccomp = Option(Seccomp(
+              unconfined = unconfined,
+              profileName = profileName
+            ))
+          ))
+        )
+      )
+    )
+  }
+}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -15,8 +15,9 @@ import scala.concurrent.duration._
 
 class TaskUnreachableIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
 
-  override lazy val mesosNumMasters = 1
-  override lazy val mesosNumSlaves = 2
+  override val mesosConfig = MesosConfig(
+    numAgents = 2
+  )
 
   override val marathonArgs: Map[String, String] = Map(
     "reconciliation_initial_delay" -> "5000",

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 class TaskUnreachableIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
 
-  override val mesosConfig = MesosConfig(
+  override lazy val mesosConfig = MesosConfig(
     numAgents = 2
   )
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
@@ -26,41 +26,44 @@ import scala.sys.process.ProcessBuilder
 import scala.util.Try
 
 case class MesosConfig(
+    numMasters: Int = 1,
+    numAgents: Int = 1,
+    quorumSize: Int = 1,
     launcher: String = "posix",
     containerizers: String = "mesos",
     isolation: Option[String] = None,
-    imageProviders: Option[String] = None)
+    imageProviders: Option[String] = None,
+    mastersFaultDomains: Seq[Option[FaultDomain]] = Seq.empty,
+    agentsFaultDomains: Seq[Option[FaultDomain]] = Seq.empty,
+    agentsGpus: Option[Int] = None,
+    agentSeccompConfigDir: Option[String] = None,
+    agentSeccompProfileName: Option[String] = None) {
+
+  require(validQuorumSize, "Mesos quorum size should be 0 or smaller than number of agents")
+  require(validSeccompConfig, "To enable seccomp, agentSeccompConfigDir should be defined and isolation \"linux/seccomp\" used")
+  require(validFaultDomainConfig, "Fault domains should be configure for all agents or not at all")
+
+  def validQuorumSize: Boolean = quorumSize > 0 && quorumSize <= numMasters
+  def validFaultDomainConfig: Boolean = agentsFaultDomains.isEmpty || agentsFaultDomains.size == numAgents
+  def validSeccompConfig: Boolean = agentSeccompConfigDir.isEmpty || (agentSeccompConfigDir.isDefined && isolation.get.contains("linux/seccomp"))
+}
 
 case class MesosCluster(
     suiteName: String,
-    numMasters: Int,
-    numAgents: Int,
     masterUrl: String,
-    quorumSize: Int = 1,
     autoStart: Boolean = false,
     config: MesosConfig = MesosConfig(),
-    waitForMesosTimeout: FiniteDuration = 5.minutes,
-    mastersFaultDomains: Seq[Option[FaultDomain]],
-    agentsFaultDomains: Seq[Option[FaultDomain]],
-    agentsGpus: Option[Int] = None,
-    agentSeccompConfigDir: Option[String],
-    agentSeccompDefaultProfile: Option[String])(implicit
+    waitForMesosTimeout: FiniteDuration = 5.minutes)(implicit
     system: ActorSystem,
     mat: Materializer,
     ctx: ExecutionContext,
     scheduler: Scheduler) extends AutoCloseable with Eventually {
 
-  require(isValidQuorumSize, "Mesos quorum size should be 0 or smaller than number of agents")
-  require(isValidFaultDomainConfig, "Fault domains should be configure for all agents or not at all")
-  require(isValidSeccompConfig, "To enable seccomp, agentSeccompConfigDir should be defined and isolation \"linux/seccomp\" set")
 
-  def isValidQuorumSize: Boolean = quorumSize > 0 && quorumSize <= numMasters
-  def isValidFaultDomainConfig: Boolean = agentsFaultDomains.isEmpty || agentsFaultDomains.size == numAgents
-  def isValidSeccompConfig: Boolean = agentSeccompConfigDir.isEmpty || (agentSeccompConfigDir.isDefined && config.isolation.get.contains("linux/seccomp"))
 
-  lazy val masters = 0.until(numMasters).map { i =>
-    val faultDomainJson = if (mastersFaultDomains.nonEmpty && mastersFaultDomains(i).nonEmpty) {
-      val faultDomain = mastersFaultDomains(i).get
+  lazy val masters = 0.until(config.numMasters).map { i =>
+    val faultDomainJson = if (config.mastersFaultDomains.nonEmpty && config.mastersFaultDomains(i).nonEmpty) {
+      val faultDomain = config.mastersFaultDomains(i).get
       val faultDomainJson = s"""
                                |{
                                |  "fault_domain":
@@ -82,18 +85,18 @@ case class MesosCluster(
     Master(extraArgs = Seq(
       "--slave_ping_timeout=1secs",
       "--max_slave_ping_timeouts=4",
-      s"--quorum=$quorumSize") ++ faultDomainJson.map(fd => s"--domain=$fd"))
+      s"--quorum=${config.quorumSize}") ++ faultDomainJson.map(fd => s"--domain=$fd"))
   }
 
-  lazy val agents = 0.until(numAgents).map { i =>
+  lazy val agents = 0.until(config.numAgents).map { i =>
     // We can add additional resources constraints for our test clusters here.
     // IMPORTANT: we give each cluster's agent it's own port range! Otherwise every mesos will offer the same port range
     // to it's marathon, leading to multiple tasks (from different IT suits) trying to use the same port!
     // First-come-first-served task will bind successfully where the others will fail leading to a lot inconsistency and
     // flakiness in tests.
 
-    val (faultDomainAgentAttributes: Map[String, Option[String]], mesosFaultDomainAgentCmdOption) = if (agentsFaultDomains.nonEmpty && agentsFaultDomains(i).nonEmpty) {
-      val faultDomain = agentsFaultDomains(i).get
+    val (faultDomainAgentAttributes: Map[String, Option[String]], mesosFaultDomainAgentCmdOption) = if (config.agentsFaultDomains.nonEmpty && config.agentsFaultDomains(i).nonEmpty) {
+      val faultDomain = config.agentsFaultDomains(i).get
       val mesosFaultDomainCmdOption = s"""
           |{
           |  "fault_domain":
@@ -121,11 +124,11 @@ case class MesosCluster(
 
     val renderedAttributes: String = attributes.map { case (key, maybeVal) => s"$key${maybeVal.map(v => s":$v").getOrElse("")}" }.mkString(";")
 
-    Agent(resources = new Resources(ports = PortAllocator.portsRange(), gpus = agentsGpus), extraArgs = Seq(
+    Agent(resources = new Resources(ports = PortAllocator.portsRange(), gpus = config.agentsGpus), extraArgs = Seq(
       s"--attributes=$renderedAttributes"
     ) ++ mesosFaultDomainAgentCmdOption.map(fd => s"--domain=$fd")
-      ++ agentSeccompConfigDir.map(dir => s"--seccomp_config_dir=$dir")
-      ++ agentSeccompDefaultProfile.map(prf => s"--seccomp_profile_name=$prf")
+      ++ config.agentSeccompConfigDir.map(dir => s"--seccomp_config_dir=$dir")
+      ++ config.agentSeccompProfileName.map(prf => s"--seccomp_profile_name=$prf")
     )
   }
 
@@ -360,37 +363,15 @@ trait MesosClusterTest extends Suite with ZookeeperServerTest with MesosTest wit
   implicit val ctx: ExecutionContext
   implicit val scheduler: Scheduler
 
-  def mastersFaultDomains: Seq[Option[FaultDomain]] = Seq.empty
-
-  def agentsFaultDomains: Seq[Option[FaultDomain]] = Seq.empty
-
-  def agentsGpus: Option[Int] = None
-
-  def agentSeccompConfigDir: Option[String] = None
-
-  def agentSeccompProfileName: Option[String] = None
-
   private val localMesosUrl = sys.env.get("USE_LOCAL_MESOS")
   lazy val mesosMasterUrl = s"zk://${zkServer.connectUri}/mesos"
-  lazy val mesosNumMasters = 1
-  lazy val mesosNumSlaves = 1
-  lazy val mesosQuorumSize = 1
   lazy val mesosConfig = MesosConfig()
-  lazy val mesosLeaderTimeout: FiniteDuration = patienceConfig.timeout.toMillis.milliseconds
   lazy val mesosCluster = MesosCluster(
     suiteName,
-    mesosNumMasters,
-    mesosNumSlaves,
     mesosMasterUrl,
-    mesosQuorumSize,
     autoStart = false,
     config = mesosConfig,
-    mesosLeaderTimeout,
-    mastersFaultDomains,
-    agentsFaultDomains,
-    agentsGpus,
-    agentSeccompConfigDir,
-    agentSeccompProfileName
+    waitForMesosTimeout = patienceConfig.timeout.toMillis.milliseconds
   )
   lazy val mesos = new MesosFacade(localMesosUrl.getOrElse(mesosCluster.waitForLeader().futureValue))
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
@@ -59,8 +59,6 @@ case class MesosCluster(
     ctx: ExecutionContext,
     scheduler: Scheduler) extends AutoCloseable with Eventually {
 
-
-
   lazy val masters = 0.until(config.numMasters).map { i =>
     val faultDomainJson = if (config.mastersFaultDomains.nonEmpty && config.mastersFaultDomains(i).nonEmpty) {
       val faultDomain = config.mastersFaultDomains(i).get


### PR DESCRIPTION
Summary:
Added:
- support for `seccomp` parameters to `MesosClusterTest`
- default `seccomp` profile (taken from DC/OS config)
- new `SeccompIntegrationTest` suite

JIRA: DCOS-51846