### PR TITLE
Only match disk with profile if that profile is needed (#6916)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### Fixed issues
 
-- [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) - Previously, Mesos disks with profiles would be matched before it was possible to specify that a service definition should only accept a specific disk profile. The behavior changed in a backwards incompatible way when support for disk profile matching was added. If no profile was specified to be matched for a Marathon service definition, then only Mesos disks without profiles would be considered as matching candidates. The behavior has been restored so that all Mesos disk profiles (specified or not) will be considered if no profile requirement is specified in the Marathon service definition.
+- [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) - The initial support for volume profiles would match disk resources with a profile, even if no profile was required. This behavior has been adjusted so that disk resources with profiles are only used when those profiles are required, and are not used if the service for which we are matching offers does not require a disk with that profile.
 
 ## Changes to 1.7.216
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
-## Changes to 1.7.XXX
+## Changes to 1.7.xxx
+
+### Fixed issues
+
+- [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) - Previously, Mesos disks with profiles would be matched before it was possible to specify that a service definition should only accept a specific disk profile. The behavior changed in a backwards incompatible way when support for disk profile matching was added. If no profile was specified to be matched for a Marathon service definition, then only Mesos disks without profiles would be considered as matching candidates. The behavior has been restored so that all Mesos disk profiles (specified or not) will be considered if no profile requirement is specified in the Marathon service definition.
+
+## Changes to 1.7.216
 
 ### Introduce global throttling to Marathon health checks
 Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -375,13 +375,6 @@ object ResourceMatcher extends StrictLogging {
     volumesWithMounts: Seq[VolumeWithMount[PersistentVolume]],
     scope: ScalarMatchResult.Scope): Seq[ScalarMatchResult] = {
 
-    def matchesProfileName(profileName: Option[String], resource: Protos.Resource): Boolean = {
-      profileName.forall { specifiedProfileName =>
-        resource.hasDisk && resource.getDisk.hasSource && resource.getDisk.getSource.hasProfile &&
-          specifiedProfileName == resource.getDisk.getSource.getProfile
-      }
-    }
-
     @tailrec
     def findMatches(
       diskType: DiskType,
@@ -399,7 +392,7 @@ object ResourceMatcher extends StrictLogging {
             case Right(VolumeWithMount(volume, _)) =>
               def matcher(resource: Protos.Resource): Boolean = {
                 VolumeConstraints.meetsAllConstraints(resource, volume.persistent.constraints) &&
-                  matchesProfileName(volume.persistent.profileName, resource)
+                  VolumeProfileMatcher.matchesProfileName(volume.persistent.profileName, resource)
               }
 
               (matcher _, volume.persistent.size.toDouble)
@@ -447,7 +440,7 @@ object ResourceMatcher extends StrictLogging {
             VolumeConstraints.meetsAllConstraints(resource, nextAllocation.volume.persistent.constraints) &&
               (resourceSize >= nextAllocation.volume.persistent.size) &&
               (resourceSize <= nextAllocation.volume.persistent.maxSize.getOrElse(Long.MaxValue)) &&
-              matchesProfileName(nextAllocation.volume.persistent.profileName, resource)
+              VolumeProfileMatcher.matchesProfileName(nextAllocation.volume.persistent.profileName, resource)
           } match {
             case Some(matchedResource) =>
               val consumedAmount = matchedResource.getScalar.getValue

--- a/src/main/scala/mesosphere/mesos/VolumeProfileMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/VolumeProfileMatcher.scala
@@ -1,0 +1,28 @@
+package mesosphere.mesos
+
+import org.apache.mesos
+
+import scala.util.Try
+
+object VolumeProfileMatcher {
+
+  /**
+    * @param requiredProfileName the name of the profile that needs to be set on a disk resource, if any.
+    * @param resource the resource that shall be matched against the provided requiredProfileName
+    * @return true, if the provided resource is a disk and has the required profile name,
+    * or if no profile is requested and the disk has no profile set.
+    * Will return false if the profile does not match or the disk has a profile
+    * while no profile is requested.
+    */
+  def matchesProfileName(requiredProfileName: Option[String], resource: mesos.Protos.Resource): Boolean = {
+    val diskProfile: Option[String] = Try(resource.getDisk.getSource.getProfile).filter(_.nonEmpty).toOption
+
+    requiredProfileName.map { profile =>
+      // If a profile is specified, only match disk resources that have that specified profile
+      diskProfile.contains(profile)
+    }.getOrElse {
+      // If no profile is specified, only match disks that do not have a profile set at all
+      diskProfile.isEmpty
+    }
+  }
+}

--- a/src/test/scala/mesosphere/mesos/VolumeProfileMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/VolumeProfileMatcherTest.scala
@@ -1,0 +1,44 @@
+package mesosphere.mesos
+
+import mesosphere.UnitTest
+import org.apache.mesos
+
+class VolumeProfileMatcherTest extends UnitTest {
+  "matchesProfileName" should {
+    "match disk with profile if that profile is required" in {
+      val disk = diskResource(profile = Some("profile"))
+      VolumeProfileMatcher.matchesProfileName(Some("profile"), disk) shouldBe true
+    }
+    "not match disk with profile if no profile is required" in {
+      val disk = diskResource(profile = Some("profile"))
+      VolumeProfileMatcher.matchesProfileName(None, disk) shouldBe false
+    }
+    "match disk without profile when no profile is required" in {
+      val disk = diskResource(profile = None)
+      VolumeProfileMatcher.matchesProfileName(None, disk) shouldBe true
+    }
+    "not match disk with profile if a different profile is required" in {
+      val disk = diskResource(profile = Some("profile"))
+      VolumeProfileMatcher.matchesProfileName(Some("needed-profile"), disk) shouldBe false
+    }
+  }
+
+  /** Helper to create disk resources with/without profile */
+  def diskResource(profile: Option[String]): mesos.Protos.Resource = {
+    val source = mesos.Protos.Resource.DiskInfo.Source.newBuilder()
+      .setType(mesos.Protos.Resource.DiskInfo.Source.Type.PATH)
+      .setPath(mesos.Protos.Resource.DiskInfo.Source.Path.newBuilder().setRoot("test"))
+      .setId("pathDiskId")
+    profile.foreach { p =>
+      source.setProfile(p)
+      source.setVendor("vendorId")
+    }
+
+    mesos.Protos.Resource.newBuilder()
+      .setType(mesos.Protos.Value.Type.SCALAR)
+      .setName("disk")
+      .setDisk(mesos.Protos.Resource.DiskInfo.newBuilder()
+        .setSource(source))
+      .build()
+  }
+}


### PR DESCRIPTION
Summary:
The initial support for volume profiles would match disk resources with a profile, even if no profile was required. This commit changes this behavior so that disks resources are not used if the service for which we are matching offers does not require a disk with that profile.

JIRA issues: DCOS_OSS-5211