### PR TITLE
Name apps for easier system test debugging.

### DIFF
--- a/tests/shakedown/shakedown/dcos/helpers.py
+++ b/tests/shakedown/shakedown/dcos/helpers.py
@@ -26,6 +26,9 @@ def get_transport(host, username, key):
     if host == master_ip():
         transport = paramiko.Transport(host)
     else:
+
+        logger.debug('Connecting to %s@%s with key %s', username, master_ip(), key)
+
         transport_master = paramiko.Transport(master_ip())
         transport_master = start_transport(transport_master, username, key)
 
@@ -98,6 +101,7 @@ def validate_key(key_path):
     key_path = os.path.expanduser(key_path)
 
     if not os.path.isfile(key_path):
+        logger.warning('Provided key %s is not a file.', key_path)
         return False
 
     return paramiko.RSAKey.from_private_key_file(key_path)

--- a/tests/system/dcos_service_marathon_tests.py
+++ b/tests/system/dcos_service_marathon_tests.py
@@ -13,7 +13,7 @@ from shakedown.clients import marathon
 from shakedown.dcos.marathon import deployment_wait
 
 
-@retrying.retry(wait_fixed=1000, stop_max_attempt_number=16, retry_on_exception=common.ignore_exception)
+@retrying.retry(wait_fixed=1000, stop_max_attempt_number=16)
 def assert_deployment_not_ready(deployment_id):
     client = marathon.create_client()
     deployment = client.get_deployment(deployment_id)
@@ -38,7 +38,7 @@ def test_deploy_custom_framework():
 def test_framework_readiness_time_check():
     """Tests that an app is being in deployment until the readiness check is done."""
 
-    fw = apps.fake_framework()
+    fw = apps.fake_framework(app_id='framework-readiness-time')
     readiness_time = 15
     fw['readinessChecks'][0]['intervalSeconds'] = readiness_time
 

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -233,7 +233,7 @@ def test_ui_available(marathon_service_name):
 def test_task_failure_recovers():
     """Tests that if a task is KILLED, another one will be launched with a different ID."""
 
-    app_def = apps.sleep_app()
+    app_def = apps.sleep_app(app_id='/task-failure-recovers')
     app_def['cmd'] = 'sleep 1000'
     app_id = app_def["id"]
 
@@ -255,7 +255,7 @@ def test_task_failure_recovers():
 def test_run_app_with_specified_user():
     """Runs an app with a given user (cnetos). CentOS is expected, since it has centos user by default."""
 
-    app_def = apps.sleep_app()
+    app_def = apps.sleep_app(app_id='/app-with-specified-user')
     app_def['user'] = 'centos'
     app_id = app_def['id']
 
@@ -275,7 +275,7 @@ def test_run_app_with_specified_user():
 def test_run_app_with_non_existing_user():
     """Runs an app with a non-existing user, which should be failing."""
 
-    app_def = apps.sleep_app(app_id='non-existing-user')
+    app_def = apps.sleep_app(app_id='/non-existing-user')
     app_def['user'] = 'bad'
 
     client = marathon.create_client()
@@ -288,7 +288,7 @@ def test_run_app_with_non_existing_user():
 def test_run_app_with_non_downloadable_artifact():
     """Runs an app with a non-downloadable artifact."""
 
-    app_def = apps.sleep_app()
+    app_def = apps.sleep_app(app_id='/non-downloadable-artifact')
     app_def['fetch'] = [{"uri": "http://localhost/missing-artifact"}]
 
     client = marathon.create_client()

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -275,7 +275,7 @@ def test_run_app_with_specified_user():
 def test_run_app_with_non_existing_user():
     """Runs an app with a non-existing user, which should be failing."""
 
-    app_def = apps.sleep_app()
+    app_def = apps.sleep_app(app_id='non-existing-user')
     app_def['user'] = 'bad'
 
     client = marathon.create_client()


### PR DESCRIPTION
Summary:
This should make it a little simpler to track failed apps or pods in the Marathon logs.