### PR TITLE
Sanitize accepted resource roles.

### DIFF
--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -60,7 +60,13 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 7, 0),
     hardRemoveVersion = SemVer(1, 8, 0))
 
-  def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC)
+  val sanitizeAcceptedResourceRoles = DeprecatedFeature(
+    "sanitize_accepted_resource_roles",
+    description = "Enables sanitization of accepted resource roles in app and pod definitions.",
+    softRemoveVersion = SemVer(1, 10, 0),
+    hardRemoveVersion = SemVer(1, 11, 0))
+
+  def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC, sanitizeAcceptedResourceRoles)
 
   def description: String = {
     "  - " + all.map { df =>

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeaturesSet.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeaturesSet.scala
@@ -52,3 +52,7 @@ case class DeprecatedFeatureSet(
     hardRemovedFeatures.isEmpty
   }
 }
+
+object DeprecatedFeatureSet {
+  def empty(currentVersion: SemVer): DeprecatedFeatureSet = DeprecatedFeatureSet(currentVersion, Set.empty)
+}

--- a/src/main/scala/mesosphere/marathon/FeaturesConf.scala
+++ b/src/main/scala/mesosphere/marathon/FeaturesConf.scala
@@ -43,8 +43,6 @@ trait FeaturesConf extends ScallopConf {
   def availableDeprecatedFeatures: DeprecatedFeatureSet = deprecatedFeatures()
 
   def isFeatureSet(name: String): Boolean = availableFeatures.contains(name)
-  def isDeprecatedFeatureEnabled(deprecatedFeature: DeprecatedFeature): Boolean =
-    availableDeprecatedFeatures.enabledDeprecatedFeatures.contains(deprecatedFeature)
 
   private[this] def validateFeatures(features: Set[String]): Boolean = {
     // throw exceptions for better error messages

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -314,7 +314,7 @@ object AppNormalization {
 
     // sanitize accepted resource roles if enabled
     val acceptedResourceRoles =
-      if (config.availableDeprecatedFeatures.isEnabled(DeprecatedFeatures.sanitizeAcceptedResourceRoles)) {
+      if (config.sanitizeAcceptedResourceRoles) {
         sanitizeAcceptedResourceRoles(app, role)
       } else app.acceptedResourceRoles
 
@@ -333,7 +333,7 @@ object AppNormalization {
     def mesosBridgeName: String
     def enabledFeatures: Set[String]
     def roleSettings: RoleSettings
-    def availableDeprecatedFeatures: DeprecatedFeatureSet
+    def sanitizeAcceptedResourceRoles: Boolean
   }
 
   /** static app normalization configuration */
@@ -342,7 +342,7 @@ object AppNormalization {
       override val mesosBridgeName: String,
       enabledFeatures: Set[String],
       roleSettings: RoleSettings,
-      availableDeprecatedFeatures: DeprecatedFeatureSet
+      sanitizeAcceptedResourceRoles: Boolean
   ) extends Config {
 
   }
@@ -354,7 +354,7 @@ object AppNormalization {
         config.mesosBridgeName(),
         config.availableFeatures,
         roleSettings,
-        config.availableDeprecatedFeatures
+        config.availableDeprecatedFeatures.isEnabled(DeprecatedFeatures.sanitizeAcceptedResourceRoles)
       )
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/PodNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodNormalization.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package api.v2
 
-import mesosphere.marathon.raml.{AnyToRaml, Endpoint, Network, NetworkMode, Pod, PodContainer, PodPersistentVolume, PodSchedulingPolicy, PodUpgradeStrategy}
+import mesosphere.marathon.raml.{AnyToRaml, Endpoint, Network, NetworkMode, Pod, PodContainer, PodPersistentVolume, PodPlacementPolicy, PodSchedulingPolicy, PodUpgradeStrategy}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.util.RoleSettings
 
@@ -16,13 +16,17 @@ object PodNormalization {
   /** dynamic pod normalization configuration, useful for migration and/or testing */
   trait Config extends NetworkNormalization.Config {
     def roleSettings: RoleSettings
+    def availableDeprecatedFeatures: DeprecatedFeatureSet
   }
 
-  case class Configuration(defaultNetworkName: Option[String], roleSettings: RoleSettings) extends Config
+  case class Configuration(
+      defaultNetworkName: Option[String],
+      roleSettings: RoleSettings,
+      availableDeprecatedFeatures: DeprecatedFeatureSet) extends Config
 
   object Configuration {
     def apply(config: MarathonConf, roleSettings: RoleSettings): Config =
-      Configuration(config.defaultNetworkName.toOption, roleSettings)
+      Configuration(config.defaultNetworkName.toOption, roleSettings, config.availableDeprecatedFeatures)
   }
 
   case class Containers(networks: Seq[Network], containers: Seq[PodContainer])
@@ -45,6 +49,33 @@ object PodNormalization {
   }
 
   /**
+    * Removes all roles that are not the service role or "*" from the placement policy.
+    *
+    * @param maybePlacement The placement policy containing the accepted resource roles.
+    * @param effectiveRole The final Mesos role of the pod.
+    * @return the placement policy with update accepted resource roles.
+    */
+  def sanitizeAcceptedResourceRoles(maybePlacement: Option[PodPlacementPolicy], effectiveRole: String): Option[PodPlacementPolicy] = {
+    maybePlacement.map { placement =>
+      val sanitizedAcceptedResourceRoles = placement.acceptedResourceRoles.filter(role => role == "*" || role == effectiveRole)
+      placement.copy(acceptedResourceRoles = sanitizedAcceptedResourceRoles)
+    }
+  }
+
+  def normalizeUpgradeAndUnreachableStrategy(pod: Pod): PodSchedulingPolicy = {
+    val defaultUpgradeStrategy = state.UpgradeStrategy.forResidentTasks.toRaml
+    val defaultUnreachableStrategy = state.UnreachableStrategy.default(true).toRaml
+    val scheduling = pod.scheduling.getOrElse(PodSchedulingPolicy())
+    val upgradeStrategy = scheduling.upgrade.getOrElse(PodUpgradeStrategy(
+      minimumHealthCapacity = defaultUpgradeStrategy.minimumHealthCapacity,
+      maximumOverCapacity = defaultUpgradeStrategy.maximumOverCapacity))
+    val unreachableStrategy = scheduling.unreachableStrategy.getOrElse(defaultUnreachableStrategy)
+    scheduling.copy(
+      upgrade = Some(upgradeStrategy),
+      unreachableStrategy = Some(unreachableStrategy))
+  }
+
+  /**
     * If a pod has one or more persistent volumes, this method ensure that
     * the pod's upgrade and unreachable strategies have values which make
     * sense for resident pods: the unreachable strategy should be disabled
@@ -52,31 +83,31 @@ object PodNormalization {
     * for such pods.
     *
     * @param pod a pod which scheduling policy should be normalized
+    * @param effectiveRole the final Mesos role of the pod
+    * @param config the normalization configuration
     * @return a normalized scheduling policy
     */
-  def normalizeScheduling(pod: Pod): Option[PodSchedulingPolicy] = {
+  def normalizeScheduling(pod: Pod, effectiveRole: String, config: Config): Option[PodSchedulingPolicy] = {
     val hasPersistentVolumes = pod.volumes.existsAn[PodPersistentVolume]
-    if (hasPersistentVolumes) {
-      val defaultUpgradeStrategy = state.UpgradeStrategy.forResidentTasks.toRaml
-      val defaultUnreachableStrategy = state.UnreachableStrategy.default(hasPersistentVolumes).toRaml
-      val scheduling = pod.scheduling.getOrElse(PodSchedulingPolicy())
-      val upgradeStrategy = scheduling.upgrade.getOrElse(PodUpgradeStrategy(
-        minimumHealthCapacity = defaultUpgradeStrategy.minimumHealthCapacity,
-        maximumOverCapacity = defaultUpgradeStrategy.maximumOverCapacity))
-      val unreachableStrategy = scheduling.unreachableStrategy.getOrElse(defaultUnreachableStrategy)
-      Some(scheduling.copy(
-        upgrade = Some(upgradeStrategy),
-        unreachableStrategy = Some(unreachableStrategy)))
+    val normalized = if (hasPersistentVolumes) {
+      Some(normalizeUpgradeAndUnreachableStrategy(pod))
     } else pod.scheduling
+
+    // sanitize accepted resource roles if enabled
+    if (config.availableDeprecatedFeatures.isEnabled(DeprecatedFeatures.sanitizeAcceptedResourceRoles)) {
+      normalized.map { scheduling =>
+        scheduling.copy(placement = sanitizeAcceptedResourceRoles(scheduling.placement, effectiveRole))
+      }
+    } else normalized
   }
 
   def apply(config: Config): Normalization[Pod] = Normalization { pod =>
     val networks = Networks(config, Some(pod.networks)).normalize.networks.filter(_.nonEmpty).getOrElse(DefaultNetworks)
     NetworkNormalization.requireContainerNetworkNameResolution(networks)
     val containers = Containers(networks, pod.containers).normalize.containers
-    val scheduling = normalizeScheduling(pod)
-
     val role = pod.role.getOrElse(config.roleSettings.defaultRole)
+
+    val scheduling = normalizeScheduling(pod, role, config)
 
     pod.copy(containers = containers, networks = networks, scheduling = scheduling, role = Some(role))
   }

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -34,7 +34,7 @@ object RoleSettings extends StrictLogging {
       RoleSettings(validRoles = Set(defaultRole), defaultRole = defaultRole)
     } else {
       val topLevelGroupPath = servicePathId.rootPath
-      val groupRole = topLevelGroupPath.root
+      val topLevelGroupRole = topLevelGroupPath.root
       val topLevelGroup = rootGroup.group(topLevelGroupPath)
 
       val defaultForEnforceFromConfig: Boolean = false // TODO: Use value from config instead
@@ -53,12 +53,12 @@ object RoleSettings extends StrictLogging {
 
       if (enforceRole) {
         // With enforceRole, we only allow the service to use the group-role or an existing role
-        RoleSettings(validRoles = Set(groupRole) ++ maybeExistingRole, defaultRole = groupRole)
+        RoleSettings(validRoles = Set(topLevelGroupRole) ++ maybeExistingRole, defaultRole = topLevelGroupRole)
       } else {
         // Without enforce role, we allow default role, group role and already existing role
         // The default role depends on the config parameter
-        val defaultRoleToUse = if (defaultForEnforceFromConfig) groupRole else defaultRole
-        RoleSettings(validRoles = Set(defaultRole, groupRole) ++ maybeExistingRole, defaultRole = defaultRoleToUse)
+        val defaultRoleToUse = if (defaultForEnforceFromConfig) topLevelGroupRole else defaultRole
+        RoleSettings(validRoles = Set(defaultRole, topLevelGroupRole) ++ maybeExistingRole, defaultRole = defaultRoleToUse)
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -60,7 +60,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       config.mesosBridgeName(),
       config.availableFeatures,
       ValidationHelper.roleSettings,
-      config.availableDeprecatedFeatures)
+      config.availableDeprecatedFeatures.isEnabled(DeprecatedFeatures.sanitizeAcceptedResourceRoles))
     implicit lazy val appDefinitionValidator = AppDefinition.validAppDefinition(config.availableFeatures, normalizationConfig.roleSettings)(PluginManager.None)
 
     implicit val validateAndNormalizeApp: Normalization[raml.App] =

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -55,7 +55,12 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
     implicit val authenticator: Authenticator = auth.auth
     implicit val authorizer: Authorizer = auth.auth
 
-    val normalizationConfig = AppNormalization.Configuration(config.defaultNetworkName.toOption, config.mesosBridgeName(), config.availableFeatures, ValidationHelper.roleSettings)
+    val normalizationConfig = AppNormalization.Configuration(
+      config.defaultNetworkName.toOption,
+      config.mesosBridgeName(),
+      config.availableFeatures,
+      ValidationHelper.roleSettings,
+      config.availableDeprecatedFeatures)
     implicit lazy val appDefinitionValidator = AppDefinition.validAppDefinition(config.availableFeatures, normalizationConfig.roleSettings)(PluginManager.None)
 
     implicit val validateAndNormalizeApp: Normalization[raml.App] =

--- a/src/test/scala/mesosphere/marathon/api/v2/PodNormalizationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodNormalizationTest.scala
@@ -65,7 +65,7 @@ class PodNormalizationTest extends UnitTest with Inside {
             net.name.value shouldBe "net1"
         }
       }
-      "with default network name" in new Fixture(PodNormalization.Configuration(defaultNetworkName = Some("default1"), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))) {
+      "with default network name" in new Fixture(PodNormalization.Configuration(defaultNetworkName = Some("default1"), ValidationHelper.roleSettings, true)) {
         // replace empty network name with the default
         val withoutNetworkName = template.copy(networks = Seq(Network()))
         inside(withoutNetworkName.normalize.networks) {
@@ -122,7 +122,7 @@ class PodNormalizationTest extends UnitTest with Inside {
         }
       }
 
-      "return the configured role for pods without a role" in new Fixture(config = PodNormalization.Configuration(None, RoleSettings(validRoles = Set("customDefault"), defaultRole = "customDefault"), DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))) {
+      "return the configured role for pods without a role" in new Fixture(config = PodNormalization.Configuration(None, RoleSettings(validRoles = Set("customDefault"), defaultRole = "customDefault"), true)) {
         inside(template.normalize.role) {
           case Some(role) =>
             role shouldBe "customDefault"
@@ -144,8 +144,8 @@ class PodNormalizationTest extends UnitTest with Inside {
         containers = Seq(PodContainer(name = "c", resources = Resources())),
         scheduling = Some(PodSchedulingPolicy(placement = Some(PodPlacementPolicy(acceptedResourceRoles = Seq("*", "other")))))
       )
-      val sanitizationEnabled = PodNormalization.Configuration(None, ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
-      val sanitizationDisabled = PodNormalization.Configuration(None, ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 10, 0)))
+      val sanitizationEnabled = PodNormalization.Configuration(None, ValidationHelper.roleSettings, true)
+      val sanitizationDisabled = PodNormalization.Configuration(None, ValidationHelper.roleSettings, false)
 
       s"remove the role if ${DeprecatedFeatures.sanitizeAcceptedResourceRoles} is enabled" in new Fixture(config = sanitizationEnabled) {
         template.normalize.scheduling.value.placement.value.acceptedResourceRoles should contain theSameElementsAs (Set("*"))
@@ -158,7 +158,7 @@ class PodNormalizationTest extends UnitTest with Inside {
 
   }
 
-  abstract class Fixture(config: PodNormalization.Config = PodNormalization.Configuration(None, ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))) {
+  abstract class Fixture(config: PodNormalization.Config = PodNormalization.Configuration(None, ValidationHelper.roleSettings, true)) {
     protected implicit val normalization: Normalization[Pod] = PodNormalization(config)
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -41,8 +41,8 @@ class AppDefinitionFormatsTest extends UnitTest
     """)
   }
 
-  def normalizeAndConvert(app: raml.App, deprecatedFeatureSet: DeprecatedFeatureSet = DeprecatedFeatureSet.empty(SemVer(1, 9, 0))): AppDefinition = {
-    val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, deprecatedFeatureSet)
+  def normalizeAndConvert(app: raml.App, sanitizeAcceptedResourceRoles: Boolean = true): AppDefinition = {
+    val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, sanitizeAcceptedResourceRoles)
     Raml.fromRaml(
       // this is roughly the equivalent of how the original Formats behaved, which is notable because Formats
       // (like this code) reverses the order of validation and normalization
@@ -201,7 +201,7 @@ class AppDefinitionFormatsTest extends UnitTest
 
     """FromJSON should parse "acceptedResourceRoles": ["production", "*"] """ in {
       val json = Json.parse(""" { "id": "test", "cmd": "foo", "acceptedResourceRoles": ["production", "*"] }""")
-      val appDef = normalizeAndConvert(json.as[raml.App], DeprecatedFeatureSet.empty(SemVer(1, 10, 0)))
+      val appDef = normalizeAndConvert(json.as[raml.App], false)
       appDef.acceptedResourceRoles should equal(Set("production", ResourceRole.Unreserved))
     }
 
@@ -575,7 +575,7 @@ class AppDefinitionFormatsTest extends UnitTest
     }
 
     "FromJSON should fail for empty container (#4978)" in {
-      val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+      val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, true)
       val json = Json.parse(
         """{
           |  "id": "/docker-compose-demo",

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -41,8 +41,8 @@ class AppDefinitionFormatsTest extends UnitTest
     """)
   }
 
-  def normalizeAndConvert(app: raml.App): AppDefinition = {
-    val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings)
+  def normalizeAndConvert(app: raml.App, deprecatedFeatureSet: DeprecatedFeatureSet = DeprecatedFeatureSet.empty(SemVer(1, 9, 0))): AppDefinition = {
+    val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, deprecatedFeatureSet)
     Raml.fromRaml(
       // this is roughly the equivalent of how the original Formats behaved, which is notable because Formats
       // (like this code) reverses the order of validation and normalization
@@ -201,7 +201,7 @@ class AppDefinitionFormatsTest extends UnitTest
 
     """FromJSON should parse "acceptedResourceRoles": ["production", "*"] """ in {
       val json = Json.parse(""" { "id": "test", "cmd": "foo", "acceptedResourceRoles": ["production", "*"] }""")
-      val appDef = normalizeAndConvert(json.as[raml.App])
+      val appDef = normalizeAndConvert(json.as[raml.App], DeprecatedFeatureSet.empty(SemVer(1, 10, 0)))
       appDef.acceptedResourceRoles should equal(Set("production", ResourceRole.Unreserved))
     }
 
@@ -575,7 +575,7 @@ class AppDefinitionFormatsTest extends UnitTest
     }
 
     "FromJSON should fail for empty container (#4978)" in {
-      val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings)
+      val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
       val json = Json.parse(
         """{
           |  "id": "/docker-compose-demo",

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -21,7 +21,6 @@ import scala.concurrent.duration._
 
 class AppDefinitionTest extends UnitTest with ValidationTestLike {
   val enabledFeatures = Set("secrets")
-  val deprecatedFeatures = DeprecatedFeatureSet.empty(SemVer(1, 9, 0))
   val enforcedrole = "*"
 
   val validator = AppDefinition.validAppDefinition(enabledFeatures, ValidationHelper.roleSettings)(PluginManager.None)
@@ -29,7 +28,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
   val validatorWithRole = AppDefinition.validAppDefinition(enabledFeatures, RoleSettings(validRoles = Set("someRole"), defaultRole = "someRole"))(PluginManager.None)
 
   private[this] def appNormalization(app: raml.App): raml.App =
-    AppHelpers.appNormalization(AppNormalization.Configuration(None, "mesos-bridge-name", enabledFeatures, ValidationHelper.roleSettings, deprecatedFeatures)).normalized(app)
+    AppHelpers.appNormalization(AppNormalization.Configuration(None, "mesos-bridge-name", enabledFeatures, ValidationHelper.roleSettings, true)).normalized(app)
 
   private[this] def fromJson(json: String): AppDefinition = {
     val raw: raml.App = Json.parse(json).as[raml.App]

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration._
 
 class AppDefinitionTest extends UnitTest with ValidationTestLike {
   val enabledFeatures = Set("secrets")
+  val deprecatedFeatures = DeprecatedFeatureSet.empty(SemVer(1, 9, 0))
   val enforcedrole = "*"
 
   val validator = AppDefinition.validAppDefinition(enabledFeatures, ValidationHelper.roleSettings)(PluginManager.None)
@@ -28,7 +29,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
   val validatorWithRole = AppDefinition.validAppDefinition(enabledFeatures, RoleSettings(validRoles = Set("someRole"), defaultRole = "someRole"))(PluginManager.None)
 
   private[this] def appNormalization(app: raml.App): raml.App =
-    AppHelpers.appNormalization(AppNormalization.Configuration(None, "mesos-bridge-name", enabledFeatures, ValidationHelper.roleSettings)).normalized(app)
+    AppHelpers.appNormalization(AppNormalization.Configuration(None, "mesos-bridge-name", enabledFeatures, ValidationHelper.roleSettings, deprecatedFeatures)).normalized(app)
 
   private[this] def fromJson(json: String): AppDefinition = {
     val raw: raml.App = Json.parse(json).as[raml.App]

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
@@ -11,7 +11,7 @@ class AppUpdateFormatTest extends UnitTest {
 
   def normalizedAndValidated(appUpdate: AppUpdate): AppUpdate =
     AppHelpers.appUpdateNormalization(
-      AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))).normalized(appUpdate)
+      AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, true)).normalized(appUpdate)
 
   def fromJson(json: String): AppUpdate =
     normalizedAndValidated(Json.parse(json).as[AppUpdate])

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateFormatTest.scala
@@ -11,7 +11,7 @@ class AppUpdateFormatTest extends UnitTest {
 
   def normalizedAndValidated(appUpdate: AppUpdate): AppUpdate =
     AppHelpers.appUpdateNormalization(
-      AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings)).normalized(appUpdate)
+      AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))).normalized(appUpdate)
 
   def fromJson(json: String): AppUpdate =
     normalizedAndValidated(Json.parse(json).as[AppUpdate])

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -25,7 +25,7 @@ class AppUpdateTest extends UnitTest with ValidationTestLike {
     */
   private[this] def fromJsonString(json: String): AppUpdate = {
     val update: AppUpdate = Json.fromJson[AppUpdate](Json.parse(json)).get
-    AppNormalization.forDeprecatedUpdates(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings))
+    AppNormalization.forDeprecatedUpdates(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0))))
       .normalized(update)
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppUpdateTest.scala
@@ -25,7 +25,7 @@ class AppUpdateTest extends UnitTest with ValidationTestLike {
     */
   private[this] def fromJsonString(json: String): AppUpdate = {
     val update: AppUpdate = Json.fromJson[AppUpdate](Json.parse(json)).get
-    AppNormalization.forDeprecatedUpdates(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0))))
+    AppNormalization.forDeprecatedUpdates(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, true))
       .normalized(update)
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
@@ -13,7 +13,7 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
   val noEnabledFeatures = AllConf.withTestConfig()
   val appConversionFunc: (App => AppDefinition) = { app =>
     // assume canonical form and that the app is valid
-    Raml.fromRaml(AppNormalization.apply(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))).normalized(app))
+    Raml.fromRaml(AppNormalization.apply(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, true)).normalized(app))
   }
   implicit val groupUpdateRamlReader = raml.GroupConversion.groupUpdateRamlReads // HACK: workaround bogus compiler error?!
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
@@ -13,7 +13,7 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
   val noEnabledFeatures = AllConf.withTestConfig()
   val appConversionFunc: (App => AppDefinition) = { app =>
     // assume canonical form and that the app is valid
-    Raml.fromRaml(AppNormalization.apply(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings)).normalized(app))
+    Raml.fromRaml(AppNormalization.apply(AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))).normalized(app))
   }
   implicit val groupUpdateRamlReader = raml.GroupConversion.groupUpdateRamlReads // HACK: workaround bogus compiler error?!
 

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -9,9 +9,9 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 
 class AppValidationTest extends UnitTest with ValidationTestLike with TableDrivenPropertyChecks {
 
-  val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+  val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, true)
   val configWithDefaultNetworkName =
-    AppNormalization.Configuration(Some("defaultNetworkName"), "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+    AppNormalization.Configuration(Some("defaultNetworkName"), "mesos-bridge-name", Set(), ValidationHelper.roleSettings, true)
   val basicValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName)
   val withSecretsValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set("secrets"), () => config.defaultNetworkName)
   val withDefaultNetworkNameValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => configWithDefaultNetworkName.defaultNetworkName)

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -9,8 +9,9 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 
 class AppValidationTest extends UnitTest with ValidationTestLike with TableDrivenPropertyChecks {
 
-  val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings)
-  val configWithDefaultNetworkName = AppNormalization.Configuration(Some("defaultNetworkName"), "mesos-bridge-name", Set(), ValidationHelper.roleSettings)
+  val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+  val configWithDefaultNetworkName =
+    AppNormalization.Configuration(Some("defaultNetworkName"), "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
   val basicValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName)
   val withSecretsValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set("secrets"), () => config.defaultNetworkName)
   val withDefaultNetworkNameValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => configWithDefaultNetworkName.defaultNetworkName)

--- a/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
@@ -52,8 +52,7 @@ class AppUpdateValidatorTest extends UnitTest with Matchers {
           |}
         """.stripMargin).as[App]
 
-      val config =
-        AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+      val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, false)
       val appDef = Raml.fromRaml(
         AppNormalization.apply(config)
           .normalized(AppNormalization.forDeprecated(config).normalized(originalApp)))

--- a/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppUpdateValidatorTest.scala
@@ -52,7 +52,8 @@ class AppUpdateValidatorTest extends UnitTest with Matchers {
           |}
         """.stripMargin).as[App]
 
-      val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings)
+      val config =
+        AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
       val appDef = Raml.fromRaml(
         AppNormalization.apply(config)
           .normalized(AppNormalization.forDeprecated(config).normalized(originalApp)))

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -18,7 +18,8 @@ import scala.reflect.ClassTag
 
 class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
 
-  val config = AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings)
+  val config =
+    AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
   private implicit lazy val validApp = AppValidation.validateCanonicalAppAPI(Set(), () => config.defaultNetworkName)
   private implicit lazy val validAppDefinition = AppDefinition.validAppDefinition(Set(), config.roleSettings)(PluginManager.None)
   private def validContainer(networks: Seq[Network] = Nil) = Container.validContainer(networks, Set())
@@ -591,7 +592,8 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
 
       val f = new Fixture
       val app = Json.parse(f.cassandraWithoutResidency).as[App]
-      val config = AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings)
+      val config =
+        AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
       val result = validAppDefinition(Raml.fromRaml(
         AppNormalization(config).normalized(
           validateOrThrow(
@@ -604,7 +606,8 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
       val f = new Fixture
       val base = Json.parse(f.cassandraWithoutResidency).as[App]
       val app = base.copy(upgradeStrategy = Some(raml.UpgradeStrategy(0, 0)))
-      val config = AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings)
+      val config =
+        AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
       val result = validAppDefinition(Raml.fromRaml(
         AppNormalization(config).normalized(
           validateOrThrow(

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -19,7 +19,7 @@ import scala.reflect.ClassTag
 class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
 
   val config =
-    AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+    AppNormalization.Configuration(None, "mesos-bridge-name", Set(), ValidationHelper.roleSettings, true)
   private implicit lazy val validApp = AppValidation.validateCanonicalAppAPI(Set(), () => config.defaultNetworkName)
   private implicit lazy val validAppDefinition = AppDefinition.validAppDefinition(Set(), config.roleSettings)(PluginManager.None)
   private def validContainer(networks: Seq[Network] = Nil) = Container.validContainer(networks, Set())
@@ -593,7 +593,7 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
       val f = new Fixture
       val app = Json.parse(f.cassandraWithoutResidency).as[App]
       val config =
-        AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+        AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, true)
       val result = validAppDefinition(Raml.fromRaml(
         AppNormalization(config).normalized(
           validateOrThrow(
@@ -607,7 +607,7 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
       val base = Json.parse(f.cassandraWithoutResidency).as[App]
       val app = base.copy(upgradeStrategy = Some(raml.UpgradeStrategy(0, 0)))
       val config =
-        AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+        AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, true)
       val result = validAppDefinition(Raml.fromRaml(
         AppNormalization(config).normalized(
           validateOrThrow(

--- a/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
@@ -91,7 +91,7 @@ class AppConversionTest extends UnitTest with ValidationTestLike {
       val readApp: AppDefinition = withValidationClue {
         Raml.fromRaml(
           AppHelpers.appNormalization(
-            AppNormalization.Configuration(None, "bridge-name", features, ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))).normalized(ramlApp)
+            AppNormalization.Configuration(None, "bridge-name", features, ValidationHelper.roleSettings, true)).normalized(ramlApp)
         )
       }
       Then("The app is identical")
@@ -108,7 +108,7 @@ class AppConversionTest extends UnitTest with ValidationTestLike {
       val protoRamlApp = app.toProto.toRaml[App]
 
       Then("The direct and indirect RAML conversions are identical")
-      val config = AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
+      val config = AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, true)
       val normalizedProtoRamlApp = AppNormalization(
         config).normalized(AppNormalization.forDeprecated(config).normalized(protoRamlApp))
       normalizedProtoRamlApp should be(ramlApp)

--- a/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
@@ -91,7 +91,7 @@ class AppConversionTest extends UnitTest with ValidationTestLike {
       val readApp: AppDefinition = withValidationClue {
         Raml.fromRaml(
           AppHelpers.appNormalization(
-            AppNormalization.Configuration(None, "bridge-name", features, ValidationHelper.roleSettings)).normalized(ramlApp)
+            AppNormalization.Configuration(None, "bridge-name", features, ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))).normalized(ramlApp)
         )
       }
       Then("The app is identical")
@@ -108,7 +108,7 @@ class AppConversionTest extends UnitTest with ValidationTestLike {
       val protoRamlApp = app.toProto.toRaml[App]
 
       Then("The direct and indirect RAML conversions are identical")
-      val config = AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings)
+      val config = AppNormalization.Configuration(None, "bridge-name", Set(), ValidationHelper.roleSettings, DeprecatedFeatureSet.empty(SemVer(1, 9, 0)))
       val normalizedProtoRamlApp = AppNormalization(
         config).normalized(AppNormalization.forDeprecated(config).normalized(protoRamlApp))
       normalizedProtoRamlApp should be(ramlApp)


### PR DESCRIPTION
Summary:
This introduces a feature flag to sanitize the accepted resource roles
field on apps and pods. The feature will be off by default with 1.10 and
removed with 1.11. It should ease the migration to multi-role
deployments without running into validation errors.

JIRA issues: MARATHON-8653