### PR TITLE
Persistent volumes with profile now default to DiskType.Mount

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,8 @@
 - [DCOS-51375](https://jira.mesosphere.com/browse/DCOS-51375) - Fixed an issue where deployment cancellation could leak instances.
 
 - [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) - The initial support for volume profiles would match disk resources with a profile, even if no profile was required. This behavior has been adjusted so that disk resources with profiles are only used when those profiles are required, and are not used if the service for which we are matching offers does not require a disk with that profile.
-- [MARATHON-8631](https://jira.mesosphere.com/browse/MARATHON-8631) - When using DC/OS Storage Service (DSS), users can provision storage volumes as disk resources tagged with a profile name. Marathon allows users to create services that make use of disks tagged with these profiles. The type of disk resource in Mesos will be `Mount` in this case, as this is the only disk type DSS supports. Therefore, Marathon should default to disk type `Mount` instead of `Root`, when a profileName is given for a persistent volume configuration.
+
+- [MARATHON-8631](https://jira.mesosphere.com/browse/MARATHON-8631) - In order to prepare for the general availability of the [DC/OS Storage Service](https://docs.mesosphere.com/services/beta-storage/) (DSS), Marathon will now default to disk type `Mount`, if a persistent volume `profileName` is configured by the user without specifying the wanted disk `type`. Services like DSS will populate this field to allow users selecting the volumes they previously created. Mesos `Root` disks will not have a `profileName` set, so the default for persistent volumes that do not specify a `profileName` is still `Root`.
 
 - [MARATHON-8422](https://jira.mesosphere.com/browse/MARATHON-8422) - Kill unreachable tasks that came back. Marathon could get stuck waiting for terminal events but not issue a kill.
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 - [DCOS-51375](https://jira.mesosphere.com/browse/DCOS-51375) - Fixed an issue where deployment cancellation could leak instances.
 
 - [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) - The initial support for volume profiles would match disk resources with a profile, even if no profile was required. This behavior has been adjusted so that disk resources with profiles are only used when those profiles are required, and are not used if the service for which we are matching offers does not require a disk with that profile.
+- [MARATHON-8631](https://jira.mesosphere.com/browse/MARATHON-8631) - When using DC/OS Storage Service (DSS), users can provision storage volumes as disk resources tagged with a profile name. Marathon allows users to create services that make use of disks tagged with these profiles. The type of disk resource in Mesos will be `Mount` in this case, as this is the only disk type DSS supports. Therefore, Marathon should default to disk type `Mount` instead of `Root`, when a profileName is given for a persistent volume configuration.
 
 - [MARATHON-8422](https://jira.mesosphere.com/browse/MARATHON-8422) - Kill unreachable tasks that came back. Marathon could get stuck waiting for terminal events but not issue a kill.
 

--- a/docs/docs/rest-api/public/api/v2/types/volumes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/volumes.raml
@@ -29,7 +29,7 @@ types:
     type: string
     description: |
       The type of mesos disk resource to use; defaults to root if no profile name is specified.
-      When specififying a profileName, only disk type mount is supported.
+      When specififying a profileName, this will default to mount.
     enum: [ root, path, mount ]
   PersistentVolumeInfo:
     type: object

--- a/docs/docs/rest-api/public/api/v2/types/volumes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/volumes.raml
@@ -27,7 +27,9 @@ types:
         description: Provider specific volume configuration options
   PersistentVolumeType:
     type: string
-    description: The type of mesos disk resource to use; defaults to root
+    description: |
+      The type of mesos disk resource to use; defaults to root if no profile name is specified.
+      When specififying a profileName, only disk type mount is supported.
     enum: [ root, path, mount ]
   PersistentVolumeInfo:
     type: object

--- a/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
@@ -9,8 +9,26 @@ import org.apache.mesos.{Protos => Mesos}
 trait VolumeConversion extends ConstraintConversion with DefaultConversions {
 
   /**
-    * If a disk profile is set, disk type defaults to Mount, as only that is supported by DSS which sets profileNames
-    * In any other case, DiskType defaults to Root
+    * Will select the default disk type to use depending on whether or not a disk profileName is given.
+    *
+    * There are three types of disk currently supported by Marathon: Root, Path and Mount. These are the disk types
+    * introduced by Mesos and documented as Multiple Disks:
+    * http://mesos.apache.org/documentation/latest/multiple-disk/
+    *
+    * A Root disk usually maps to the storage on the main operating system drive. Root is the default type used when
+    * none is provided by the user. Other volume types will only exist if an operator created those using the present
+    * operating system drive. That means, when external services or tools carve up raw disks, they will produce disks
+    * of types Mount or Path, which can be used by frameworks. The only such service we are currently aware of and
+    * integrate with is the DC/OS Storage Service (DSS) which is in beta:
+    * https://docs.mesosphere.com/services/beta-storage/
+    *
+    * There are additional two types of disk that Marathon currently does not support directly, since they are of no
+    * direct value to the user: Raw and Block. For more information on these, see
+    * http://mesos.apache.org/documentation/latest/csi/
+    *
+    * DSS will use Mesos Raw disks and create Mount or Block devices out of them. The mechanism for frameworks to select
+    * such a Mount volume is the profileName, which will be populated by DSS. Therefore, if a disk profileName is set,
+    * the disk type default to Mount.
     */
   def defaultDiskTypeForProfile(profileName: Option[String]): DiskType = profileName.map(_ => DiskType.Mount).getOrElse(DiskType.Root)
 

--- a/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/VolumeConversion.scala
@@ -13,8 +13,10 @@ trait VolumeConversion extends ConstraintConversion with DefaultConversions {
     case hv: PodHostVolume => state.HostVolume(name = Some(hv.name), hostPath = hv.host)
     case sv: PodSecretVolume => state.SecretVolume(name = Some(sv.name), secret = sv.secret)
     case pv: PodPersistentVolume =>
+      // If a disk profile is set, only DiskType.Mount is supported, while DiskType defaults to Root
+      val diskType = pv.persistent.profileName.map(_ => DiskType.Mount).getOrElse(pv.persistent.`type`.fromRaml)
       val persistentInfo = state.PersistentVolumeInfo(
-        `type` = pv.persistent.`type`.fromRaml,
+        `type` = diskType,
         size = pv.persistent.size,
         maxSize = pv.persistent.maxSize,
         profileName = pv.persistent.profileName,
@@ -140,8 +142,10 @@ trait VolumeConversion extends ConstraintConversion with DefaultConversions {
   }
 
   implicit val volumePersistentReads: Reads[AppPersistentVolume, state.VolumeWithMount[Volume]] = Reads { volumeRaml =>
+    // If a disk profile is set, only DiskType.Mount is supported, while DiskType defaults to Root
+    val diskType = volumeRaml.persistent.profileName.map(_ => DiskType.Mount).getOrElse(volumeRaml.persistent.`type`.fromRaml)
     val info = state.PersistentVolumeInfo(
-      `type` = volumeRaml.persistent.`type`.fromRaml,
+      `type` = diskType,
       size = volumeRaml.persistent.size,
       maxSize = volumeRaml.persistent.maxSize,
       profileName = volumeRaml.persistent.profileName,


### PR DESCRIPTION
Summary:
When using DC/OS Storage Service (DSS), users can provision storage volumes as disk resources tagged with a profile name. Marathon allows users to create services that make use of disks tagged with these profiles. The type of disk resource in Mesos will be `Mount` in this case, as this is the only disk type DSS supports. Therefore, Marathon should default to disk type `Mount` instead of `Root`, when a profileName is given for a persistent volume configuration.

JIRA issues: MARATHON-8631