### PR TITLE
Add TASK_UNKNOWN to the valid mesos task status enums (#6910)

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -75,7 +75,7 @@ types:
       - TASK_STAGING
       - TASK_STARTING
       - TASK_UNREACHABLE
-      - TASK_UNREACHABLE
+      - TASK_UNKNOWN
       - TASK_GONE
       - TASK_DROPPED
   Condition:


### PR DESCRIPTION
JIRA Issues: MARATHON-8624

(cherry picked from commit 4e5e551ef1b3db9e45e6cef93f0c7eb990341f21)
