### PR TITLE
Pin type-generator target and release to java 8

### DIFF
--- a/type-generator/build.sbt
+++ b/type-generator/build.sbt
@@ -16,5 +16,10 @@ lazy val root = (project in file("."))
       Tests.Argument(
         "-u", "target/test-reports", // TODO(MARATHON-8215): Remove this line
         "-o", "-eDFG",
-        "-y", "org.scalatest.WordSpec"))
+        "-y", "org.scalatest.WordSpec")),
+    scalacOptions in Compile ++= Seq(
+      "-encoding", "UTF-8",
+      "-target:jvm-1.8",
+      "-release", "8"
+    )
   )

--- a/type-generator/build.sbt
+++ b/type-generator/build.sbt
@@ -20,6 +20,6 @@ lazy val root = (project in file("."))
     scalacOptions in Compile ++= Seq(
       "-encoding", "UTF-8",
       "-target:jvm-1.8",
-      "-release", "8"
+      "-release", "8" // Because of https://github.com/scala/bug/issues/11125
     )
   )


### PR DESCRIPTION
Java 11 introduces some issues with scala (StringLike.lines), so we need
to pin the target release to java 8, in case sbt is running with a java 11 JDK