### PR TITLE
Reset runSpec delay when it is indicated that an agent is being drained

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@
 As described [in an earlies note](#--gpu_scheduling_behavior-default-is-now-restricted-undefined-is-deprecated-and-will-be-removed) `undefined`
 is removed with `1.9.x`.
 
+### Marathon will auto-reset backoff delays when agents are being drained
+
+When Marathon receives a TASK_GONE_BY_OPERATOR or TASK_KILLED status update with a reason indicating that the agent is being drained, any delay for the related run spec will be deleted. This is to speed up the process of replacing tasks from drained agents.
+
 ## Changes from 1.8.194 to 1.8.xxx
 
 ### Revive and Suppress Refactoring

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ is removed with `1.9.x`.
 
 ### Marathon will auto-reset backoff delays when agents are being drained
 
-When Marathon receives a TASK_GONE_BY_OPERATOR or TASK_KILLED status update with a reason indicating that the agent is being drained, any delay for the related run spec will be deleted. This is to speed up the process of replacing tasks from drained agents.
+When Marathon receives a `TASK_GONE_BY_OPERATOR` or `TASK_KILLED` status update with a reason indicating that the agent is being drained, any delay for the related run spec will be deleted. This is to speed up the process of replacing tasks from drained agents.
 
 ## Changes from 1.8.194 to 1.8.xxx
 

--- a/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
+++ b/mesos-simulation/src/main/scala/mesosphere/mesos/simulation/SimulatedDriver.scala
@@ -118,4 +118,10 @@ class SimulatedDriver(driverProps: Props) extends SchedulerDriver with StrictLog
         Status.DRIVER_STOPPED
     }
   }
+
+  override def reviveOffers(roles: util.Collection[String]): Status = ???
+
+  override def suppressOffers(roles: util.Collection[String]): Status = ???
+
+  override def updateFramework(frameworkInfo: FrameworkInfo, suppressedRoles: util.Collection[String]): Status = ???
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -125,7 +125,7 @@ object Dependency {
     val Logstash = "4.9"
     val MarathonApiConsole = "3.0.8-accept"
     val MarathonUI = "1.3.1"
-    val Mesos = "1.8.0"
+    val Mesos = "1.9.0-SNAPSHOT"
     val Mustache = "0.9.0"
     val PlayJson = "2.6.7"
     val Raven = "8.0.3"

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -11,7 +11,6 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.UnknownInstanceTerminated
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
@@ -31,7 +30,6 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     instanceTracker: InstanceTracker,
     driverHolder: MarathonSchedulerDriverHolder,
     killService: KillService,
-    launchQueue: LaunchQueue,
     eventStream: EventStream) extends TaskStatusUpdateProcessor with StrictLogging {
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -78,15 +76,11 @@ class TaskStatusUpdateProcessorImpl @Inject() (
             Future.successful(killService.killUnknownTask(taskId, KillReason.NotInSync))
           }
         }
-        checkDelay(instance, status)
         acknowledge(status)
 
       case Some(instance) =>
         // TODO(PODS): we might as well pass the taskCondition here
-        instanceTracker.updateStatus(instance, status, now).flatMap{ _ =>
-          checkDelay(instance, status)
-          acknowledge(status)
-        }
+        instanceTracker.updateStatus(instance, status, now).flatMap(_ => acknowledge(status))
 
       case None if terminalUnknown(taskCondition) =>
         logger.warn(s"Received terminal status update for unknown $taskId")
@@ -104,34 +98,6 @@ class TaskStatusUpdateProcessorImpl @Inject() (
         val taskStr = taskKnownOrNotStr(maybeInstance)
         logger.info(s"Ignoring ${status.getState} update for $taskStr $taskId")
         acknowledge(status)
-    }
-  }
-
-  /**
-    * @return true, if the received status indicates that the agent it comes from is being drained.
-    *
-    * The only relevant states here are TASK_KILLED and TASK_GONE_BY_OPERATOR. See the design doc
-    * https://docs.google.com/document/d/1w3O80NFE6m52XNMv7EdXSO-1NebEs8opA8VZPG1tW0Y/edit#
-    * for more info
-    */
-  def agentDraining(status: MesosProtos.TaskStatus): Boolean = {
-    val relevantState = status.hasState &&
-      (status.getState == MesosProtos.TaskState.TASK_KILLED || status.getState == MesosProtos.TaskState.TASK_GONE_BY_OPERATOR)
-    val isDraining = status.hasReason && status.getReason == MesosProtos.TaskStatus.Reason.REASON_SLAVE_DRAINING
-
-    relevantState && isDraining
-  }
-
-  /**
-    * When receiving task statuses from draining agents, we reset any delay
-    * that might exist for the related runSpec. This is to speed up the
-    * process of replacing these tasks.
-    */
-  def checkDelay(instance: Instance, status: MesosProtos.TaskStatus): Unit = {
-    // reset any delay for the related runSpec if the agent is being drained
-    if (agentDraining(status)) {
-      logger.info(s"Reset delay for ${instance.instanceId.runSpecId} because status update for ${status.getTaskId.getValue} indicated ${status.getSlaveId.getValue} is being drained")
-      launchQueue.resetDelay(instance.runSpec)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -11,6 +11,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.event.UnknownInstanceTerminated
 import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.update.TaskStatusUpdateProcessor
@@ -30,6 +31,7 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     instanceTracker: InstanceTracker,
     driverHolder: MarathonSchedulerDriverHolder,
     killService: KillService,
+    launchQueue: LaunchQueue,
     eventStream: EventStream) extends TaskStatusUpdateProcessor with StrictLogging {
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -53,7 +55,7 @@ class TaskStatusUpdateProcessorImpl @Inject() (
   logger.info("Started status update processor")
 
   override def publish(status: MesosProtos.TaskStatus): Future[Unit] = publishTimeMetric {
-    logger.debug(s"Received status update\n${status}")
+    logger.debug(s"Received status update\n$status")
     getTaskStateCounterMetric(status.getState).increment()
 
     import TaskStatusUpdateProcessorImpl._
@@ -71,33 +73,65 @@ class TaskStatusUpdateProcessorImpl @Inject() (
       case Some(instance) if taskIsUnknown(instance, taskId) =>
         if (killWhenUnknown(taskCondition)) {
           killUnknownTaskTimeMetric {
-            logger.warn(s"Kill ${taskId} because it's unknown to marathon. " +
+            logger.warn(s"Kill $taskId because it's unknown to marathon. " +
               s"The related instance ${instance.instanceId} is associated with ${instance.tasksMap.keys}")
             Future.successful(killService.killUnknownTask(taskId, KillReason.NotInSync))
           }
         }
+        checkDelay(instance, status)
         acknowledge(status)
 
       case Some(instance) =>
         // TODO(PODS): we might as well pass the taskCondition here
-        instanceTracker.updateStatus(instance, status, now).flatMap(_ => acknowledge(status))
+        instanceTracker.updateStatus(instance, status, now).flatMap{ _ =>
+          checkDelay(instance, status)
+          acknowledge(status)
+        }
 
       case None if terminalUnknown(taskCondition) =>
-        logger.warn(s"Received terminal status update for unknown ${taskId}")
+        logger.warn(s"Received terminal status update for unknown $taskId")
         eventStream.publish(UnknownInstanceTerminated(taskId.instanceId, taskId.runSpecId, taskCondition))
         acknowledge(status)
 
       case None if killWhenUnknown(taskCondition) =>
         killUnknownTaskTimeMetric {
-          logger.warn(s"Kill unknown ${taskId}")
+          logger.warn(s"Kill unknown $taskId")
           killService.killUnknownTask(taskId, KillReason.Unknown)
           acknowledge(status)
         }
 
-      case maybeTask: Option[Instance] =>
-        val taskStr = taskKnownOrNotStr(maybeTask)
+      case maybeInstance: Option[Instance] =>
+        val taskStr = taskKnownOrNotStr(maybeInstance)
         logger.info(s"Ignoring ${status.getState} update for $taskStr $taskId")
         acknowledge(status)
+    }
+  }
+
+  /**
+    * @return true, if the received status indicates that the agent it comes from is being drained.
+    *
+    * The only relevant states here are TASK_KILLED and TASK_GONE_BY_OPERATOR. See the design doc
+    * https://docs.google.com/document/d/1w3O80NFE6m52XNMv7EdXSO-1NebEs8opA8VZPG1tW0Y/edit#
+    * for more info
+    */
+  def agentDraining(status: MesosProtos.TaskStatus): Boolean = {
+    val relevantState = status.hasState &&
+      (status.getState == MesosProtos.TaskState.TASK_KILLED || status.getState == MesosProtos.TaskState.TASK_GONE_BY_OPERATOR)
+    val isDraining = status.hasReason && status.getReason == MesosProtos.TaskStatus.Reason.REASON_SLAVE_DRAINING
+
+    relevantState && isDraining
+  }
+
+  /**
+    * When receiving task statuses from draining agents, we reset any delay
+    * that might exist for the related runSpec. This is to speed up the
+    * process of replacing these tasks.
+    */
+  def checkDelay(instance: Instance, status: MesosProtos.TaskStatus): Unit = {
+    // reset any delay for the related runSpec if the agent is being drained
+    if (agentDraining(status)) {
+      logger.info(s"Reset delay for ${instance.instanceId.runSpecId} because status update for ${status.getTaskId.getValue} indicated ${status.getSlaveId.getValue} is being drained")
+      launchQueue.resetDelay(instance.runSpec)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImpl.scala
@@ -1,58 +1,84 @@
 package mesosphere.marathon
 package core.task.update.impl.steps
 
-import java.time.OffsetDateTime
-
 import akka.Done
 import com.google.inject.{Inject, Provider}
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.group.GroupManager
+import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler}
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.state.{PathId, RunSpec}
 
-import scala.async.Async._
 import scala.concurrent.Future
 
 class NotifyRateLimiterStepImpl @Inject() (
-    launchQueueProvider: Provider[LaunchQueue],
-    groupManagerProvider: Provider[GroupManager]) extends InstanceChangeHandler {
+    launchQueueProvider: Provider[LaunchQueue]) extends InstanceChangeHandler with StrictLogging {
 
   import NotifyRateLimiterStep._
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   private[this] lazy val launchQueue = launchQueueProvider.get()
-  private[this] lazy val groupManager = groupManagerProvider.get()
 
   override def name: String = "notifyRateLimiter"
   override def metricName: String = "notify-rate-limiter"
 
+  /**
+    * RateLimiter is triggered for every InstanceChange event. Right now,
+    * InstanceChange is very tied to condition changes so InstanceChange pretty
+    * much was condition change all the time. But now, we will be having
+    * InstanceChange event also for goal changes and we don't want to trigger
+    * RateLimiter for that.
+    */
   override def process(update: InstanceChange): Future[Done] = {
-    update.condition match {
-      // RateLimiter is triggered for every InstanceChange event. Right now, InstanceChange is very tight to condition
-      // change so InstanceChange pretty much was condition change all the time. But now, we will be having
-      // InstanceChange event also for goal changes and we don't want to trigger RateLimiter for that
-      case condition if limitWorthy(condition) && update.conditionUpdated =>
-        notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime, launchQueue.addDelay)
-      case condition if advanceWorthy(condition) && update.conditionUpdated =>
-        notifyRateLimiter(update.runSpecId, update.instance.runSpecVersion.toOffsetDateTime, launchQueue.advanceDelay)
+
+    update.instance match {
+      case instance if agentDraining(instance) =>
+        val runSpecId = update.runSpecId
+        val instanceId = instance.instanceId
+        val agentId = instance.agentInfo.flatMap(_.agentId).getOrElse("unknown")
+        logger.info(s"Reset delay for $runSpecId because status update for $instanceId (${update.condition}) indicated $agentId is being drained")
+        launchQueue.resetDelay(instance.runSpec)
+
+      case instance if limitWorthy(instance.state.condition) && update.conditionUpdated =>
+        launchQueue.addDelay(instance.runSpec)
+
+      case instance if advanceWorthy(instance.state.condition) && update.conditionUpdated =>
+        launchQueue.advanceDelay(instance.runSpec)
+
       case _ =>
-        Future.successful(Done)
+      // nothing to do
+    }
+
+    Future.successful(Done)
+  }
+}
+
+private[steps] object NotifyRateLimiterStep extends StrictLogging {
+
+  /**
+    * If any of the instance's tasks has a mesos status in state TASK_KILLED or
+    * TASK_GONE_BY_OPERATOR, and a reason REASON_SLAVE_DRAINING, then the agent
+    * that task was running on is being drained.
+    *
+    * The only relevant states here are TASK_KILLED and TASK_GONE_BY_OPERATOR.
+    * See the public design doc for more info:
+    * https://docs.google.com/document/d/1w3O80NFE6m52XNMv7EdXSO-1NebEs8opA8VZPG1tW0Y/edit#
+    *
+    * @return true, if the given instance indicates that the associated agent is
+    *         being drained.
+    */
+  def agentDraining(instance: Instance): Boolean = {
+    import org.apache.mesos.{Protos => MesosProtos}
+    instance.tasksMap.valuesIterator.exists { task =>
+      task.status.mesosStatus.fold(false) { status =>
+        val relevantState = status.hasState &&
+          (status.getState == MesosProtos.TaskState.TASK_KILLED || status.getState == MesosProtos.TaskState.TASK_GONE_BY_OPERATOR)
+        val isDraining = status.hasReason && status.getReason == MesosProtos.TaskStatus.Reason.REASON_SLAVE_DRAINING
+
+        relevantState && isDraining
+      }
     }
   }
 
-  private[this] def notifyRateLimiter(runSpecId: PathId, version: OffsetDateTime, fn: RunSpec => Unit): Future[Done] =
-    async {
-      val appFuture = groupManager.appVersion(runSpecId, version)
-      val podFuture = groupManager.podVersion(runSpecId, version)
-      val (app, pod) = (await(appFuture), await(podFuture))
-      app.foreach(fn)
-      pod.foreach(fn)
-      Done
-    }
-}
-
-private[steps] object NotifyRateLimiterStep {
   // A set of conditions that are worth rate limiting the associated runSpec
   val limitWorthy: Set[Condition] = Set(
     Condition.Dropped, Condition.Error, Condition.Failed, Condition.Gone, Condition.Finished

--- a/src/test/scala/mesosphere/marathon/core/task/bus/MesosTaskStatusTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/MesosTaskStatusTestHelper.scala
@@ -21,11 +21,12 @@ object MesosTaskStatusTestHelper {
     maybeAgentId: Option[SlaveID] = None,
     taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)): TaskStatus = {
 
+    val agentID = maybeAgentId.getOrElse(SlaveID.newBuilder().setValue("agent").build())
     val mesosStatus = TaskStatus.newBuilder
       .setTaskId(taskId.mesosTaskId)
       .setState(state)
       .setTimestamp(timestamp.seconds.toDouble)
-    maybeAgentId.foreach(mesosStatus.setSlaveId)
+    mesosStatus.setSlaveId(agentID)
     maybeHealthy.foreach(mesosStatus.setHealthy)
     maybeReason.foreach(mesosStatus.setReason)
     maybeMessage.foreach(mesosStatus.setMessage)
@@ -62,12 +63,12 @@ object MesosTaskStatusTestHelper {
   def failed(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)) = mesosStatus(state = TaskState.TASK_FAILED, taskId = taskId)
   def finished(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)) = mesosStatus(state = TaskState.TASK_FINISHED, taskId = taskId)
   def gone(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)) = mesosStatus(state = TaskState.TASK_GONE, taskId = taskId)
-  def goneByOperator(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None), agentId: Option[SlaveID] = None) =
-    mesosStatus(state = TaskState.TASK_GONE_BY_OPERATOR, taskId = taskId, maybeAgentId = agentId)
+  def goneByOperator(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None), agentId: Option[SlaveID] = None, maybeReason: Option[Reason] = None) =
+    mesosStatus(state = TaskState.TASK_GONE_BY_OPERATOR, taskId = taskId, maybeAgentId = agentId, maybeReason = maybeReason)
   def error(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)) = mesosStatus(state = TaskState.TASK_ERROR, taskId = taskId)
   def lost(reason: Reason, taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None), since: Timestamp = Timestamp.zero) =
     mesosStatus(TaskState.TASK_LOST, maybeReason = Some(reason), timestamp = since, taskId = taskId)
-  def killed(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)) = mesosStatus(state = TaskState.TASK_KILLED, taskId = taskId)
+  def killed(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None), maybeReason: Option[Reason] = None) = mesosStatus(state = TaskState.TASK_KILLED, taskId = taskId, maybeReason = maybeReason)
   def killing(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)) = mesosStatus(state = TaskState.TASK_KILLING, taskId = taskId)
   def unknown(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None)) = mesosStatus(state = TaskState.TASK_UNKNOWN, taskId = taskId)
   def unreachable(taskId: Task.Id = Task.EphemeralTaskId(newInstanceId(), None), since: Timestamp = Timestamp.zero) = {

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -9,6 +9,7 @@ import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.pod.MesosContainer
 import mesosphere.marathon.core.task.{Task, TaskCondition}
 import mesosphere.marathon.state.{PathId, Timestamp}
+import org.apache.mesos
 import org.apache.mesos.Protos.TaskStatus.Reason
 import org.apache.mesos.Protos.{TaskState, TaskStatus}
 
@@ -135,10 +136,11 @@ object TaskStatusUpdateTestHelper {
     }
   }
 
-  def killed(instance: Instance = defaultInstance) = {
+  def killed(instance: Instance = defaultInstance, draining: Boolean = false) = {
     // TODO(PODS): the method signature should allow passing a taskId
     val (taskId, _) = instance.tasksMap.head
-    val status = MesosTaskStatusTestHelper.killed(taskId)
+    val maybeReason = if (draining) Some(mesos.Protos.TaskStatus.Reason.REASON_SLAVE_DRAINING) else None
+    val status = MesosTaskStatusTestHelper.killed(taskId, maybeReason)
     taskUpdateFor(instance, Condition.Killed, status)
   }
 
@@ -163,9 +165,10 @@ object TaskStatusUpdateTestHelper {
     taskUpdateFor(instance, Condition.Gone, status)
   }
 
-  def goneByOperator(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {
+  def goneByOperator(instance: Instance = defaultInstance, container: Option[MesosContainer] = None, draining: Boolean = false) = {
     val taskId = Task.Id(instance.instanceId, container)
-    val status = MesosTaskStatusTestHelper.goneByOperator(taskId)
+    val maybeReason = if (draining) Some(mesos.Protos.TaskStatus.Reason.REASON_SLAVE_DRAINING) else None
+    val status = MesosTaskStatusTestHelper.goneByOperator(taskId, maybeReason = maybeReason)
     taskUpdateFor(instance, Condition.Gone, status)
   }
 

--- a/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/bus/TaskStatusUpdateTestHelper.scala
@@ -50,7 +50,7 @@ object TaskStatusUpdateTestHelper {
   lazy val defaultInstance = TestInstanceBuilder.newBuilder(PathId("/app")).addTaskStaged().getInstance()
   lazy val defaultTimestamp = Timestamp(OffsetDateTime.of(2015, 2, 3, 12, 30, 0, 0, ZoneOffset.UTC))
 
-  def provision(instance: Instance, timestamp: Timestamp = defaultTimestamp) = {
+  def provision(instance: Instance = defaultInstance, timestamp: Timestamp = defaultTimestamp) = {
     val dummy = TestInstanceBuilder.newBuilderWithInstanceId(instance.instanceId, timestamp).addTaskProvisioned().getInstance()
     val operation = InstanceUpdateOperation.Provision(instance.instanceId, dummy.agentInfo.get, dummy.runSpec, dummy.tasksMap, timestamp)
     val provisioned = instance.provisioned(dummy.agentInfo.get, dummy.runSpec, dummy.tasksMap, timestamp)
@@ -103,6 +103,12 @@ object TaskStatusUpdateTestHelper {
     val taskId = Task.Id(instance.instanceId)
     val status = MesosTaskStatusTestHelper.staging(taskId)
     taskUpdateFor(instance, Condition.Staging, status)
+  }
+
+  def starting(instance: Instance = defaultInstance) = {
+    val taskId = Task.Id(instance.instanceId)
+    val status = MesosTaskStatusTestHelper.starting(taskId)
+    taskUpdateFor(instance, Condition.Starting, status)
   }
 
   def finished(instance: Instance = defaultInstance, container: Option[MesosContainer] = None) = {

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImplTest.scala
@@ -4,7 +4,6 @@ package core.task.update.impl
 import akka.Done
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.instance.TestInstanceBuilder
-import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.{MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper}
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImplTest.scala
@@ -1,0 +1,61 @@
+package mesosphere.marathon
+package core.task.update.impl.steps
+
+import com.google.inject.Provider
+import mesosphere.UnitTest
+import mesosphere.marathon.core.instance.update.InstanceChange
+import mesosphere.marathon.core.launchqueue.LaunchQueue
+import mesosphere.marathon.core.task.bus.TaskStatusUpdateTestHelper
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class NotifyRateLimiterStepImplTest extends UnitTest with TableDrivenPropertyChecks {
+
+  "NotifyRateLimiterStepImpl" when {
+    val instanceUpdates = Table (
+      ("testCase", "action", "instanceChange"),
+      ("killed(draining)", ResetDelay, TaskStatusUpdateTestHelper.killed(draining = true).wrapped),
+      ("goneByOperator(draining)", ResetDelay, TaskStatusUpdateTestHelper.goneByOperator(draining = true).wrapped),
+      ("dropped", AddDelay, TaskStatusUpdateTestHelper.dropped().wrapped),
+      ("error", AddDelay, TaskStatusUpdateTestHelper.error().wrapped),
+      ("failed", AddDelay, TaskStatusUpdateTestHelper.failed().wrapped),
+      ("gone", AddDelay, TaskStatusUpdateTestHelper.gone().wrapped),
+      ("finished", AddDelay, TaskStatusUpdateTestHelper.finished().wrapped),
+      ("starting", AdvanceDelay, TaskStatusUpdateTestHelper.starting().wrapped),
+      ("running", AdvanceDelay, TaskStatusUpdateTestHelper.running().wrapped),
+      ("unknown", Noop, TaskStatusUpdateTestHelper.unknown().wrapped),
+      ("killed", Noop, TaskStatusUpdateTestHelper.killed().wrapped),
+      ("unreachable", Noop, TaskStatusUpdateTestHelper.unreachable().wrapped)
+    )
+
+    "processing update" when {
+      forAll (instanceUpdates) { (testCase: String, expectedAction: ExpectedAction, instanceChange: InstanceChange) =>
+        s"$testCase should $expectedAction" in {
+          val f = new Fixture
+          f.step.process(instanceChange).futureValue
+          expectedAction match {
+            case ResetDelay => verify(f.launchQueue).resetDelay(instanceChange.instance.runSpec)
+            case AddDelay => verify(f.launchQueue).addDelay(instanceChange.instance.runSpec)
+            case AdvanceDelay => verify(f.launchQueue).advanceDelay(instanceChange.instance.runSpec)
+            case Noop => noMoreInteractions(f.launchQueue)
+          }
+        }
+      }
+    }
+  }
+
+  sealed trait ExpectedAction extends Product with Serializable
+  case object ResetDelay extends ExpectedAction
+  case object AddDelay extends ExpectedAction
+  case object AdvanceDelay extends ExpectedAction
+  case object Noop extends ExpectedAction
+
+  class Fixture {
+    val launchQueue: LaunchQueue = mock[LaunchQueue]
+    private val launchQueueProvider = new Provider[LaunchQueue] {
+      override def get(): LaunchQueue = launchQueue
+    }
+
+    val step = new NotifyRateLimiterStepImpl(launchQueueProvider)
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/update/impl/steps/NotifyRateLimiterStepImplTest.scala
@@ -11,24 +11,24 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 class NotifyRateLimiterStepImplTest extends UnitTest with TableDrivenPropertyChecks {
 
   "NotifyRateLimiterStepImpl" when {
-    val instanceUpdates = Table (
-      ("testCase", "action", "instanceChange"),
-      ("killed(draining)", ResetDelay, TaskStatusUpdateTestHelper.killed(draining = true).wrapped),
-      ("goneByOperator(draining)", ResetDelay, TaskStatusUpdateTestHelper.goneByOperator(draining = true).wrapped),
-      ("dropped", AddDelay, TaskStatusUpdateTestHelper.dropped().wrapped),
-      ("error", AddDelay, TaskStatusUpdateTestHelper.error().wrapped),
-      ("failed", AddDelay, TaskStatusUpdateTestHelper.failed().wrapped),
-      ("gone", AddDelay, TaskStatusUpdateTestHelper.gone().wrapped),
-      ("finished", AddDelay, TaskStatusUpdateTestHelper.finished().wrapped),
-      ("starting", AdvanceDelay, TaskStatusUpdateTestHelper.starting().wrapped),
-      ("running", AdvanceDelay, TaskStatusUpdateTestHelper.running().wrapped),
-      ("unknown", Noop, TaskStatusUpdateTestHelper.unknown().wrapped),
-      ("killed", Noop, TaskStatusUpdateTestHelper.killed().wrapped),
-      ("unreachable", Noop, TaskStatusUpdateTestHelper.unreachable().wrapped)
+    val updateCombinations = Table (
+      ("test case",                 "expected action",  "instanceChange"),
+      ("killed(draining)",          ResetDelay,         TaskStatusUpdateTestHelper.killed(draining = true).wrapped),
+      ("goneByOperator(draining)",  ResetDelay,         TaskStatusUpdateTestHelper.goneByOperator(draining = true).wrapped),
+      ("dropped",                   AddDelay,           TaskStatusUpdateTestHelper.dropped().wrapped),
+      ("error",                     AddDelay,           TaskStatusUpdateTestHelper.error().wrapped),
+      ("failed",                    AddDelay,           TaskStatusUpdateTestHelper.failed().wrapped),
+      ("gone",                      AddDelay,           TaskStatusUpdateTestHelper.gone().wrapped),
+      ("finished",                  AddDelay,           TaskStatusUpdateTestHelper.finished().wrapped),
+      ("starting",                  AdvanceDelay,       TaskStatusUpdateTestHelper.starting().wrapped),
+      ("running",                   AdvanceDelay,       TaskStatusUpdateTestHelper.running().wrapped),
+      ("unknown",                   Noop,               TaskStatusUpdateTestHelper.unknown().wrapped),
+      ("killed",                    Noop,               TaskStatusUpdateTestHelper.killed().wrapped),
+      ("unreachable",               Noop,               TaskStatusUpdateTestHelper.unreachable().wrapped),
     )
 
     "processing update" when {
-      forAll (instanceUpdates) { (testCase: String, expectedAction: ExpectedAction, instanceChange: InstanceChange) =>
+      forAll (updateCombinations) { (testCase: String, expectedAction: ExpectedAction, instanceChange: InstanceChange) =>
         s"$testCase should $expectedAction" in {
           val f = new Fixture
           f.step.process(instanceChange).futureValue


### PR DESCRIPTION
Summary:
When Marathon receives a TASK_GONE_BY_OPERATOR or TASK_KILLED status update with a reason indicating that the agent is being drained, any delay for the related run spec will be deleted. This is to speed up the process of replacing tasks.

Jira issues: MARATHON-8652