### PR TITLE
Only comment with collapsed details

### DIFF
--- a/ci/githubClient.sc
+++ b/ci/githubClient.sc
@@ -73,7 +73,7 @@ def reject(
   buildTag: String): Unit = {
   val msg = s"I'm building your change at [$buildTag]($buildUrl)."
 
-  comment(pullNumber, msg, "REQUEST_CHANGES")
+  comment(pullNumber, msg)
 }
 
 /**

--- a/ci/githubClient.sc
+++ b/ci/githubClient.sc
@@ -106,6 +106,9 @@ def reportSuccess(
   var msg = s"""
     |**\u2714 Build of #$pullNumber completed successfully.**
     |
+    |<details>
+    |<summary>Details</summary>
+    |
     |See details at [$buildTag]($buildUrl).
     |
     |$buildinfoDiff
@@ -116,11 +119,12 @@ def reportSuccess(
     | * [Strict](https://jenkins.mesosphere.com/service/jenkins/view/Marathon/job/system-integration-tests/job/marathon-si-pr/parambuild/?Pull_Request_Id=$pullNumber&Variant=strict&Channel=testing/pull/1296)
     |
     |The job will report back to this PR.
+    |</details>
     |
     |**＼\\ ٩( ᐛ )و /／**
     |""".stripMargin
 
-  comment(pullNumber, msg, event="APPROVE")
+  comment(pullNumber, msg)
 }
 
 /**
@@ -140,13 +144,16 @@ def reportFailure(
   val body = s"""
     |**\u2717 Build of #$pullNumber failed.**
     |
+    |<details>
+    |<summary>Details</summary>
     |See the [logs]($buildUrl/console) and [test results]($buildUrl/testReport) for details.
     |
     |Error message:
     |>$msg
+    |</details>
     |
     |**(๑′°︿°๑)**
     |""".stripMargin
 
-  comment(pullNumber, body, event="REQUEST_CHANGES")
+  comment(pullNumber, body)
 }


### PR DESCRIPTION
Summary:
The Marathon CI bot would approve or reject pull requests and spam the
comments section. This change remove the bot as an approve and thus
enforce the two-approval rule. It also changes a big portion of the
comments to a details field and slims down the noise.