### PR TITLE
Fix rollback on 1.8 with default deployment strategy

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -69,6 +69,8 @@ This option was deprecated since 1.5 and using that have no effect on Marathon. 
 
 - [MARATHON-8566](https://jira.mesosphere.com/browse/MARATHON-8566) - We fixed a race condition causing `v2/deployments` not containing a confirmed deployment after HTTP 200/201 response was returned.
 
+- [MARATHON-8625](https://jira.mesosphere.com/browse/MARATHON-8625) - We fixed stuck rollbacks of persistent apps.
+
 ### Closing connection on slow event consumers
 
 Prior to 1.8 Marathon would drop events from the event stream for slow consumers. Starting with 1.8 Marathon will close

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -24,7 +24,6 @@ import mesosphere.util.state.FrameworkId
 import org.apache.mesos.Protos.{ExecutorInfo, TaskGroupInfo, TaskInfo}
 import org.apache.mesos.{Protos => Mesos}
 
-import scala.annotation.tailrec
 import scala.concurrent.duration._
 
 class InstanceOpFactoryImpl(

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -10,8 +10,8 @@ import mesosphere.marathon.core.instance.{Instance, LocalVolume, LocalVolumeId, 
 import mesosphere.marathon.core.launcher.{InstanceOp, InstanceOpFactory, OfferMatchResult}
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.core.task.state.NetworkInfo
+import mesosphere.marathon.core.task.{Task, Tasks}
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.plugin.scheduler.SchedulerPlugin
 import mesosphere.marathon.plugin.task.RunSpecTaskProcessor
@@ -48,7 +48,7 @@ class InstanceOpFactoryImpl(
     logger.debug(s"Matching offer ${request.offer.getId}")
     val scheduledInstances = request.scheduledInstances
 
-    val result = scheduledInstances.head match {
+    val result: OfferMatchResult = scheduledInstances.head match {
       case scheduledInstance @ Instance(_, _, _, _, app: AppDefinition, _) =>
         if (app.isResident) inferForResidents(request, scheduledInstance)
         else inferNormalTaskOp(app, request.instances, request.offer, request.localRegion, scheduledInstance)
@@ -60,10 +60,10 @@ class InstanceOpFactoryImpl(
     }
 
     result match {
-      case m: OfferMatchResult.Match => result
+      case _: OfferMatchResult.Match => result
       case _ if scheduledInstances.tail.nonEmpty =>
-        val tail = scheduledInstances.tail
-        matchOfferRequest(request.copy(scheduledInstances = NonEmptyIterable(tail.head, tail)))
+        val rest = scheduledInstances.tail
+        matchOfferRequest(request.copy(scheduledInstances = NonEmptyIterable(rest.head, rest.tail)))
       case _ => result
     }
   }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -731,8 +731,8 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       val app = App(
         id = id.toString,
         cmd = Some("sleep 12345"),
-        backoffFactor = 1d,
         instances = 2,
+        backoffFactor = 1d,
         upgradeStrategy = Some(UpgradeStrategy(maximumOverCapacity = 0d, minimumHealthCapacity = 0d))
       )
       val created = marathon.createAppV2(app)
@@ -740,7 +740,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForDeployment(created)
 
       And("it is updated with an impossible constraint")
-      val updated = marathon.updateApp(id, AppUpdate(cpus = Some(1000d), cmd = Some("na")))
+      val updated = marathon.updateApp(id, AppUpdate(cpus = Some(1000d), cmd = Some("na"), instances = Some(1)))
       updated shouldBe OK
       val deploymentId = updated.deploymentId.value
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -7,7 +7,7 @@ import akka.util.ByteString
 import mesosphere.marathon.integration.facades.MarathonFacade._
 import mesosphere.marathon.integration.facades.{ITDeployment, ITEnrichedTask, ITQueueItem}
 import mesosphere.marathon.integration.setup._
-import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol}
+import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, AppCommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.{AkkaIntegrationTest, WaitTestSupport}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -4,14 +4,13 @@ package integration
 import java.util.UUID
 
 import akka.util.ByteString
-import mesosphere.{AkkaIntegrationTest, WaitTestSupport}
-import mesosphere.marathon.api.RestResource
 import mesosphere.marathon.integration.facades.MarathonFacade._
 import mesosphere.marathon.integration.facades.{ITDeployment, ITEnrichedTask, ITQueueItem}
 import mesosphere.marathon.integration.setup._
-import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, AppCommandCheck, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol, UpgradeStrategy}
+import mesosphere.marathon.raml.{App, AppHealthCheck, AppHealthCheckProtocol, AppUpdate, Container, ContainerPortMapping, DockerContainer, EngineType, Network, NetworkMode, NetworkProtocol}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{PathId, Timestamp}
+import mesosphere.{AkkaIntegrationTest, WaitTestSupport}
 import org.scalactic.source.Position
 
 import scala.concurrent.duration._

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/AppDeployIntegrationTest.scala
@@ -762,7 +762,7 @@ class AppDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
     // Regression for MARATHON-8537
     "rollback deployment with default deployment strategy" in {
       Given("an existing app")
-      val id: PathId = appId(Some("yet-another-deployment-rollback"))
+      val id: PathId = appId(Some("deployment-rollback-default-version"))
       val app = App(
         id = id.toString,
         cmd = Some("sleep 12345"),


### PR DESCRIPTION
Summary:
Fix for the rollback issue on 1.8. Also added integration test to cover the regression.

JIRA issues: MARATHON-8625
