### PR TITLE
Only match disk with profile if that profile is needed

### DIFF
--- a/src/main/scala/mesosphere/mesos/VolumeProfileMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/VolumeProfileMatcher.scala
@@ -1,0 +1,28 @@
+package mesosphere.mesos
+
+import org.apache.mesos
+
+import scala.util.Try
+
+object VolumeProfileMatcher {
+
+  /**
+    * @param requiredProfileName the name of the profile that needs to be set on a disk resource, if any.
+    * @param resource the resource that shall be matched against the provided requiredProfileName
+    * @return true, if the provided resource is a disk and has the required profile name,
+    * or if no profile is requested and the disk has no profile set.
+    * Will return false if the profile does not match or the disk has a profile
+    * while no profile is requested.
+    */
+  def matchesProfileName(requiredProfileName: Option[String], resource: mesos.Protos.Resource): Boolean = {
+    val diskProfile: Option[String] = Try(resource.getDisk.getSource.getProfile).filter(_.nonEmpty).toOption
+
+    requiredProfileName.map { profile =>
+      // If a profile is specified, only match disk resources that have that specified profile
+      diskProfile.contains(profile)
+    }.getOrElse {
+      // If no profile is specified, only match disks that do not have a profile set at all
+      diskProfile.isEmpty
+    }
+  }
+}

--- a/src/test/scala/mesosphere/mesos/VolumeProfileMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/VolumeProfileMatcherTest.scala
@@ -1,0 +1,44 @@
+package mesosphere.mesos
+
+import mesosphere.UnitTest
+import org.apache.mesos
+
+class VolumeProfileMatcherTest extends UnitTest {
+  "matchesProfileName" should {
+    "match disk with profile if that profile is required" in {
+      val disk = diskResource(profile = Some("profile"))
+      VolumeProfileMatcher.matchesProfileName(Some("profile"), disk) shouldBe true
+    }
+    "not match disk with profile if no profile is required" in {
+      val disk = diskResource(profile = Some("profile"))
+      VolumeProfileMatcher.matchesProfileName(None, disk) shouldBe false
+    }
+    "match disk without profile when no profile is required" in {
+      val disk = diskResource(profile = None)
+      VolumeProfileMatcher.matchesProfileName(None, disk) shouldBe true
+    }
+    "not match disk with profile if a different profile is required" in {
+      val disk = diskResource(profile = Some("profile"))
+      VolumeProfileMatcher.matchesProfileName(Some("needed-profile"), disk) shouldBe false
+    }
+  }
+
+  /** Helper to create disk resources with/without profile */
+  def diskResource(profile: Option[String]): mesos.Protos.Resource = {
+    val source = mesos.Protos.Resource.DiskInfo.Source.newBuilder()
+      .setType(mesos.Protos.Resource.DiskInfo.Source.Type.PATH)
+      .setPath(mesos.Protos.Resource.DiskInfo.Source.Path.newBuilder().setRoot("test"))
+      .setId("pathDiskId")
+    profile.foreach { p =>
+      source.setProfile(p)
+      source.setVendor("vendorId")
+    }
+
+    mesos.Protos.Resource.newBuilder()
+      .setType(mesos.Protos.Value.Type.SCALAR)
+      .setName("disk")
+      .setDisk(mesos.Protos.Resource.DiskInfo.newBuilder()
+        .setSource(source))
+      .build()
+  }
+}


### PR DESCRIPTION
Summary:
The initial support for volume profiles would match disk resources with a profile, even if no profile was required. This commit changes this behavior so that disks resources are not used if the service for which we are matching offers does not require a disk with that profile.

JIRA issues: DCOS_OSS-5211