### PR TITLE
 Restart legacy resident apps. 

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
@@ -72,12 +72,24 @@ object Reservation {
     }
 
     /**
-      * Construct a reservation id from an instance id.
+      * Infer reservation id from instance.
       *
-      * @param instanceId The instance id used for the reservation id.
-      * @return
+      * Instances created prior to 1.8 ''always'' have at least one task attached in reserved state.
+      * Thus we use the reservation id from the `appTask`. If an instance has no task we assume the
+      * instance is from 1.8 or later and uses the [[SimplifiedId]].
+      *
+      * This method might return a [[SimplifiedId]] even when there is an `appTask` for pods.
+      *
+      * @param instance An instance with a reservation.
+      * @return The reservation id for given instance.
       */
-    def apply(instanceId: Instance.Id): Id = Reservation.LegacyId(instanceId.runSpecId, ".", instanceId.uuid) //Reservation.SimplifiedId(instanceId)
+    def apply(instance: Instance): Id = {
+      if (instance.tasksMap.nonEmpty) {
+        instance.appTask.taskId.reservationId
+      } else {
+        Reservation.SimplifiedId(instance.instanceId)
+      }
+    }
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
@@ -77,7 +77,7 @@ object Reservation {
       * @param instanceId The instance id used for the reservation id.
       * @return
       */
-    def apply(instanceId: Instance.Id): Id = Reservation.SimplifiedId(instanceId)
+    def apply(instanceId: Instance.Id): Id = Reservation.LegacyId(instanceId.runSpecId, ".", instanceId.uuid) //Reservation.SimplifiedId(instanceId)
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -173,7 +173,7 @@ class InstanceOpFactoryImpl(
       // resources are reserved for this role, so we only consider those resources
       val rolesToConsider = config.mesosRole.toOption.toSet
       // TODO(karsten): We should pass the instance id to the resource matcher instead. See MARATHON-8517.
-      val reservationId = Reservation.Id(volumeMatch.instance.instanceId)
+      val reservationId = Reservation.Id(volumeMatch.instance)
       val reservationLabels = TaskLabels.labelsForTask(request.frameworkId, reservationId).labels
       val resourceMatchResponse =
         ResourceMatcher.matchResources(
@@ -340,7 +340,7 @@ class InstanceOpFactoryImpl(
     val reservation = Reservation(persistentVolumeIds, state)
     val agentInfo = Instance.AgentInfo(offer)
 
-    val reservationLabels = TaskLabels.labelsForTask(frameworkId, Reservation.Id(scheduledInstance.instanceId))
+    val reservationLabels = TaskLabels.labelsForTask(frameworkId, Reservation.Id(scheduledInstance))
     val stateOp = InstanceUpdateOperation.Reserve(scheduledInstance.instanceId, reservation, agentInfo)
     instanceOperationFactory.reserveAndCreateVolumes(reservationLabels, stateOp, resourceMatch.resources, localVolumes)
   }

--- a/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launcher/impl/TaskLabelsTest.scala
@@ -47,7 +47,7 @@ class TaskLabelsTest extends UnitTest {
   class Fixture {
     val appId = PathId("/test")
     val instanceId = Instance.Id.forRunSpec(appId)
-    val reservationId = Reservation.Id(instanceId)
+    val reservationId = Reservation.SimplifiedId(instanceId)
     val frameworkId = MarathonTestHelper.frameworkId
     val otherFrameworkId = FrameworkId("very other different framework id")
 

--- a/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/base/util/OfferOperationFactoryTest.scala
@@ -140,7 +140,7 @@ class OfferOperationFactoryTest extends UnitTest {
     val runSpecId = PathId("/my-app")
     val instanceId = Instance.Id.forRunSpec(runSpecId)
     val taskId = Task.Id(instanceId)
-    val reservationId = Reservation.Id(instanceId)
+    val reservationId = Reservation.SimplifiedId(instanceId)
     val frameworkId = MarathonTestHelper.frameworkId
     val reservationLabels = TaskLabels.labelsForTask(frameworkId, reservationId)
     val principal = Some("principal")

--- a/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/reconcile/impl/OfferMatcherReconcilerTest.scala
@@ -35,7 +35,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val instanceId = Instance.Id.forRunSpec(appId)
       val taskId = Task.Id(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
-      val offer = MarathonTestHelper.offerWithVolumes(Reservation.Id(instanceId), localVolumeIdLaunched)
+      val offer = MarathonTestHelper.offerWithVolumes(Reservation.SimplifiedId(instanceId), localVolumeIdLaunched)
 
       And("no groups")
       f.groupRepository.root() returns Future.successful(createRootGroup())
@@ -65,7 +65,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val instanceId = Instance.Id.forRunSpec(appId)
       val taskId = Task.Id(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
-      val offer = MarathonTestHelper.offerWithVolumes(Reservation.Id(instanceId), localVolumeIdLaunched)
+      val offer = MarathonTestHelper.offerWithVolumes(Reservation.SimplifiedId(instanceId), localVolumeIdLaunched)
 
       And("a bogus app")
       val app = AppDefinition(appId, cmd = Some("sleep"))
@@ -95,7 +95,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val instanceId = Instance.Id.forRunSpec(appId)
       val taskId = Task.Id(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
-      val offer = MarathonTestHelper.offerWithVolumes(Reservation.Id(instanceId), localVolumeIdLaunched)
+      val offer = MarathonTestHelper.offerWithVolumes(Reservation.SimplifiedId(instanceId), localVolumeIdLaunched)
 
       And("no groups")
       f.groupRepository.root() returns Future.successful(createRootGroup())
@@ -125,7 +125,7 @@ class OfferMatcherReconcilerTest extends UnitTest with GroupCreation {
       val instanceId = Instance.Id.forRunSpec(appId)
       val taskId = Task.Id(instanceId)
       val localVolumeIdLaunched = LocalVolumeId(appId, "persistent-volume-launched", "uuidLaunched")
-      val offer = MarathonTestHelper.offerWithVolumes(Reservation.Id(instanceId), localVolumeIdLaunched)
+      val offer = MarathonTestHelper.offerWithVolumes(Reservation.SimplifiedId(instanceId), localVolumeIdLaunched)
 
       And("a matching bogus app")
       val app = AppDefinition(appId, cmd = Some("sleep"))

--- a/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/PersistentVolumeMatcherTest.scala
@@ -64,8 +64,8 @@ class PersistentVolumeMatcherTest extends UnitTest {
       val offer =
         f.offerWithVolumes(unknownInstance, localVolumeId1)
           .toBuilder
-          .addAllResources(MarathonTestHelper.persistentVolumeResources(Reservation.Id(instances.head.instanceId), localVolumeId2).asJava)
-          .addAllResources(MarathonTestHelper.persistentVolumeResources(Reservation.Id(instances(1).instanceId), localVolumeId3).asJava)
+          .addAllResources(MarathonTestHelper.persistentVolumeResources(Reservation.Id(instances.head), localVolumeId2).asJava)
+          .addAllResources(MarathonTestHelper.persistentVolumeResources(Reservation.Id(instances(1)), localVolumeId3).asJava)
           .build()
 
       When("We ask for a volume match")

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -143,7 +143,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
 
     "match resources success with preserved reservations" in {
       val instanceId = Instance.Id(PathId("/my/app"), PrefixInstance, UUID.randomUUID())
-      val labels = TaskLabels.labelsForTask(FrameworkId("foo"), Reservation.Id(instanceId)).labels
+      val labels = TaskLabels.labelsForTask(FrameworkId("foo"), Reservation.SimplifiedId(instanceId)).labels
       val cpuReservation = MarathonTestHelper.reservation(principal = "cpuPrincipal", labels)
       val cpuReservation2 = MarathonTestHelper.reservation(principal = "cpuPrincipal", labels)
       val memReservation = MarathonTestHelper.reservation(principal = "memPrincipal", labels)
@@ -266,7 +266,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val cpuReservation2 = MarathonTestHelper.reservation(principal = "cpuPrincipal")
       val memReservation = MarathonTestHelper.reservation(
         principal = "memPrincipal",
-        labels = TaskLabels.labelsForTask(FrameworkId("foo"), Reservation.Id(instanceId)).labels)
+        labels = TaskLabels.labelsForTask(FrameworkId("foo"), Reservation.SimplifiedId(instanceId)).labels)
       val diskReservation = MarathonTestHelper.reservation(principal = "diskPrincipal")
       val portsReservation = MarathonTestHelper.reservation(principal = "portPrincipal")
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
@@ -38,10 +38,10 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
   val marathon16322Artifact = MarathonArtifact("1.6.322", "marathon-1.6.322-2bf46b341.tgz")
 
   // Configure Mesos to provide the Mesos containerizer with Docker image support.
-  //  override lazy val mesosConfig = MesosConfig(
-  //    launcher = "linux",
-  //    isolation = Some("filesystem/linux,docker/runtime"),
-  //    imageProviders = Some("docker"))
+  override lazy val mesosConfig = MesosConfig(
+    launcher = "linux",
+    isolation = Some("filesystem/linux,docker/runtime"),
+    imageProviders = Some("docker"))
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
@@ -276,7 +276,7 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
   }
 
   "resident app can be restarted after upgrade from 1.6.322" in {
-    val zkUrl = s"$zkURLBase-to-latest"
+    val zkUrl = s"$zkURLBase-resident-apps"
     val marathon16322 = Marathon16322(marathon16322Artifact.marathonPackage, suiteName = s"$suiteName-1-6-322", mesosMasterUrl, zkUrl)
 
     // Start apps in 1.6.322
@@ -289,7 +289,7 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
     val residentApp_16322 = residentApp(
       id = testBasePath / "resident-app-16322",
       containerPath = containerPath,
-      cmd = s"""echo "data" > $containerPath/data && sleep 1000""")
+      cmd = s"""echo "data" >> $containerPath/data && sleep 1000""")
     marathon16322.client.createAppV2(residentApp_16322) should be(Created)
 
     patienceConfig
@@ -324,6 +324,8 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
       marathonCurrent.client.tasks(residentApp_16322.id.toPath).value should not contain theSameElementsAs(restartedApp16322Tasks)
       marathonCurrent should have (runningTasksFor(residentApp_16322.id.toPath, 1))
     }
+
+    marathonCurrent.close()
   }
 
   /**


### PR DESCRIPTION
Summary:
The reservation id defaults to `SimplifiedId`. This breaks the restart of older
resident apps and pods since their reservations have an old id. Unfortunately,
we construct the reservation id with each match instead of persisting it. This
will change with MARATHON-8517 which requires a migration.

This patch uses the same logic from 1.7 and earlier to infer the reservation id
via `instance.appTask.reservationId`.

JIRA issues: DCOS_OSS-5212