### PR TITLE
Test ReviveRepeaterLogic.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
@@ -102,19 +102,19 @@ class ReviveOffersActor(
   val reviveSuppressMetrics: Sink[RoleDirective, Future[Done]] = Sink.foreach {
     case UpdateFramework(newState, newlyRevived, newlySuppressed) =>
       newlyRevived.foreach { role =>
-        logger.info(s"Role ${role} newly revived via update framework call")
+        logger.info(s"Role '${role}' newly revived via update framework call")
         reviveCountMetric.increment()
       }
 
       newlySuppressed.foreach { role =>
-        logger.info(s"Role ${role} newly suppressed via update framework call")
+        logger.info(s"Role '${role}' newly suppressed via update framework call")
         suppressCountMetric.increment()
       }
 
     case IssueRevive(roles) =>
       roles.foreach { role =>
         reviveCountMetric.increment()
-        logger.info(s"Role ${role} explicitly revived")
+        logger.info(s"Role '${role}' explicitly revived")
       }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
@@ -98,7 +98,7 @@ class ReviveOffersActor(
     done.pipeTo(self)
   }
 
-  val reviveSuppressMetrics: Flow[RoleDirective, RoleDirective, NotUsed] = Flow[RoleDirective] {
+  val reviveSuppressMetrics: Flow[RoleDirective, RoleDirective, NotUsed] = Flow[RoleDirective].map {
     case directive @ UpdateFramework(newState, newlyRevived, newlySuppressed) =>
       newlyRevived.foreach { role =>
         logger.info(s"Role '${role}' newly revived via update framework call")

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
@@ -220,9 +220,12 @@ object ReviveOffersStreamLogic extends StrictLogging {
     }
 
     def handleTick(): List[RoleDirective] = {
+      // Decrease tick counts and filter out those that are zero.
       val newRepeatIn = repeatIn.collect {
         case (k, v) if v >= 1 => k -> (v - 1)
       }
+
+      // Repeat revives for those roles that waited for a tick.
       val rolesForReviveRepetition = newRepeatIn.iterator.collect {
         case (role, counter) if counter == 0 && currentRoleState.get(role).contains(OffersWanted) => role
       }.toSet

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
@@ -199,7 +199,7 @@ object ReviveOffersStreamLogic extends StrictLogging {
     * specifically, it will indicate that offers should be revived for a role on the 2nd tick received after the initial
     * unsuppress or revive directive was received, unless if offers for the role are suppressed.
     */
-  private[impl] class ReviveRepeaterLogic {
+  private[impl] class ReviveRepeaterLogic extends StrictLogging {
     var currentRoleState: Map[Role, RoleOfferState] = Map.empty
     var repeatIn: Map[Role, Int] = Map.empty
 
@@ -219,6 +219,7 @@ object ReviveOffersStreamLogic extends StrictLogging {
     }
 
     def handleTick(): List[RoleDirective] = {
+      println(repeatIn)
       val newRepeatIn = repeatIn.collect {
         case (k, v) if v > 1 => k -> (v - 1)
       }
@@ -231,6 +232,7 @@ object ReviveOffersStreamLogic extends StrictLogging {
       if (rolesForReviveRepetition.isEmpty) {
         Nil
       } else {
+        logger.debug(s"Repeat revive for $rolesForReviveRepetition.")
         List(IssueRevive(rolesForReviveRepetition))
       }
     }

--- a/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogicTest.scala
+++ b/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogicTest.scala
@@ -112,6 +112,26 @@ class ReviveOffersStreamLogicTest extends AkkaUnitTest with Inside {
       logic.handleTick() shouldBe Nil
 
     }
+
+    "send a repeat two times every other tick" in {
+      val logic = new ReviveOffersStreamLogic.ReviveRepeaterLogic
+
+      logic.processRoleDirective(UpdateFramework(Map("role" -> OffersWanted), Set("role"), Set.empty))
+      logic.handleTick() shouldBe Nil
+      logic.handleTick() shouldBe List(IssueRevive(Set("role")))
+
+      logic.processRoleDirective(IssueRevive(Set("role")))
+      logic.handleTick() shouldBe Nil
+
+      logic.handleTick() shouldBe List(IssueRevive(Set("role")))
+      logic.handleTick() shouldBe Nil
+
+      logic.handleTick() shouldBe List(IssueRevive(Set("role")))
+      logic.handleTick() shouldBe Nil
+
+      logic.handleTick() shouldBe List(IssueRevive(Set("role")))
+      logic.handleTick() shouldBe Nil
+    }
   }
 
   "Suppress and revive without throttling" should {

--- a/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogicTest.scala
+++ b/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogicTest.scala
@@ -113,22 +113,20 @@ class ReviveOffersStreamLogicTest extends AkkaUnitTest with Inside {
 
     }
 
-    "send a repeat two times every other tick" in {
+    "send a repeat revive once after the second tick" in {
       val logic = new ReviveOffersStreamLogic.ReviveRepeaterLogic
 
       logic.processRoleDirective(UpdateFramework(Map("role" -> OffersWanted), Set("role"), Set.empty))
       logic.handleTick() shouldBe Nil
+
+      // First repeat for update framework
       logic.handleTick() shouldBe List(IssueRevive(Set("role")))
 
+      // Revive was triggered
       logic.processRoleDirective(IssueRevive(Set("role")))
       logic.handleTick() shouldBe Nil
 
-      logic.handleTick() shouldBe List(IssueRevive(Set("role")))
-      logic.handleTick() shouldBe Nil
-
-      logic.handleTick() shouldBe List(IssueRevive(Set("role")))
-      logic.handleTick() shouldBe Nil
-
+      // Second repeat for newly triggered revive
       logic.handleTick() shouldBe List(IssueRevive(Set("role")))
       logic.handleTick() shouldBe Nil
     }

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActorTest.scala
@@ -17,7 +17,7 @@ import mesosphere.marathon.util.StreamHelpers
 import org.apache.mesos.Protos.FrameworkInfo
 import org.apache.mesos.SchedulerDriver
 import org.mockito.Mockito
-import org.mockito.verification.VerificationWithTimeout
+import org.mockito.verification.VerificationMode
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -137,7 +137,7 @@ class ReviveOffersActorTest extends AkkaUnitTest {
       delayUpdates: Source[RateLimiter.DelayUpdate, NotUsed] = StreamHelpers.sourceNever,
       val defaultRole: String = "role",
       enableSuppress: Boolean = true,
-      val invocationTimeout: VerificationWithTimeout = Mockito.timeout(1000)) {
+      val invocationTimeout: VerificationMode = Mockito.timeout(1000).atLeastOnce()) {
 
     val instanceUpdates: InstanceTracker.InstanceUpdates = Source.single(instancesSnapshot -> instanceChanges)
     implicit val mat: ActorMaterializer = ActorMaterializer()
@@ -163,7 +163,7 @@ class ReviveOffersActorTest extends AkkaUnitTest {
       import org.mockito.Matchers.{eq => mEq}
       Mockito.verify(driver, invocationTimeout).updateFramework(any, mEq(Seq(defaultRole).asJava))
     }
-    def verifyExplicitRevive(timeout: VerificationWithTimeout = invocationTimeout): Unit = {
+    def verifyExplicitRevive(timeout: VerificationMode = invocationTimeout): Unit = {
       Mockito.verify(driver, timeout).reviveOffers(Set(defaultRole).asJava)
     }
 


### PR DESCRIPTION
Summary:
This should also fix a race condition in `ReviveOffersActorTest` when a revive would be repeated
but we verify only one invoation.