### PR TITLE
Fix matching http log lines that don't include protocol

### DIFF
--- a/tools/elk/conf/filter-marathon-1.4.x.conf
+++ b/tools/elk/conf/filter-marathon-1.4.x.conf
@@ -29,7 +29,7 @@ filter {
     remove_tag => ["unclassified"]
   }
   grok {
-    match => {"message" => "^%{IP:httpHost} - (?<user>%{WORD}|-)[^\"]*\"(?<method>GET|PUT|DELETE|POST|HEAD)\s+(http:|https:|)//(?<authority>[^/]+)%{URIPATH:uri}(?:%{URIPARAM:params})?.*?\" %{POSINT:httpStatus:int} %{POSINT:size:int} \"[^\"]+\" \"(?<httpUserAgent>[^\"]+)\"" }
+    match => {"message" => "^%{IP:httpHost} - (?<user>%{WORD}|-)[^\"]*\"(?<method>GET|PUT|DELETE|POST|HEAD)\s+(http://|https://|/+)(?<authority>[^/]+)%{URIPATH:uri}(?:%{URIPARAM:params})?.*?\" %{POSINT:httpStatus:int} %{POSINT:size:int} \"[^\"]+\" \"(?<httpUserAgent>[^\"]+)\"" }
     add_field => {"class" => "http"}
     add_field => {"class2" => "response"}
     tag_on_failure => []


### PR DESCRIPTION
Log output can sometimes say `GET /v2/apps?embed=apps.tasks`, without a protocol and without a double slash. This change updates the regex to also match those log lines.
