### PR TITLE
Drop Debian 8 support. (#6951)

### DIFF
--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -23,8 +23,8 @@ target/mesos-version: ../../project/Dependencies.scala
 	[ "$$(wc -l $@.tmp | awk '{print $$1}')" = 1 ]
 	mv $@.tmp $@
 
-target/debian8.built: debian8/Dockerfile debian8/mesos-version
-	cd debian8 && docker build . -t marathon-package-test:debian8
+target/debian9.built: debian9/Dockerfile debian9/mesos-version
+	cd debian9 && docker build . -t marathon-package-test:debian9
 	mkdir -p target
 	touch $@
 
@@ -46,11 +46,11 @@ target/centos7.built: centos7/Dockerfile centos7/mesos-version
 	cd centos7 && docker build . -t marathon-package-test:centos7
 	touch $@
 
-target/mesos.built: target/debian8.built mesos/Dockerfile
+target/mesos.built: target/debian9.built mesos/Dockerfile
 	cd mesos && docker build . -t marathon-package-test:mesos
 	touch $@
 
 test: | all
 	amm test.sc all
 
-all: target/mesos.built target/debian8.built target/centos7.built target/centos6.built target/ubuntu1404.built target/ubuntu1604.built
+all: target/mesos.built target/debian9.built target/centos7.built target/centos6.built target/ubuntu1404.built target/ubuntu1604.built

--- a/tests/package/debian9/Dockerfile
+++ b/tests/package/debian9/Dockerfile
@@ -1,18 +1,19 @@
-FROM debian:jessie
+FROM jrei/systemd-debian:9
 
 COPY ./mesos-version /mesos-version
 
+RUN apt-get -y update && apt-get -y install gnupg2
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF && \
-    echo "deb http://archive.debian.org/debian jessie-backports main" >> /etc/apt/sources.list && \
-    echo "deb http://repos.mesosphere.com/debian jessie-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
-    echo "deb http://repos.mesosphere.com/debian jessie main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian stretch-unstable main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian stretch-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+    echo "deb http://repos.mesosphere.com/debian stretch main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
     apt-get -o Acquire::Check-Valid-Until=false update && \
     # this MUST be done first, unfortunately, because Mesos packages will create folders that should be symlinks and break the python install process
     apt-get install python2.7-minimal -y && \
-    apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java=20161107~bpo8+1 && \
+    apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates && \
     # Workaround required due to https://github.com/mesosphere/mesos-deb-packaging/issues/102
     # Remove after upgrading to Mesos 1.7.0
-    apt-get install -y libcurl3-nss && \
+    # apt-get install -y libcurl3-nss && \
     apt-get install --no-install-recommends -y --force-yes mesos=$(cat /mesos-version) && \
 
     # disable mesos-master; we don't want to start in this image
@@ -30,5 +31,3 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151B
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV JAVA_HOME /docker-java-home
-
-ENTRYPOINT ["/sbin/init"]

--- a/tests/package/mesos/Dockerfile
+++ b/tests/package/mesos/Dockerfile
@@ -1,4 +1,4 @@
-FROM marathon-package-test:debian8
+FROM marathon-package-test:debian9
 
 COPY zookeeper.service /lib/systemd/system
 
@@ -7,4 +7,3 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && \
   systemctl enable zookeeper && \
   systemctl enable mesos-master
 
-ENTRYPOINT ["/sbin/init"]

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -155,7 +155,7 @@ trait SystemvSpec extends MesosTest {
   }
 }
 
-trait Debian8Container extends MesosTest {
+trait Debian9Container extends MesosTest {
 
   val marathonDebPackage: String
   var mesos: Container = _
@@ -165,7 +165,7 @@ trait Debian8Container extends MesosTest {
     super.beforeAll()
     assertPackagesCleanlyBuilt()
     mesos = startMesos()
-    systemd = runContainer("--name", "debian8", "-v", s"${packagePath}:/var/packages", "marathon-package-test:debian8")
+    systemd = runContainer("--name", "debian9", "-v", s"${packagePath}:/var/packages", "marathon-package-test:debian9")
 
     System.err.println(s"Installing package...")
     // install the package
@@ -222,12 +222,7 @@ trait Ubuntu1604Container extends MesosTest {
 }
 
 
-class Debian8Test extends SystemdSpec with Debian8Container with MesosTest {
-  override val marathonDebPackage = s"/var/packages/marathon_${MarathonVersion}-*.debian8_all.deb"
-
-  "Marathon Debian 8 package" should behave like systemdUnit(systemd, mesos)
-}
-class Debian9Test extends SystemdSpec with Debian8Container with MesosTest {
+class Debian9Test extends SystemdSpec with Debian9Container with MesosTest {
   override val marathonDebPackage = s"/var/packages/marathon_${MarathonVersion}-*.debian9_all.deb"
 
   "Marathon Debian 9 package" should behave like systemdUnit(systemd, mesos)
@@ -435,7 +430,6 @@ def main(args: String*): Unit = {
     t.getClass.getSimpleName.split("$").last
 
   val tests = Seq(
-    new Debian8Test,
     new Debian9Test,
     new Centos7Test,
     new Centos6Test,

--- a/tools/packager/Makefile
+++ b/tools/packager/Makefile
@@ -61,7 +61,7 @@ el: el6 el7
 ubuntu: ubuntu-trusty-1404 ubuntu-xenial-1604 ubuntu-bionic-1804
 
 .PHONY: debian
-debian: debian-jessie-8 debian-stretch-9
+debian: debian-stretch-9
 
 .PHONY: el6
 el6: toor/el6/etc/init.d/marathon
@@ -120,15 +120,6 @@ ubuntu-bionic-1804: toor/ubuntu-bionic/etc/default/marathon
 ubuntu-bionic-1804: fpm-docker/.provisioned
 	$(FPM) -C toor/ubuntu-xenial \
 		--iteration $(PKG_REL).ubuntu1804 \
-		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
-
-.PHONY: debian-jessie-8
-debian-jessie-8: toor/debian-jessie-8/lib/systemd/system/marathon.service
-debian-jessie-8: toor/debian-jessie-8/$(PREFIX)/share/marathon
-debian-jessie-8: toor/debian-jessie-8/etc/default/marathon
-debian-jessie-8: fpm-docker/.provisioned
-	$(FPM) -C toor/debian-jessie-8 \
-		--iteration $(PKG_REL).debian8 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
 .PHONY: debian-stretch-9


### PR DESCRIPTION
Summary:
The current master build fails on Debian 8 package tests since Mesos 1.8
cannot be installed on Debian 8. Thus we drop testing and support in
favor of Debian 9 support.

Backport of #6951