### PR TITLE
Install Mesos with distro name.

### DIFF
--- a/ci/provision.sc
+++ b/ci/provision.sc
@@ -19,7 +19,7 @@ def installMesos(): Unit = {
 
   // Install Mesos
   def install_mesos(version: String): Unit = {
-    %%('sudo, "apt-get", "install", "-y", "--force-yes", "--no-install-recommends", s"mesos=$version")
+    %%('sudo, "apt-get", "install", "-y", "--force-yes", "--no-install-recommends", s"mesos=$version.debian9")
   }
 
   // Stop Mesos service

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -138,7 +138,7 @@ object Dependency {
     val WixAccord = "0.7.1"
 
     // Version of Mesos to use in Dockerfile.
-    val MesosDebian = "1.8.0-2.0.6.debian9"
+    val MesosDebian = "1.8.0-2.0.6"
 
     // test deps versions
     val JMH = "1.19"

--- a/tests/package/ubuntu1404/Dockerfile
+++ b/tests/package/ubuntu1404/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv DF7D54CBE56151BF && \
   # install mesos
   # this MUST be done first, unfortunately, because Mesos packages will create folders that should be symlinks and break the python install process
   apt-get install python2.7-minimal -y && \
-  apt-get install --no-install-recommends -y --force-yes mesos=$(cat /mesos-version) && \
+  apt-get install --no-install-recommends -y --force-yes mesos="$(cat /mesos-version).ubuntu1404" && \
 
   # disable mesos-master; we don't want to start in this image
   echo manual | tee /etc/init/mesos-master.override && \

--- a/tests/package/ubuntu1604/Dockerfile
+++ b/tests/package/ubuntu1604/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -my wget gnupg lsb-release && \
     # this MUST be done first, unfortunately, because Mesos packages will create folders that should be symlinks and break the python install process
     apt-get install python2.7-minimal -y && \
     apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless && \
-    apt-get install --no-install-recommends -y --force-yes mesos=$(cat /mesos-version) && \
+    apt-get install --no-install-recommends -y --force-yes mesos="$(cat /mesos-version).ubuntu1604" && \
 
     # disable mesos-master; we don't want to start in this image
     systemctl disable mesos-master && \


### PR DESCRIPTION
Summary:
The Marathon package tests fail because we cannot install Mesos on the
test Docker images. This happened because the package versions include
the distribution versions now. This patch should fix that.