### PR TITLE
Set the min_revive_offers_interval default back to five seconds

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
@@ -19,7 +19,7 @@ trait ReviveOffersConfig extends ScallopConf {
   lazy val minReviveOffersInterval = opt[Long](
     "min_revive_offers_interval",
     descr = "Do not ask for all offers (also already seen ones) more often than this interval (ms).",
-    default = Some(30000))
+    default = Some(5000))
 
   /**
     * Deprecated. Has no effect


### PR DESCRIPTION
Recently, this value was modified from 5 seconds to 30 seconds. It
turns out that this caused some system tests to timeout. 5 seconds is
a better default.
