### PR TITLE
Do not try to kill a terminal instance.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@
 
 - [DCOS_OSS-5211](https://jira.mesosphere.com/browse/DCOS_OSS-5211) - The initial support for volume profiles would match disk resources with a profile, even if no profile was required. This behavior has been adjusted so that disk resources with profiles are only used when those profiles are required, and are not used if the service for which we are matching offers does not require a disk with that profile.
 
+- [MARATHON-8422](https://jira.mesosphere.com/browse/MARATHON-8422) - Kill unreachable tasks that came back. Marathon could get stuck waiting for terminal events but not issue a kill.
+
 ## Changes from 1.7.xxx to 1.8.180
 
 ### AppC is now deprecated

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -106,7 +106,8 @@ private[impl] class KillServiceActor(
       (inFlight.contains(id) || instancesToKill.contains(id)) =>
       handleTerminal(id)
 
-    case InstanceChanged(id, _, _, _, instance) if instance.state.goal.isTerminal() =>
+    // Only consider goal changes for non-terminal instances. This event could also be triggered by a condition change.
+    case InstanceChanged(id, _, _, condition, instance) if instance.state.goal.isTerminal() && !considerTerminal(condition) =>
       if (instancesToKill.contains(id)) {
         logger.info(s"Ignoring goal change to ${instance.state.goal} for ${instance.state.goal} since the instance is already queued.")
       } else {
@@ -134,7 +135,7 @@ private[impl] class KillServiceActor(
     logger.debug(s"Adding instances $instanceIds to the queue")
     maybePromise.map(p => p.completeWith(KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)))
     instances
-      .filterNot(instance => inFlight.keySet.contains(instance.instanceId) || instance.tasksMap.isEmpty || instance.state.condition.isTerminal)
+      .filterNot(instance => inFlight.keySet.contains(instance.instanceId) || instance.tasksMap.isEmpty)
       .foreach { instance =>
         logger.info(s"Process kill for ${instance.instanceId}:{${instance.state.condition}, ${instance.state.goal}} with tasks ${instance.tasksMap.values.map(_.taskId).toSeq}")
         val taskIds: IndexedSeq[Id] = instance.tasksMap.values.withFilter(!_.isTerminal).map(_.taskId)(collection.breakOut)
@@ -145,7 +146,7 @@ private[impl] class KillServiceActor(
             ToKill(instance.instanceId, taskIds, maybeInstance = Some(instance), attempts = 0)
           )
         } else {
-          logger.warn(s"${instance.instanceId} is ${instance.state.condition} and we try to kill all its terminal tasks.")
+          logger.warn(s"Told to kill ${instance.instanceId} which is ${instance.state.condition} and has no active tasks.")
         }
       }
     processKills()

--- a/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActor.scala
@@ -134,15 +134,19 @@ private[impl] class KillServiceActor(
     logger.debug(s"Adding instances $instanceIds to the queue")
     maybePromise.map(p => p.completeWith(KillStreamWatcher.watchForKilledTasks(instanceTracker.instanceUpdates, instances).runWith(Sink.ignore)))
     instances
-      .filterNot(instance => inFlight.keySet.contains(instance.instanceId) || instance.tasksMap.isEmpty) // Don't trigger a kill request for instances that are already being killed
+      .filterNot(instance => inFlight.keySet.contains(instance.instanceId) || instance.tasksMap.isEmpty || instance.state.condition.isTerminal)
       .foreach { instance =>
-        // TODO(PODS): do we make sure somewhere that an instance has _at_least_ one task?
         logger.info(s"Process kill for ${instance.instanceId}:{${instance.state.condition}, ${instance.state.goal}} with tasks ${instance.tasksMap.values.map(_.taskId).toSeq}")
         val taskIds: IndexedSeq[Id] = instance.tasksMap.values.withFilter(!_.isTerminal).map(_.taskId)(collection.breakOut)
-        instancesToKill.update(
-          instance.instanceId,
-          ToKill(instance.instanceId, taskIds, maybeInstance = Some(instance), attempts = 0)
-        )
+
+        if (taskIds.nonEmpty) {
+          instancesToKill.update(
+            instance.instanceId,
+            ToKill(instance.instanceId, taskIds, maybeInstance = Some(instance), attempts = 0)
+          )
+        } else {
+          logger.warn(s"${instance.instanceId} is ${instance.state.condition} and we try to kill all its terminal tasks.")
+        }
       }
     processKills()
   }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -301,6 +301,9 @@ class KillServiceActorTest extends AkkaUnitTest with StrictLogging with Eventual
         val promise = Promise[Done]()
         actor ! KillServiceActor.KillInstances(Seq(instance), promise)
 
+        promise.future.futureValue should be(Done)
+        actor.underlyingActor.instancesToKill should be('empty)
+        actor.underlyingActor.inFlight should be('empty)
         noMoreInteractions(f.driver)
       }
     }

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillStreamWatcherTest.scala
@@ -38,6 +38,18 @@ class KillStreamWatcherTest extends AkkaUnitTest {
       result shouldBe Done
     }
 
+    "completes immediately if provided instances are already terminal and no updates arrive" in {
+      val terminalInstance = TestInstanceBuilder.newBuilder(PathId("/test")).addTaskKilled().instance
+      val emptyUpdates: InstanceTracker.InstanceUpdates = Source.single((InstancesSnapshot(Seq(terminalInstance)), sourceNever))
+
+      val result = KillStreamWatcher
+        .watchForKilledTasks(emptyUpdates, Seq(terminalInstance))
+        .runWith(Sink.ignore)
+        .futureValue
+
+      result shouldBe Done
+    }
+
     "recognizes instances that are already terminal in the initial snapshot" in {
       val unreachableInstance = TestInstanceBuilder.newBuilder(PathId("/test")).addTaskUnreachable().instance
       val instanceUpdates = Source.single(InstancesSnapshot(Seq(unreachableInstance)) -> sourceNever)


### PR DESCRIPTION
Summary:
The `KillServiceActor` would queue a terminal instance for kill. The queued item would have no task
attached and thus would not issue any kill. The queue item would also never be dequeued. Thus
if a task transitioned from `TASK_UNKNOWN` to `TASK_RUNNING` the `KillServiceActor` would
ignore it.

This removes the queuing of terminal instances and issues a warning in the logs. We also verify
that the `KillStreamWatcher` reports a terminal instances as, well, terminal.

JIRA issues: MARATHON-8422