### PR TITLE
Remove version from ca-certificates-java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -182,7 +182,7 @@ lazy val packagingSettings = Seq(
           |apt-get update && \\
           |# jdk setup
           |mkdir -p /usr/share/man/man1 && \\
-          |apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20170929~deb9u1 && \\
+          |apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java && \\
           |/var/lib/dpkg/info/ca-certificates-java.postinst configure && \\
           |ln -svT "/usr/lib/jvm/java-8-openjdk-$$(dpkg --print-architecture)" /docker-java-home && \\
           |# mesos setup


### PR DESCRIPTION
Backport of https://github.com/mesosphere/marathon/pull/6914

Fixes 1.7 build.