### PR TITLE
AMI disable system upgrade cron

### DIFF
--- a/ami/install.bash
+++ b/ami/install.bash
@@ -64,8 +64,8 @@ apt-get install -y nodejs
 # Setup system
 systemctl enable docker
 update-ca-certificates -f
-systemctl stop apt-daily.timer
-systemctl stop apt-daily-upgrade.timer
+systemctl disable apt-daily.timer
+systemctl disable apt-daily-upgrade.timer
 
 # Install jq
 curl -L -o /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && sudo chmod +x /usr/local/bin/jq


### PR DESCRIPTION

Summary:
The claim is that this might fix our flaky CI provisioning which has been working until recent where now it errors with:

```
ammonite.ops.ShelloutException: CommandResult 100
E: Could not get lock /var/lib/dpkg/lock - open (11: Resource temporarily unavailable)
E: Unable to lock the administration directory (/var/lib/dpkg/), is another process using it?
```

JIRA issues:
