### PR TITLE
Update ssl-basic-access-authentication.md

### DIFF
--- a/docs/docs/ssl-basic-access-authentication.md
+++ b/docs/docs/ssl-basic-access-authentication.md
@@ -80,7 +80,7 @@ If you do not already have a Java keystore, follow the steps below to create one
     $ openssl pkcs12 -inkey marathon.key \
                     -passin "env:MARATHON_KEY_PASSWORD" \
                       -name marathon \
-                        -in trusted.pem \
+                        -in self-signed-marathon.pem \
                   -password "env:MARATHON_PKCS_PASSWORD" \
              -chain -CAfile "trustedCA.crt" \
                -export -out marathon.pkcs12


### PR DESCRIPTION
Not sure if I am right. But here both `trusted.pem` and `self-signed-marathon.pem` appear only once, and no introduction on how to generate `trusted.pem. So I guess they are the same file