### PR TITLE
Set a default value for offersWanted subjects

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/OfferMatcherManagerModule.scala
@@ -31,7 +31,7 @@ class OfferMatcherManagerModule(
     actorName: String = "offerMatcherManager")(implicit val materializer: Materializer) {
 
   private[this] val (inputOffersWanted, offersWanted) = Source.queue[Boolean](16, OverflowStrategy.backpressure)
-    .toMat(Subject[Boolean](16, OverflowStrategy.dropHead))(Keep.both)
+    .toMat(Subject[Boolean](16, OverflowStrategy.dropHead, default = Some(false)))(Keep.both)
     .run
 
   private[this] lazy val offerMatcherManagerMetrics = new OfferMatcherManagerActorMetrics(metrics)


### PR DESCRIPTION
Summary:
There are two sources for signal indicating if offers are wanted. Metronome is
based on Marathon and only needs one of those sources. By assigning a default
value to both subjects, the combineLatest mechanism can function and not wait
forever for both sources to provide an initial value before yielding combined
elements.

JIRA issues: DCOS_OSS-5166