### PR TITLE
Fix interfering deployments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,14 +1,20 @@
-## Changes from 1.8.180 to 1.8.xxx
+## Changes from 1.8.194 to 1.8.xxx
 
 ### Fixed issues
 
-- [DCOS_OSS-5212](https://jira.mesosphere.com/browse/DCOS_OSS-5212) - Fix an issue that prevented reserved instances created by older Marathon versions from being restarted
+- [DCOS-54927](https://jira.mesosphere.com/browse/DCOS-54927) - Fixed an issue where two independent deployments could interfere with each other resulting in too many tasks launched and/or possibly a stuck deployment.
 
-- [MARATHON-8623](https://jira.mesosphere.com/browse/MARATHON-8623) - Fix an issue that could cause /v2/deployments to become stale
+## Changes from 1.8.180 to 1.8.194
 
-- [MARATHON-8624](https://jira.mesosphere.com/browse/MARATHON-8624) - Fix issue where the presence of a TASK_UNKNOWN status could cause an API failure
+### Fixed issues
 
-- [DCOS-51375](https://jira.mesosphere.com/browse/DCOS-51375) - Fix an issue where deployment cancellation could leak instances.
+- [DCOS_OSS-5212](https://jira.mesosphere.com/browse/DCOS_OSS-5212) - Fixed an issue that prevented reserved instances created by older Marathon versions from being restarted
+
+- [MARATHON-8623](https://jira.mesosphere.com/browse/MARATHON-8623) - Fixed an issue that could cause /v2/deployments to become stale
+
+- [MARATHON-8624](https://jira.mesosphere.com/browse/MARATHON-8624) - Fixed issue where the presence of a TASK_UNKNOWN status could cause an API failure
+
+- [DCOS-51375](https://jira.mesosphere.com/browse/DCOS-51375) - Fixed an issue where deployment cancellation could leak instances.
 
 - [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) - The initial support for volume profiles would match disk resources with a profile, even if no profile was required. This behavior has been adjusted so that disk resources with profiles are only used when those profiles are required, and are not used if the service for which we are matching offers does not require a disk with that profile.
 

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActor.scala
@@ -132,10 +132,7 @@ class TaskReplaceActor(
   def replaceBehavior: Receive = {
 
     // === An InstanceChanged event for the *new* instance ===
-    case ic: InstanceChanged if !isOldInstance(ic.instance) =>
-      val id = ic.id
-      val condition = ic.condition
-      val instance = ic.instance
+    case InstanceChanged(id, _, `pathId`, condition, instance) if !isOldInstance(instance) =>
       val goal = instance.state.goal
       val agentId = instance.agentInfo.fold(Option.empty[String])(_.agentId)
 
@@ -155,10 +152,7 @@ class TaskReplaceActor(
       }
 
     // === An InstanceChanged event for the *old* instance ===
-    case ic: InstanceChanged if isOldInstance(ic.instance) =>
-      val id = ic.id
-      val condition = ic.condition
-      val instance = ic.instance
+    case InstanceChanged(id, _, `pathId`, condition, instance) if isOldInstance(instance) =>
       val goal = instance.state.goal
 
       // 1) An old instance terminated out of band and was not yet chosen to be decommissioned or stopped.
@@ -263,7 +257,7 @@ class TaskReplaceActor(
   /**
     * @return whether [[instance]] has the new run spec version or an old one.
     */
-  def isOldInstance(instance: Instance): Boolean = instance.runSpecVersion != runSpec.version
+  def isOldInstance(instance: Instance): Boolean = instance.runSpecId == runSpec.id && instance.runSpecVersion != runSpec.version
 }
 
 object TaskReplaceActor extends StrictLogging {


### PR DESCRIPTION
Summary:
Fixed a regression where two independent deployments could interfere with each other resulting in too many tasks launched and/or possibly a stuck deployment. At the core of the issue `TaskReplaceActor` would be unselective when handling `InstanceChanged` events.

JIRA: DCOS-54927