### PR TITLE
Remove version from ca-certificates-java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val packagingSettings = Seq(
           |apt-get update && \\
           |# jdk setup
           |mkdir -p /usr/share/man/man1 && \\
-          |apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20170929~deb9u1 && \\
+          |apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java && \\
           |/var/lib/dpkg/info/ca-certificates-java.postinst configure && \\
           |ln -svT "/usr/lib/jvm/java-8-openjdk-$$(dpkg --print-architecture)" /docker-java-home && \\
           |# mesos setup


### PR DESCRIPTION
This is a forward port of https://github.com/mesosphere/marathon/pull/6913 and a fix to make the master build passing again.