### PR TITLE
Fix bug where app-normalization logic treated relative paths as absolute

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -35,7 +35,7 @@ class GroupBenchmark {
   lazy val groupIds = 0 until groupDepth
 
   lazy val groupPaths: Vector[PathId] = groupIds.foldLeft(Vector[PathId]()) { (allPaths, nextChild) =>
-    val nextChildPath = allPaths.lastOption.getOrElse(PathId.empty) / s"group-$nextChild"
+    val nextChildPath = allPaths.lastOption.getOrElse(PathId.root) / s"group-$nextChild"
     allPaths :+ nextChildPath
   }
 

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -60,7 +60,7 @@ class GroupBenchmark {
   lazy val groupIds = 0 until numberOfGroups
 
   lazy val childGroupPaths: Vector[PathId] = groupIds.map { groupId =>
-    s"group-$groupId".toRootPath
+    s"group-$groupId".toAbsolutePath
   }(breakOut)
 
   lazy val rootGroup: RootGroup = fillRootGroup()

--- a/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
+++ b/mesos-simulation/src/test/scala/mesosphere/mesos/scale/SingleAppScalingTest.scala
@@ -43,7 +43,7 @@ class SingleAppScalingTest extends AkkaIntegrationTest with ZookeeperServerTest 
   override lazy val leadingMarathon = Future.successful(marathonServer)
 
   override lazy val marathonUrl: String = s"http://localhost:${marathonServer.httpPort}"
-  override lazy val testBasePath: PathId = PathId.empty
+  override lazy val testBasePath: PathId = PathId.root
   override lazy val marathon: MarathonFacade = new MarathonFacade(marathonUrl, testBasePath)
 
   override def beforeAll(): Unit = {

--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -106,8 +106,8 @@ class TaskKiller @Inject() (
     val version = Timestamp.now()
 
     def killDeployment = groupManager.updateRoot(
-      PathId.empty,
-      _.updateTransitiveApps(PathId.empty, scaleApp, version),
+      PathId.root,
+      _.updateTransitiveApps(PathId.root, scaleApp, version),
       version = version,
       force = force,
       toKill = appInstances

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.v2
 
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{FetchUri, PathId}
+import mesosphere.marathon.state.{AbsolutePathId, FetchUri, PathId}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.util.RoleSettings
 
@@ -279,7 +279,7 @@ object AppNormalization {
     app.copy(
       // it's kind of cheating to do this here, but its required in order to pass canonical validation (that happens
       // before canonical normalization)
-      id = app.id.toRootPath.toString,
+      id = app.id.toAbsolutePath.toString,
       // normalize fetch
       fetch = fetch,
       uris = None,
@@ -414,7 +414,7 @@ object AppNormalization {
         throw NormalizationException("cannot mix deprecated and canonical network APIs")
     }
   }
-  def withCanonizedIds[T](base: PathId = PathId.empty): Normalization[T] = Normalization {
+  def withCanonizedIds[T](base: AbsolutePathId = PathId.root): Normalization[T] = Normalization {
     case update: AppUpdate =>
       update.copy(
         id = update.id.map(id => PathId(id).canonicalPath(base).toString),

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -51,7 +51,7 @@ class AppTasksResource @Inject() (
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       id match {
         case GroupTasks(gid) =>
-          val groupPath = gid.toRootPath
+          val groupPath = gid.toAbsolutePath
           val maybeGroup = groupManager.group(groupPath)
           await(withAuthorization(ViewGroup, maybeGroup, Future.successful(unknownGroup(groupPath))) { group =>
             async {
@@ -60,7 +60,7 @@ class AppTasksResource @Inject() (
             }
           })
         case _ =>
-          val appId = id.toRootPath
+          val appId = id.toAbsolutePath
           val maybeApp = groupManager.app(appId)
           val tasks = await(runningTasks(Set(appId), instancesBySpec)).toRaml
           withAuthorization(ViewRunSpec, maybeApp, unknownApp(appId)) { _ =>
@@ -88,7 +88,7 @@ class AppTasksResource @Inject() (
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val id = appId.toRootPath
+      val id = appId.toAbsolutePath
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
         ok(EndpointsHelper.appsToEndpointString(ListTasks(instancesBySpec, Seq(app))))
@@ -106,7 +106,7 @@ class AppTasksResource @Inject() (
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val pathId = appId.toRootPath
+      val pathId = appId.toAbsolutePath
 
       def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
         Option(host).fold(appTasks) { hostname =>
@@ -144,7 +144,7 @@ class AppTasksResource @Inject() (
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val pathId = appId.toRootPath
+      val pathId = appId.toAbsolutePath
 
       def findToKill(appTasks: Seq[Instance]): Seq[Instance] = {
         try {

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -31,7 +31,7 @@ class AppVersionsResource(
     @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val id = appId.toRootPath
+      val id = appId.toAbsolutePath
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { _ =>
         ok(jsonObjString("versions" -> service.listAppVersions(id)))
       }
@@ -47,7 +47,7 @@ class AppVersionsResource(
     @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val id = appId.toRootPath
+      val id = appId.toAbsolutePath
       val timestamp = Timestamp(version)
       withAuthorization(ViewRunSpec, service.getApp(id, timestamp), unknownApp(id, Some(timestamp))) { app =>
         ok(jsonString(app))

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -51,7 +51,7 @@ class AppsResource @Inject() (
 
   private[this] val ListApps = """^((?:.+/)|)\*$""".r
 
-  private def createValidatorAndNormalizerForApp(pathId: PathId): (Normalization[raml.App], Validator[AppDefinition]) = {
+  private def createValidatorAndNormalizerForApp(pathId: AbsolutePathId): (Normalization[raml.App], Validator[AppDefinition]) = {
     val roleSettings = RoleSettings.forService(config, pathId, groupManager.rootGroup())
     val normalizationConfig = AppNormalization.Configuration(config, roleSettings)
     val normalizer: Normalization[raml.App] = appNormalization(normalizationConfig)(AppNormalization.withCanonizedIds())
@@ -60,7 +60,7 @@ class AppsResource @Inject() (
     (normalizer, validator)
   }
 
-  private def createValidatorAndNormalizerForAppUpdate(pathId: PathId): (Normalization[raml.AppUpdate], Validator[AppDefinition]) = {
+  private def createValidatorAndNormalizerForAppUpdate(pathId: AbsolutePathId): (Normalization[raml.AppUpdate], Validator[AppDefinition]) = {
     val roleSettings = RoleSettings.forService(config, pathId, groupManager.rootGroup())
     val normalizationConfig = AppNormalization.Configuration(config, roleSettings)
     val normalizer: Normalization[raml.AppUpdate] = appUpdateNormalization(normalizationConfig)(AppNormalization.withCanonizedIds())
@@ -100,7 +100,7 @@ class AppsResource @Inject() (
 
       val ramlApp = Json.parse(body).as[raml.App]
 
-      implicit val (normalize, validate) = createValidatorAndNormalizerForApp(PathId(ramlApp.id))
+      implicit val (normalize, validate) = createValidatorAndNormalizerForApp(PathId(ramlApp.id).canonicalPath(PathId.root))
 
       val now = clock.now()
 
@@ -147,7 +147,7 @@ class AppsResource @Inject() (
 
       id match {
         case ListApps(gid) =>
-          val groupId = gid.toRootPath
+          val groupId = gid.toAbsolutePath
           groupManager.group(groupId) match {
             case Some(group) =>
               checkAuthorization(ViewGroup, group)
@@ -157,7 +157,7 @@ class AppsResource @Inject() (
               unknownGroup(groupId)
           }
         case _ =>
-          val appId = id.toRootPath
+          val appId = id.toAbsolutePath
           await(appInfoService.selectApp(appId, authzSelector, resolvedEmbed)) match {
             case Some(appInfo) =>
               checkAuthorization(ViewRunSpec, appInfo.app)
@@ -176,7 +176,7 @@ class AppsResource @Inject() (
     * @param body is the raw, unparsed JSON
     * @param updateType CompleteReplacement if we want to replace the app entirely, PartialUpdate if we only want to update provided parts
     */
-  def canonicalAppUpdateFromJson(appId: PathId, body: Array[Byte], updateType: UpdateType): raml.AppUpdate = {
+  def canonicalAppUpdateFromJson(appId: AbsolutePathId, body: Array[Byte], updateType: UpdateType): raml.AppUpdate = {
     val roleSettings = RoleSettings.forService(config, appId, groupManager.rootGroup())
     val normalizationConfig = AppNormalization.Configuration(config, roleSettings)
 
@@ -212,12 +212,12 @@ class AppsResource @Inject() (
     * @param partialUpdate true if the JSON should be parsed as a partial application update (all fields optional)
     *                      or as a wholesale replacement (parsed like an app definition would be)
     */
-  def canonicalAppUpdatesFromJson(body: Array[Byte], partialUpdate: Boolean): Seq[raml.AppUpdate] = {
+  def canonicalAppUpdatesFromJson(basePath: AbsolutePathId, body: Array[Byte], partialUpdate: Boolean): Seq[raml.AppUpdate] = {
     if (partialUpdate) {
       Json.parse(body).as[Seq[raml.AppUpdate]].map { appUpdate =>
         require(appUpdate.id.isDefined, "App Update must have app id set")
 
-        implicit val (normalizer, _) = createValidatorAndNormalizerForAppUpdate(PathId(appUpdate.id.get))
+        implicit val (normalizer, _) = createValidatorAndNormalizerForAppUpdate(PathId(appUpdate.id.get).canonicalPath(basePath))
         appUpdate.normalize
       }
     } else {
@@ -226,7 +226,7 @@ class AppsResource @Inject() (
       // the version is thrown away in toUpdate so just pass `zero` for now.
       Json.parse(body).as[Seq[raml.App]].map { app =>
 
-        implicit val (normalizer, _) = createValidatorAndNormalizerForApp(PathId(app.id))
+        implicit val (normalizer, _) = createValidatorAndNormalizerForApp(app.id.toPath.canonicalPath(basePath))
         app.normalize.toRaml[raml.AppUpdate]
       }
     }
@@ -270,7 +270,7 @@ class AppsResource @Inject() (
     @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      await(updateMultiple(force, partialUpdate, body, allowCreation = true))
+      await(updateMultiple(PathId.root, force, partialUpdate, body, allowCreation = true))
     }
   }
 
@@ -282,7 +282,7 @@ class AppsResource @Inject() (
     @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      await(updateMultiple(force, partialUpdate = true, body, allowCreation = false))
+      await(updateMultiple(PathId.root, force, partialUpdate = true, body, allowCreation = false))
     }
   }
 
@@ -295,7 +295,7 @@ class AppsResource @Inject() (
     @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val appId = id.toRootPath
+      val appId = id.toAbsolutePath
       val version = Timestamp.now()
 
       def deleteApp(rootGroup: RootGroup) = {
@@ -330,7 +330,7 @@ class AppsResource @Inject() (
     @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val appId = id.toRootPath
+      val appId = id.toAbsolutePath
 
       def markForRestartingOrThrow(opt: Option[AppDefinition]) = {
         opt
@@ -341,7 +341,7 @@ class AppsResource @Inject() (
 
       val newVersion = clock.now()
       val restartDeployment = await(
-        groupManager.updateApp(id.toRootPath, markForRestartingOrThrow, newVersion, force)
+        groupManager.updateApp(id.toAbsolutePath, markForRestartingOrThrow, newVersion, force)
       )
 
       deploymentResult(restartDeployment)
@@ -362,7 +362,7 @@ class AppsResource @Inject() (
     */
   private[this] def update(id: String, body: Array[Byte], force: Boolean, partialUpdate: Boolean,
     req: HttpServletRequest, allowCreation: Boolean)(implicit identity: Identity): Future[Response] = async {
-    val appId = id.toRootPath
+    val appId = id.toAbsolutePath
 
     // can lead to race condition where two non-existent apps with the same id are inserted concurrently,
     // one of them will be overwritten by another
@@ -399,14 +399,14 @@ class AppsResource @Inject() (
     * @param identity implicit identity
     * @return http servlet response
     */
-  private[this] def updateMultiple(force: Boolean, partialUpdate: Boolean,
+  private[this] def updateMultiple(basePath: AbsolutePathId, force: Boolean, partialUpdate: Boolean,
     body: Array[Byte], allowCreation: Boolean)(implicit identity: Identity): Future[Response] = async {
 
     val version = clock.now()
-    val updates = canonicalAppUpdatesFromJson(body, partialUpdate)
+    val updates = canonicalAppUpdatesFromJson(basePath, body, partialUpdate)
 
     def updateGroup(rootGroup: RootGroup): RootGroup = updates.foldLeft(rootGroup) { (group, update) =>
-      update.id.map(PathId(_)) match {
+      update.id.map(_.toPath.canonicalPath(basePath)) match {
         case Some(id) => {
           implicit val (normalizer, validate) = createValidatorAndNormalizerForApp(id)
 
@@ -416,7 +416,7 @@ class AppsResource @Inject() (
       }
     }
 
-    deploymentResult(await(groupManager.updateRoot(PathId.empty, updateGroup, version, force)))
+    deploymentResult(await(groupManager.updateRoot(PathId.root, updateGroup, version, force)))
   }
 
   private def maybePostEvent(req: HttpServletRequest, app: AppDefinition) =

--- a/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
@@ -64,7 +64,7 @@ class DeploymentsResource @Inject() (
           } else {
             // create a new deployment to return to the previous state
             deploymentResult(await(groupManager.updateRoot(
-              PathId.empty,
+              PathId.root,
               deployment.revert,
               force = true
             )))

--- a/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/QueueResource.scala
@@ -58,7 +58,7 @@ class QueueResource @Inject() (
     @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
-      val runSpecId = id.toRootPath
+      val runSpecId = id.toAbsolutePath
       val runSpecScheduled = await(instanceTracker.specInstances(runSpecId)).exists(_.isScheduled)
       val maybeRunSpec = if (runSpecScheduled) groupManager.runSpec(runSpecId) else None
       withAuthorization(UpdateRunSpec, maybeRunSpec, notFound(runSpecNotFoundTasksQueue(runSpecId))) { runSpec =>

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -18,7 +18,7 @@ trait AppValidation {
   import ArtifactValidation._
   import EnvVarValidation._
   import NetworkValidation._
-  import PathId.{empty => _, _}
+  import PathId.{root => _, _}
   import SchedulingValidation._
   import SecretValidation._
 

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoService.scala
@@ -135,12 +135,12 @@ private[appinfo] class DefaultInfoService(
         if (groupMatches(ref)) {
           val groups: Option[Seq[GroupInfo]] =
             if (groupEmbed(GroupInfo.Embed.Groups))
-              Some(ref.groupsById.values.toIndexedSeq.flatMap(queryGroup).sortBy(_.group.id))
+              Some(ref.groupsById.values.toIndexedSeq.flatMap(queryGroup).sortBy(_.group.id: PathId))
             else
               None
           val apps: Option[Seq[AppInfo]] =
             if (groupEmbedApps)
-              Some(ref.apps.keys.flatMap(infoById.get)(collection.breakOut).sortBy(_.app.id))
+              Some(ref.apps.keys.flatMap(infoById.get)(collection.breakOut).sortBy(_.app.id: PathId))
             else
               None
           val pods: Option[Seq[PodStatus]] =

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanReverter.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanReverter.scala
@@ -107,7 +107,7 @@ private[deployment] object DeploymentPlanReverter extends StrictLogging {
       case (change1, change2) =>
         // both groups are supposed to have the same path id (if there are any)
         def pathId(change: (Option[Group], Option[Group])): PathId = {
-          Seq(change._1, change._2).flatten.headOption.fold(PathId.empty)(_.id)
+          Seq(change._1, change._2).flatten.headOption.fold(PathId.root: PathId)(_.id)
         }
 
         pathId(change1) > pathId(change2)

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -124,7 +124,7 @@ object PodDefinition {
 
   val DefaultExecutorResources: Resources = ExecutorResources().fromRaml
   val DefaultLinuxInfo = Option.empty[LinuxInfo]
-  val DefaultId = PathId.empty
+  val DefaultId = PathId.root
   val DefaultUser = Option.empty[String]
   val DefaultEnv = Map.empty[String, EnvVarValue]
   val DefaultLabels = Map.empty[String, String]

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -46,7 +46,7 @@ object UpdateGroupStructureOp {
     * Creates a new [[state.Group]] from a [[GroupUpdate]], performing both normalization and conversion.
     */
   private def createGroup(groupUpdate: GroupUpdate, gid: PathId, version: Timestamp)(implicit cf: App => AppDefinition): CoreGroup = {
-    implicit val pathNormalization: Normalization[PathId] = Normalization(_.canonicalPath(gid))
+    implicit val pathNormalization: Normalization[PathId] = Normalization(_.canonicalPath(gid.asAbsolutePath))
     implicit val appNormalization = normalizeApp(version)
 
     val appsById: Map[AppDefinition.AppKey, AppDefinition] = groupUpdate.apps.getOrElse(Set.empty).map { currentApp =>
@@ -84,7 +84,7 @@ object UpdateGroupStructureOp {
     require(groupUpdate.version.isEmpty, "For a structural update, no version should be given.")
     assert(groupUpdate.enforceRole.isDefined, s"BUG! The group normalization should have set enforceRole for ${groupUpdate.id}.")
 
-    implicit val pathNormalization: Normalization[PathId] = Normalization(_.canonicalPath(current.id))
+    implicit val pathNormalization: Normalization[PathId] = Normalization(_.canonicalPath(current.id.asAbsolutePath))
     implicit val appNormalization = normalizeApp(timestamp)
 
     val effectiveGroups: Map[PathId, CoreGroup] = groupUpdate.groups.fold(current.groupsById) { updates =>

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -422,7 +422,7 @@ object AppDefinition extends GeneralPurposeCombinators {
   val RandomPortDefinition: PortDefinition = PortDefinition(RandomPortValue, "tcp", None, Map.empty[String, String])
 
   // App defaults
-  val DefaultId = PathId.empty
+  val DefaultId = PathId.root
 
   val DefaultEnv = Map.empty[String, EnvVarValue]
 

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -225,7 +225,7 @@ object Group extends StrictLogging {
     */
   private def isChildOfParentId(group: Group): Validator[AppDefinition] = {
     isTrue("App has to be child of group with parent id") { app =>
-      if (app.id.parent == group.id) group.apps.contains(app.id)
+      if (app.id.asAbsolutePath.parent == group.id.asAbsolutePath) group.apps.contains(app.id)
       else {
         group.group(app.id.parent).exists(child => child.apps.contains(app.id))
       }
@@ -258,7 +258,7 @@ object Group extends StrictLogging {
   def emptyUpdate(id: PathId): raml.GroupUpdate = raml.GroupUpdate(Some(id.toString))
 
   /** requires that apps are in canonical form */
-  def validNestedGroupUpdateWithBase(base: PathId, originalRootGroup: RootGroup): Validator[raml.GroupUpdate] =
+  def validNestedGroupUpdateWithBase(base: AbsolutePathId, originalRootGroup: RootGroup): Validator[raml.GroupUpdate] =
     validator[raml.GroupUpdate] { group =>
       group is notNull
 

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -1,15 +1,16 @@
 package mesosphere.marathon
 package state
 
+import com.typesafe.scalalogging.StrictLogging
 import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation.isTrue
-import mesosphere.marathon.plugin
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Seq
 
-case class PathId(path: Seq[String], absolute: Boolean = true) extends Ordered[PathId] with plugin.PathId {
+sealed trait PathId extends Ordered[PathId] with plugin.PathId with Product {
+  val absolute: Boolean
 
   def root: String = path.headOption.getOrElse("")
 
@@ -17,9 +18,24 @@ case class PathId(path: Seq[String], absolute: Boolean = true) extends Ordered[P
 
   def tail: Seq[String] = path.tail
 
+  /**
+    * @return True if this path is "" or "/"
+    */
   def isEmpty: Boolean = path.isEmpty
 
-  def isRoot: Boolean = path.isEmpty
+  /**
+    * @return True if this path is "/"
+    */
+  def isRoot: Boolean = path.isEmpty && (absolute == true)
+
+  /**
+    * Workaround method used to cope with the fact that the proper type isn't used for many ids in our code.
+    *
+    * Once Group, AppDefinition and PodDefinition all use AbsolutePathId, we should remove this method
+    * @return
+    */
+  @deprecated("Assuming an absolute path where it may not be is a source of bugs; avoid using this method if possible")
+  def asAbsolutePath: AbsolutePathId
 
   lazy val parent: PathId = path match {
     case Nil => this
@@ -54,7 +70,7 @@ case class PathId(path: Seq[String], absolute: Boolean = true) extends Ordered[P
    *
    * PathId("child").canonicalPath(PathId("/parent")) == PathId("/parent/child")
    */
-  def canonicalPath(base: PathId = PathId(Nil, absolute = true)): PathId = {
+  def canonicalPath(base: AbsolutePathId = PathId.root): AbsolutePathId = {
     require(base.absolute, "Base path is not absolute, canonical path can not be computed!")
     @tailrec def in(remaining: Seq[String], result: Seq[String] = Nil): Seq[String] = remaining match {
       case head +: tail if head == "." => in(tail, result)
@@ -62,7 +78,12 @@ case class PathId(path: Seq[String], absolute: Boolean = true) extends Ordered[P
       case head +: tail => in(tail, head +: result)
       case Nil => result.reverse
     }
-    if (absolute) PathId(in(path)) else PathId(in(base.path ++ path))
+    this match {
+      case rootPath: AbsolutePathId =>
+        AbsolutePathId(in(path))
+      case relativePath: RelativePathId =>
+        AbsolutePathId(in(base.path ++ path))
+    }
   }
 
   def safePath: String = {
@@ -79,7 +100,7 @@ case class PathId(path: Seq[String], absolute: Boolean = true) extends Ordered[P
 
   override val toString: String = toString("/")
 
-  private def toString(delimiter: String): String = path.mkString(if (absolute) delimiter else "", delimiter, "")
+  protected def toString(delimiter: String): String
 
   override def compare(that: PathId): Int = {
     import Ordering.Implicits._
@@ -97,10 +118,46 @@ case class PathId(path: Seq[String], absolute: Boolean = true) extends Ordered[P
   override val hashCode: Int = scala.util.hashing.MurmurHash3.productHash(this)
 }
 
+case class AbsolutePathId(path: Seq[String]) extends PathId {
+  override val absolute: Boolean = true
+  override def asAbsolutePath: AbsolutePathId = this
+  protected def toString(delimiter: String): String =
+    path.mkString("/", delimiter, "")
+}
+
+object AbsolutePathId {
+  /**
+    * Parse the string as a path, but interpret it as relative to root, if it is relative.
+    *
+    * @param path The string representation of the path to parse
+    * @return An absolute path
+    */
+  def apply(path: String): AbsolutePathId = {
+    PathId(path).canonicalPath(PathId.root)
+  }
+
+}
+
+case class RelativePathId(path: Seq[String]) extends PathId with StrictLogging {
+  override val absolute: Boolean = false
+  override def asAbsolutePath: AbsolutePathId = {
+    /* There could be some input cases in the wild where this could be hit, but in a benign way
+     * Rather than break Marathon, lets log a loud message and hopefully those cases will be addressed as we remove
+     * this method
+     */
+    val ex = new RuntimeException("An absolute path was expected where we had a relative path")
+    logger.warn(s"Path '${this}' assumed to be an absolute path, but was relative. This is probably a bug.", ex)
+    this.canonicalPath(PathId.root)
+  }
+
+  protected def toString(delimiter: String): String =
+    path.mkString(delimiter)
+}
+
 object PathId {
   def fromSafePath(in: String): PathId = {
-    if (in.isEmpty) PathId.empty
-    else PathId(in.split("_").toList, absolute = true)
+    if (in.isEmpty) PathId.root
+    else AbsolutePathId(in.split("_").toList)
   }
 
   /**
@@ -112,16 +169,23 @@ object PathId {
   def sanitized(pieces: TraversableOnce[String], absolute: Boolean = true) =
     PathId(pieces.filter(_.nonEmpty).toList, absolute)
 
+  def apply(pieces: Seq[String], absolute: Boolean = true): PathId = {
+    if (absolute)
+      AbsolutePathId(pieces)
+    else
+      RelativePathId(pieces)
+  }
+
   def apply(in: String): PathId = {
     val raw = in.replaceAll("""(^/+)|(/+$)""", "").split("/")
     sanitized(raw, in.startsWith("/"))
   }
 
-  def empty: PathId = PathId(Nil)
+  def root: AbsolutePathId = AbsolutePathId(Nil)
 
   implicit class StringPathId(val stringPath: String) extends AnyVal {
     def toPath: PathId = PathId(stringPath)
-    def toRootPath: PathId = PathId(stringPath).canonicalPath()
+    def toAbsolutePath: AbsolutePathId = PathId(stringPath).canonicalPath()
   }
 
   /**
@@ -167,7 +231,7 @@ object PathId {
     */
   private def childOf(parent: PathId): Validator[PathId] = {
     isTrue[PathId](s"Identifier is not child of $parent. Hint: use relative paths.") { child =>
-      !parent.absolute || (child.canonicalPath(parent).parent == parent)
+      !parent.absolute || (child.canonicalPath(parent.asAbsolutePath).parent == parent)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/state/RootGroup.scala
+++ b/src/main/scala/mesosphere/marathon/state/RootGroup.scala
@@ -26,7 +26,7 @@ class RootGroup(
     groupsById: Map[Group.GroupKey, Group] = Group.defaultGroups,
     dependencies: Set[PathId] = Group.defaultDependencies,
     version: Timestamp = Group.defaultVersion) extends Group(
-  PathId.empty,
+  PathId.root,
   apps,
   pods,
   groupsById,
@@ -438,7 +438,7 @@ object RootGroup {
 
   def validRootGroup(config: MarathonConf): Validator[RootGroup] = validator[RootGroup] { rootGroup =>
     rootGroup is noCyclicDependencies
-    rootGroup is Group.validGroup(PathId.empty, config)
+    rootGroup is Group.validGroup(PathId.root, config)
     rootGroup is ExternalVolumes.validRootGroup()
     rootGroup.transitiveApps as "apps" is Group.everyApp(
       validAppRole(config, rootGroup)
@@ -452,11 +452,11 @@ object RootGroup {
     isTrue("Dependency graph has cyclic dependencies.") { _.hasNonCyclicDependencies }
 
   private def validAppRole(config: MarathonConf, rootGroup: RootGroup): Validator[AppDefinition] = (app: AppDefinition) => {
-    AppDefinition.validWithRoleEnforcement(RoleSettings.forService(config, app.id, rootGroup)).apply(app)
+    AppDefinition.validWithRoleEnforcement(RoleSettings.forService(config, app.id.asAbsolutePath, rootGroup)).apply(app)
   }
 
   private def validPodRole(config: MarathonConf, rootGroup: RootGroup): Validator[PodDefinition] = (pod: PodDefinition) => {
-    PodsValidation.validPodDefinitionWithRoleEnforcement(RoleSettings.forService(config, pod.id, rootGroup)).apply(pod)
+    PodsValidation.validPodDefinitionWithRoleEnforcement(RoleSettings.forService(config, pod.id.asAbsolutePath, rootGroup)).apply(pod)
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
+++ b/src/main/scala/mesosphere/marathon/state/TaskFailure.scala
@@ -45,7 +45,7 @@ object TaskFailure {
 
   def empty: TaskFailure = {
     TaskFailure(
-      PathId.empty,
+      PathId.root,
       mesos.TaskID.newBuilder().setValue("").build,
       mesos.TaskState.TASK_STAGING
     )

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -416,5 +416,5 @@ class StoredGroupRepositoryImpl[K, C, S](
 }
 
 object StoredGroupRepositoryImpl {
-  val RootId = PathId.empty
+  val RootId: PathId = PathId.root
 }

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package util
 
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.state.{PathId, RootGroup}
+import mesosphere.marathon.state.{RootGroup, AbsolutePathId}
 
 /**
   * Configures role enforcement on runSpecs, used for validation.
@@ -21,12 +21,12 @@ object RoleSettings extends StrictLogging {
     * Returns the role settings for the service with the specified ID, based on the top-level group and the global config
     *
     * @param config Global config to provide defaultMesos role
-    * @param servicePathId The pathId of the affected runSpec, used to determine a possible top-level group role
+    * @param servicePathId The absolute pathId of the affected runSpec, used to determine a possible top-level group role
     * @param rootGroup The root group, used to access possible top-level groups and their settings
     *
     * @return A data set with valid roles, default role and a flag if the role should be enforced
     */
-  def forService(config: MarathonConf, servicePathId: PathId, rootGroup: RootGroup): RoleSettings = {
+  def forService(config: MarathonConf, servicePathId: AbsolutePathId, rootGroup: RootGroup): RoleSettings = {
     val defaultRole = config.mesosRole()
 
     if (servicePathId.parent.isRoot) {

--- a/src/test/scala/mesosphere/marathon/api/GroupApiServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/GroupApiServiceTest.scala
@@ -22,7 +22,7 @@ class GroupApiServiceTest extends UnitTest with GroupCreation {
   "revert a version if version is provided" in {
     Given("Group manager with the group version")
     val groupManager = mock[GroupManager]
-    val groupId = PathId.empty
+    val groupId = PathId.root
     val version = Timestamp.now()
     val groupWithOlderVersion = createGroup(groupId, version = version)
     groupManager.group(groupId, version).returns(Future.successful(Some(groupWithOlderVersion)))
@@ -30,7 +30,7 @@ class GroupApiServiceTest extends UnitTest with GroupCreation {
     When("Calling update with version provided")
     val updatedGroup = f.groupApiService.updateGroup(
       createRootGroup(),
-      PathId.empty,
+      PathId.root,
       GroupUpdate(version = Some(version.toOffsetDateTime)),
       version).futureValue
 
@@ -41,7 +41,7 @@ class GroupApiServiceTest extends UnitTest with GroupCreation {
   "reverting to non-existing version throws exception" in {
     Given("Group manager with no group of required version")
     val groupManager = mock[GroupManager]
-    val groupId = PathId.empty
+    val groupId = PathId.root
     val version = Timestamp.now
     groupManager.group(groupId, version).returns(Future.successful(None))
     val f = Fixture(groupManager = groupManager)
@@ -50,7 +50,7 @@ class GroupApiServiceTest extends UnitTest with GroupCreation {
     Then("Exception will be thrown")
     val ex = f.groupApiService.updateGroup(
       createRootGroup(),
-      PathId.empty,
+      PathId.root,
       GroupUpdate(version = Some(version.toOffsetDateTime)),
       version).failed.futureValue
     ex shouldBe an[IllegalArgumentException]
@@ -59,15 +59,15 @@ class GroupApiServiceTest extends UnitTest with GroupCreation {
   "scale when scaleBy provided" in {
     Given("Initialized service with root group and one app")
     val f = Fixture()
-    val app = AppDefinition("/app".toRootPath, cmd = Some("cmd"), networks = Seq(ContainerNetwork("foo")), role = "*")
+    val app = AppDefinition("/app".toAbsolutePath, cmd = Some("cmd"), networks = Seq(ContainerNetwork("foo")), role = "*")
     val originalInstancesCount = app.instances
     val rootGroup = createRootGroup(apps = Map(
-      "/app".toRootPath -> app
+      "/app".toAbsolutePath -> app
     ))
     When("Calling update with scaleBy")
     val updatedGroup = f.groupApiService.updateGroup(
       rootGroup,
-      PathId.empty,
+      PathId.root,
       GroupUpdate(scaleBy = Some(2)),
       Timestamp.now()).futureValue
 
@@ -78,22 +78,22 @@ class GroupApiServiceTest extends UnitTest with GroupCreation {
   "update the group if version as well as scaleBy not provided" in {
     Given("Group manager with the group version")
     val groupManager = mock[GroupManager]
-    val groupId = PathId.empty
+    val groupId = PathId.root
     val newVersion = Timestamp.now()
     val existingGroup = createGroup(groupId, version = newVersion)
     groupManager.group(groupId).returns(Some(existingGroup))
     val f = Fixture(groupManager = groupManager)
     When("Calling update with new apps being added to a group")
     val update = GroupUpdate(apps = Some(Set(App("/app", role = Some(ResourceRole.Unreserved), networks = Seq(Network(mode = NetworkMode.ContainerBridge))))))
-    val normalizedUpdate = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.empty).normalized(update)
+    val normalizedUpdate = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.root).normalized(update)
     val updatedGroup = f.groupApiService.updateGroup(
       createRootGroup(),
-      PathId.empty,
+      PathId.root,
       normalizedUpdate,
       newVersion).futureValue
 
     Then("Group will contain those apps after an update")
-    updatedGroup.apps(PathId("/app")) should be (AppDefinition("/app".toRootPath, networks = Seq(BridgeNetwork()), versionInfo = VersionInfo.OnlyVersion(newVersion), role = "*"))
+    updatedGroup.apps(PathId("/app")) should be (AppDefinition("/app".toAbsolutePath, networks = Seq(BridgeNetwork()), versionInfo = VersionInfo.OnlyVersion(newVersion), role = "*"))
   }
 
   case class Fixture(

--- a/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppVersionsResourceTest.scala
@@ -42,7 +42,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       auth.authorized = false
       val req = auth.request
 
-      groupManager.app("appId".toRootPath) returns Some(AppDefinition("appId".toRootPath, role = "*"))
+      groupManager.app("appId".toAbsolutePath) returns Some(AppDefinition("appId".toAbsolutePath, role = "*"))
       When("the index is fetched")
       val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a not authorized response")
@@ -55,7 +55,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       auth.authorized = false
       val req = auth.request
 
-      groupManager.app("appId".toRootPath) returns None
+      groupManager.app("appId".toAbsolutePath) returns None
       When("the index is fetched")
       val index = asyncRequest { r => appsVersionsResource.index("appId", req, r) }
       Then("we receive a 404")
@@ -69,7 +69,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       val version = Timestamp.now()
-      service.getApp("appId".toRootPath, version) returns Some(AppDefinition("appId".toRootPath, role = "*"))
+      service.getApp("appId".toAbsolutePath, version) returns Some(AppDefinition("appId".toAbsolutePath, role = "*"))
       When("one app version is fetched")
       val show = asyncRequest { r => appsVersionsResource.show("appId", version.toString, req, r) }
       Then("we receive a not authorized response")
@@ -83,7 +83,7 @@ class AppVersionsResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       val version = Timestamp.now()
-      service.getApp("appId".toRootPath, version) returns None
+      service.getApp("appId".toAbsolutePath, version) returns None
       When("one app version is fetched")
       val show = asyncRequest { r => appsVersionsResource.show("appId", version.toString, req, r) }
       Then("we receive a not authorized response")

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -255,8 +255,8 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
     "Group Versions for root are transferred as simple json string array (Fix #2329)" in new Fixture {
       Given("Specific Group versions")
       val groupVersions = Seq(Timestamp.now(), Timestamp.now())
-      groupManager.versions(PathId.empty) returns Source(groupVersions)
-      groupManager.group(PathId.empty) returns Some(createGroup(PathId.empty))
+      groupManager.versions(PathId.root) returns Source(groupVersions)
+      groupManager.group(PathId.root) returns Some(createGroup(PathId.root))
 
       When("The versions are queried")
       val rootVersionsResponse = asyncRequest { r => groupsResource.group("versions", embed, auth.request, r) }
@@ -270,8 +270,8 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       Given("Specific group versions")
       val groupVersions = Seq(Timestamp.now(), Timestamp.now())
       groupManager.versions(any) returns Source(groupVersions)
-      groupManager.versions("/foo/bla/blub".toRootPath) returns Source(groupVersions)
-      groupManager.group("/foo/bla/blub".toRootPath) returns Some(createGroup("/foo/bla/blub".toRootPath))
+      groupManager.versions("/foo/bla/blub".toAbsolutePath) returns Source(groupVersions)
+      groupManager.group("/foo/bla/blub".toAbsolutePath) returns Some(createGroup("/foo/bla/blub".toAbsolutePath))
 
       When("The versions are queried")
       val rootVersionsResponse = asyncRequest { r => groupsResource.group("/foo/bla/blub/versions", embed, auth.request, r) }
@@ -283,8 +283,8 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
 
     "Creation of a group with same path as an existing app should be prohibited (fixes #3385)" in new FixtureWithRealGroupManager(
       initialRoot = {
-        val app = AppDefinition("/group/app".toRootPath, cmd = Some("sleep"), role = "*")
-        createRootGroup(groups = Set(createGroup("/group".toRootPath, Map(app.id -> app))), validate = false)
+        val app = AppDefinition("/group/app".toAbsolutePath, cmd = Some("sleep"), role = "*")
+        createRootGroup(groups = Set(createGroup("/group".toAbsolutePath, Map(app.id -> app))), validate = false)
       }
     ) {
       Given("A real group manager with one app")
@@ -300,7 +300,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
     }
 
     "Creation of a group with same path as an existing group should be prohibited" in
-      new FixtureWithRealGroupManager(initialRoot = createRootGroup(groups = Set(createGroup("/group".toRootPath)))) {
+      new FixtureWithRealGroupManager(initialRoot = createRootGroup(groups = Set(createGroup("/group".toAbsolutePath)))) {
         When("creating a group with the same path existing app")
         val body = Json.stringify(Json.toJson(GroupUpdate(id = Some("/group"))))
 

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -43,7 +43,7 @@ class ModelValidationTest extends UnitTest with GroupCreation with ValidationTes
 
   "ModelValidation" should {
     "A group update should pass validation" in {
-      implicit val groupUpdateValidator: Validator[GroupUpdate] = Group.validNestedGroupUpdateWithBase(PathId.empty, RootGroup.empty)
+      implicit val groupUpdateValidator: Validator[GroupUpdate] = Group.validNestedGroupUpdateWithBase(PathId.root, RootGroup.empty)
       val update = GroupUpdate(id = Some("/a/b/c"))
 
       validate(update).isSuccess should be(true)

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -1765,7 +1765,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       }
       "there are versions" when {
         import mesosphere.marathon.state.PathId._
-        val pod1 = PodDefinition("/id".toRootPath, containers = Seq(MesosContainer(name = "foo", resources = Resources())), role = "*")
+        val pod1 = PodDefinition("/id".toAbsolutePath, containers = Seq(MesosContainer(name = "foo", resources = Resources())), role = "*")
         val pod2 = pod1.copy(versionInfo = VersionInfo.OnlyVersion(pod1.version + 1.minute))
         "list the available versions" in {
           val groupManager = mock[GroupManager]
@@ -1803,7 +1803,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         "attempting to kill a single instance" in {
           implicit val killer = mock[TaskKiller]
           val f = Fixture()
-          val runSpec = AppDefinition(id = "/id1".toRootPath, versionInfo = VersionInfo.OnlyVersion(f.clock.now()), role = "*")
+          val runSpec = AppDefinition(id = "/id1".toAbsolutePath, versionInfo = VersionInfo.OnlyVersion(f.clock.now()), role = "*")
           val instanceId = Instance.Id.fromIdString("id1.instance-a905036a-f6ed-11e8-9688-2a978491fd64")
           val instance = Instance(
             instanceId, Some(Instance.AgentInfo("", None, None, None, Nil)),
@@ -1842,7 +1842,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
         }
         "attempting to kill multiple instances" in {
           implicit val killer = mock[TaskKiller]
-          val runSpec = AppDefinition(id = "/id1".toRootPath, unreachableStrategy = UnreachableStrategy.default(), role = "*")
+          val runSpec = AppDefinition(id = "/id1".toAbsolutePath, unreachableStrategy = UnreachableStrategy.default(), role = "*")
           val instances = Seq(
             Instance(Instance.Id.forRunSpec(runSpec.id), Some(Instance.AgentInfo("", None, None, None, Nil)),
               InstanceState(Condition.Running, Timestamp.now(), Some(Timestamp.now()), None, Goal.Running), Map.empty,

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -52,7 +52,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
   "QueueResource" should {
     "return well formatted JSON" in new Fixture {
       //given
-      val app = AppDefinition(id = "app".toRootPath, acceptedResourceRoles = Set("*"), role = "*")
+      val app = AppDefinition(id = "app".toAbsolutePath, acceptedResourceRoles = Set("*"), role = "*")
       val noMatch = OfferMatchResult.NoMatch(
         app,
         MarathonTestHelper.makeBasicOffer().build(),
@@ -101,7 +101,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
 
     "the generated info from the queue contains 0 if there is no delay" in new Fixture {
       //given
-      val app = AppDefinition(id = "app".toRootPath, role = "*")
+      val app = AppDefinition(id = "app".toAbsolutePath, role = "*")
       stats.getStatistics() returns Future.successful(Seq(
         QueuedInstanceInfoWithStatistics(
           app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
@@ -138,7 +138,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
 
     "application backoff can be removed from the launch queue" in new Fixture {
       //given
-      val app = AppDefinition(id = "app".toRootPath, role = "*")
+      val app = AppDefinition(id = "app".toAbsolutePath, role = "*")
       val instances = Seq.fill(23)(Instance.scheduled(app))
       instanceTracker.specInstances(any, Matchers.eq(false))(any) returns Future.successful(instances)
       groupManager.runSpec(app.id) returns Some(app)
@@ -174,7 +174,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       val req = auth.request
 
       When("one delay is reset")
-      val app = AppDefinition(id = "app".toRootPath, role = "*")
+      val app = AppDefinition(id = "app".toAbsolutePath, role = "*")
       val instances = Seq.fill(23)(Instance.scheduled(app))
       instanceTracker.specInstances(any, Matchers.eq(false))(any) returns Future.successful(instances)
       groupManager.runSpec(app.id) returns Some(app)

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -75,7 +75,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
   "SpecInstancesResource" should {
     "deleteMany" in new Fixture {
-      val appId = "/my/app".toRootPath
+      val appId = "/my/app".toAbsolutePath
       val host = "host"
       val clock = new SettableClock()
       val instance1 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, now = clock.now(), version = clock.now()).addTaskStaged().getInstance()
@@ -143,7 +143,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
     "deleteMany with wipe delegates to taskKiller with wipe value" in new Fixture {
       val appId = "/my/app"
       val host = "host"
-      healthCheckManager.statuses(appId.toRootPath) returns Future.successful(collection.immutable.Map.empty)
+      healthCheckManager.statuses(appId.toAbsolutePath) returns Future.successful(collection.immutable.Map.empty)
       taskKiller.kill(any, any, any)(any) returns Future.successful(Seq.empty[Instance])
 
       val response = asyncRequest { r =>
@@ -348,7 +348,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
       Given("the app does not exist")
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
-      groupManager.app("/app".toRootPath) returns None
+      groupManager.app("/app".toAbsolutePath) returns None
 
       When("the indexJson is fetched")
       val indexJson = asyncRequest { r => appsTaskResource.indexJson("/app", req, r) }
@@ -364,7 +364,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
       Given("the app exists")
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
-      groupManager.app("/app".toRootPath) returns Some(AppDefinition("/app".toRootPath, role = "*"))
+      groupManager.app("/app".toAbsolutePath) returns Some(AppDefinition("/app".toAbsolutePath, role = "*"))
 
       When("the indexJson is fetched")
       val indexJson = asyncRequest { r => appsTaskResource.indexJson("/app", req, r) }
@@ -380,7 +380,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
 
       Given("the group does not exist")
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
-      groupManager.group("/group".toRootPath) returns None
+      groupManager.group("/group".toAbsolutePath) returns None
 
       When("the indexJson is fetched")
       val indexJson = asyncRequest { r => appsTaskResource.indexJson("/group/*", req, r) }
@@ -395,7 +395,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val req = auth.request
 
       Given("the group exists")
-      val groupPath = "/group".toRootPath
+      val groupPath = "/group".toAbsolutePath
       groupManager.group(groupPath) returns Some(createGroup(groupPath))
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
@@ -412,7 +412,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val req = auth.request
 
       Given("The app exists")
-      groupManager.app("/app".toRootPath) returns Some(AppDefinition("/app".toRootPath, role = "*"))
+      groupManager.app("/app".toAbsolutePath) returns Some(AppDefinition("/app".toAbsolutePath, role = "*"))
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
@@ -428,7 +428,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val req = auth.request
 
       Given("The app not exists")
-      groupManager.app("/app".toRootPath) returns None
+      groupManager.app("/app".toAbsolutePath) returns None
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
@@ -447,7 +447,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val taskId = Task.Id(instanceId)
 
       Given("The app exists")
-      groupManager.runSpec("/app".toRootPath) returns Some(AppDefinition(appId, role = "*"))
+      groupManager.runSpec("/app".toAbsolutePath) returns Some(AppDefinition(appId, role = "*"))
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("deleteOne is called")
@@ -468,7 +468,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val taskId = Task.Id(instanceId)
 
       Given("The app not exists")
-      groupManager.runSpec("/app".toRootPath) returns None
+      groupManager.runSpec("/app".toAbsolutePath) returns None
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("deleteOne is called")
@@ -486,7 +486,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val req = auth.request
 
       Given("The app exists")
-      groupManager.runSpec("/app".toRootPath) returns Some(AppDefinition("/app".toRootPath, role = "*"))
+      groupManager.runSpec("/app".toAbsolutePath) returns Some(AppDefinition("/app".toAbsolutePath, role = "*"))
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("deleteMany is called")
@@ -504,7 +504,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val req = auth.request
 
       Given("The app not exists")
-      groupManager.runSpec("/app".toRootPath) returns None
+      groupManager.runSpec("/app".toAbsolutePath) returns None
 
       When("deleteMany is called")
       val deleteMany = asyncRequest { r =>

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -53,7 +53,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
     "list (txt) tasks with less ports than the current app version" in new Fixture {
       // Regression test for #234
       Given("one app with one task with less ports than required")
-      val app = AppDefinition("/foo".toRootPath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)), cmd = Some("sleep"), role = "*")
+      val app = AppDefinition("/foo".toAbsolutePath, portDefinitions = Seq(PortDefinition(0), PortDefinition(0)), cmd = Some("sleep"), role = "*")
 
       val instance = TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance()
 
@@ -92,8 +92,8 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
     "killTasks" in new Fixture {
       Given("two apps and 1 task each")
-      val app1 = "/my/app-1".toRootPath
-      val app2 = "/my/app-2".toRootPath
+      val app1 = "/my/app-1".toAbsolutePath
+      val app2 = "/my/app-2".toAbsolutePath
 
       val instance1 = TestInstanceBuilder.newBuilder(app1).addTaskStaged().getInstance()
       val instance2 = TestInstanceBuilder.newBuilder(app2).addTaskStaged().getInstance()
@@ -131,7 +131,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
     "try to kill pod instances" in new Fixture {
       Given("two apps and 1 task each")
-      val pod1 = "/pod".toRootPath
+      val pod1 = "/pod".toAbsolutePath
 
       val instance = TestInstanceBuilder.newBuilder(pod1).addTaskRunning(Some("container1")).getInstance()
 
@@ -159,8 +159,8 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
     "killTasks with force" in new Fixture {
       Given("two apps and 1 task each")
-      val app1 = "/my/app-1".toRootPath
-      val app2 = "/my/app-2".toRootPath
+      val app1 = "/my/app-1".toAbsolutePath
+      val app2 = "/my/app-2".toAbsolutePath
 
       val instance1 = TestInstanceBuilder.newBuilder(app1).addTaskRunning().getInstance()
       val instance2 = TestInstanceBuilder.newBuilder(app2).addTaskStaged().getInstance()
@@ -198,7 +198,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
     "killTasks with scale and wipe fails" in new Fixture {
       Given("a request")
-      val app1 = "/my/app-1".toRootPath
+      val app1 = "/my/app-1".toAbsolutePath
       val instance1 = Instance.Id.forRunSpec(app1)
       val taskId1 = Task.Id(instance1).idString
       val body = s"""{"ids": ["$taskId1"]}"""
@@ -215,7 +215,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
     "killTasks with wipe delegates to taskKiller with wipe value" in new Fixture {
 
       Given("a task that shall be killed")
-      val app1 = "/my/app-1".toRootPath
+      val app1 = "/my/app-1".toAbsolutePath
       val instance1 = TestInstanceBuilder.newBuilder(app1).addTaskRunning().getInstance()
       val List(taskId1) = instance1.tasksMap.keys.toList
       val body = s"""{"ids": ["${taskId1.idString}"]}"""
@@ -246,7 +246,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       Given("An unauthenticated request")
       auth.authenticated = false
       val req = auth.request
-      val appId = "/my/app".toRootPath
+      val appId = "/my/app".toAbsolutePath
       val instance1 = Instance.Id.forRunSpec(appId)
       val instance2 = Instance.Id.forRunSpec(appId)
       val instance3 = Instance.Id.forRunSpec(appId)
@@ -268,7 +268,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       Given("An unauthenticated request")
       auth.authenticated = false
       val req = auth.request
-      val appId = "/my/app".toRootPath
+      val appId = "/my/app".toAbsolutePath
       val instance1 = Instance.Id.forRunSpec(appId)
       val instance2 = Instance.Id.forRunSpec(appId)
       val instance3 = Instance.Id.forRunSpec(appId)
@@ -307,7 +307,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       auth.authenticated = true
       auth.authorized = false
       val req = auth.request
-      val appId = "/my/app".toRootPath
+      val appId = "/my/app".toAbsolutePath
       val instance1 = Instance.Id.forRunSpec(appId)
       val instance2 = Instance.Id.forRunSpec(appId)
       val instance3 = Instance.Id.forRunSpec(appId)
@@ -344,7 +344,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
     "killTasks fails for invalid taskId" in new Fixture {
       Given("a valid and an invalid taskId")
-      val app1 = "/my/app-1".toRootPath
+      val app1 = "/my/app-1".toAbsolutePath
       val instance1 = Instance.Id.forRunSpec(app1)
       val taskId1 = Task.Id(instance1).idString
       val body = s"""{"ids": ["$taskId1", "invalidTaskId"]}"""

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -26,7 +26,7 @@ class AppDefinitionFormatsTest extends UnitTest
 
   object Fixture {
     val a1 = AppDefinition(
-      id = "app1".toRootPath,
+      id = "app1".toAbsolutePath,
       role = "*",
       cmd = Some("sleep 10"),
       versionInfo = VersionInfo.OnlyVersion(Timestamp(1))
@@ -558,7 +558,7 @@ class AppDefinitionFormatsTest extends UnitTest
 
     "app with readinessCheck passes validation" in {
       val app = AppDefinition(
-        id = "test".toRootPath,
+        id = "test".toAbsolutePath,
         role = "*",
         cmd = Some("sleep 1234"),
         readinessChecks = Seq(

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -37,23 +37,23 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
 
   "AppDefinition" should {
     "Validation" in {
-      var app = AppDefinition(id = "a b".toRootPath, role = "*")
+      var app = AppDefinition(id = "a b".toAbsolutePath, role = "*")
       val idError = "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'"
       validator(app) should haveViolations("/id" -> idError)
 
-      app = app.copy(id = "a#$%^&*b".toRootPath)
+      app = app.copy(id = "a#$%^&*b".toAbsolutePath)
       validator(app) should haveViolations("/id" -> idError)
 
-      app = app.copy(id = "-dash-disallowed-at-start".toRootPath)
+      app = app.copy(id = "-dash-disallowed-at-start".toAbsolutePath)
       validator(app) should haveViolations("/id" -> idError)
 
-      app = app.copy(id = "dash-disallowed-at-end-".toRootPath)
+      app = app.copy(id = "dash-disallowed-at-end-".toAbsolutePath)
       validator(app) should haveViolations("/id" -> idError)
 
-      app = app.copy(id = "uppercaseLettersNoGood".toRootPath)
+      app = app.copy(id = "uppercaseLettersNoGood".toAbsolutePath)
       validator(app) should haveViolations("/id" -> idError)
 
-      val correct = AppDefinition(id = "test".toRootPath, role = "*")
+      val correct = AppDefinition(id = "test".toAbsolutePath, role = "*")
 
       app = correct.copy(
         role = "aRole",
@@ -479,7 +479,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
     "Read app with container definition and port mappings" in {
 
       val app4 = AppDefinition(
-        id = "bridged-webapp".toRootPath,
+        id = "bridged-webapp".toAbsolutePath,
         role = "*",
         cmd = Some("python3 -m http.server 8080"),
         networks = Seq(BridgeNetwork()), container = Some(Docker(
@@ -516,7 +516,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
     "Read app with fetch definition" in {
 
       val app = AppDefinition(
-        id = "app-with-fetch".toRootPath,
+        id = "app-with-fetch".toAbsolutePath,
         role = "*",
         cmd = Some("brew update"),
         fetch = Seq(
@@ -622,7 +622,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
 
     "Read app with labeled virtual network and discovery info" in {
       val app = AppDefinition(
-        id = "app-with-ip-address".toRootPath,
+        id = "app-with-ip-address".toAbsolutePath,
         role = "*",
         cmd = Some("python3 -m http.server 8080"),
         networks = Seq(ContainerNetwork(
@@ -668,7 +668,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
 
     "Read app with ip address without discovery info" in {
       val app = AppDefinition(
-        id = "app-with-ip-address".toRootPath,
+        id = "app-with-ip-address".toAbsolutePath,
         role = "*",
         cmd = Some("python3 -m http.server 8080"),
         container = Some(state.Container.Mesos(portMappings = Seq(Container.PortMapping.defaultInstance))), portDefinitions = Nil,
@@ -705,7 +705,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
 
     "Read app with ip address and an empty ports list" in {
       val app = AppDefinition(
-        id = "app-with-network-isolation".toRootPath,
+        id = "app-with-network-isolation".toAbsolutePath,
         role = "*",
         cmd = Some("python3 -m http.server 8080"),
         container = Some(state.Container.Mesos(portMappings = Seq(Container.PortMapping.defaultInstance))),

--- a/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
@@ -22,7 +22,7 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       Given("An empty group with updates")
       val rootGroup = createRootGroup()
       val update = GroupUpdate(
-        Some(PathId.empty.toString),
+        Some(PathId.root.toString),
         Some(Set.empty[App]),
         Some(Set(
           GroupUpdate(
@@ -36,18 +36,18 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       val timestamp = Timestamp.now()
 
       When("The update is performed")
-      val normalized = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.empty).normalized(update)
+      val normalized = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.root).normalized(update)
       val result: Group = Raml.fromRaml(GroupConversion(normalized, rootGroup, timestamp) -> appConversionFunc)
 
       validate(RootGroup.fromGroup(result))(RootGroup.validRootGroup(noEnabledFeatures)).isSuccess should be(true)
 
       Then("The update is applied correctly")
-      result.id should be(PathId.empty)
+      result.id should be(PathId.root)
       result.groupsById should have size 2
-      val test = result.group("test".toRootPath)
+      val test = result.group("test".toAbsolutePath)
       test should be('defined)
       test.get.groupsById should have size 1
-      val apps = result.group("apps".toRootPath)
+      val apps = result.group("apps".toAbsolutePath)
       apps should be('defined)
       apps.get.apps should have size 1
       val app = apps.get.apps.head
@@ -63,7 +63,7 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
         createGroup("/apps".toPath, groups = Set(createGroup("/apps/foo".toPath)))
       ))
       val update = GroupUpdate(
-        Some(PathId.empty.toString),
+        Some(PathId.root.toString),
         Some(Set.empty[App]),
         Some(Set(
           GroupUpdate(
@@ -81,20 +81,20 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       val timestamp = Timestamp.now()
 
       When("The update is performed")
-      val normalized = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.empty).normalized(update)
+      val normalized = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.root).normalized(update)
       val result: RootGroup = RootGroup.fromGroup(Raml.fromRaml(
         GroupConversion(normalized, actual, timestamp) -> appConversionFunc))
 
       validate(result)(RootGroup.validRootGroup(noEnabledFeatures)).isSuccess should be(true)
 
       Then("The update is applied correctly")
-      result.id should be(PathId.empty)
+      result.id should be(PathId.root)
       result.groupsById should have size 2
-      val test = result.group("test".toRootPath)
+      val test = result.group("test".toAbsolutePath)
       test should be('defined)
       test.get.groupsById should have size 1
       test.get.apps should have size 1
-      val apps = result.group("apps".toRootPath)
+      val apps = result.group("apps".toAbsolutePath)
       apps should be('defined)
       apps.get.groupsById should have size 1
       apps.get.apps should have size 1
@@ -169,7 +169,7 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
 
     "Relative path of a dependency, should be relative to group and not to the app" in {
       Given("A group with two apps. Second app is dependend of first.")
-      val update = GroupUpdate(Some(PathId.empty.toString), Some(Set.empty[App]), Some(Set(
+      val update = GroupUpdate(Some(PathId.root.toString), Some(Set.empty[App]), Some(Set(
         GroupUpdate(
           Some("test-group"),
           Some(Set(
@@ -179,14 +179,14 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       )))
 
       When("The update is performed")
-      val normalized = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.empty).normalized(update)
+      val normalized = GroupNormalization.updateNormalization(noEnabledFeatures, PathId.root).normalized(update)
       val result = Raml.fromRaml(
         GroupConversion(normalized, createRootGroup(), Timestamp.now()) -> appConversionFunc)
 
       validate(RootGroup.fromGroup(result))(RootGroup.validRootGroup(noEnabledFeatures)).isSuccess should be(true)
 
       Then("The update is applied correctly")
-      val group = result.group("test-group".toRootPath)
+      val group = result.group("test-group".toAbsolutePath)
       group should be('defined)
       group.get.apps should have size 2
       val dependentApp = group.get.app("/test-group/test-app2".toPath).get

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -236,8 +236,8 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       val f = new Fixture
       Given("One related and one unrelated deployment")
       val emptyRootGroup = createRootGroup()
-      val relatedDeployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.empty, _ => Map(app.id -> app), emptyRootGroup.version))
-      val unrelatedDeployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.empty, _ => Map(other.id -> other), emptyRootGroup.version))
+      val relatedDeployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.root, _ => Map(app.id -> app), emptyRootGroup.version))
+      val unrelatedDeployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.root, _ => Map(other.id -> other), emptyRootGroup.version))
       f.marathonSchedulerService.listRunningDeployments() returns Future.successful(Seq[DeploymentStepInfo](
         DeploymentStepInfo(relatedDeployment, DeploymentStep(Seq.empty), 1),
         DeploymentStepInfo(unrelatedDeployment, DeploymentStep(Seq.empty), 1)
@@ -284,7 +284,7 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       val f = new Fixture
       Given("One related and one unrelated deployment")
       val emptyRootGroup = createRootGroup()
-      val deployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.empty, _ => Map(app.id -> app), emptyRootGroup.version))
+      val deployment = DeploymentPlan(emptyRootGroup, emptyRootGroup.updateApps(PathId.root, _ => Map(app.id -> app), emptyRootGroup.version))
       val instanceId = Instance.Id.forRunSpec(app.id)
       val taskId: Task.Id = Task.Id(instanceId)
       val result = ReadinessCheckResult("foo", taskId, ready = false, None)

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
@@ -216,7 +216,7 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     "Selecting with App Selector implicitly gives access to parent groups" in {
       Given("a nested group with access to only nested app /group/app1")
       val f = new Fixture
-      val rootId = PathId.empty
+      val rootId = PathId.root
       val rootApp = AppDefinition(PathId("/app"), cmd = Some("sleep"), role = "*")
       val nestedApp1 = AppDefinition(PathId("/group/app1"), cmd = Some("sleep"), role = "*")
       val nestedApp2 = AppDefinition(PathId("/group/app2"), cmd = Some("sleep"), role = "*")

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -323,7 +323,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val appNew = app.copy(args = Seq("foo"))
 
       val from = createRootGroup(apps = Map(app.id -> app))
-      val to = from.updateApps(PathId.empty, _ => Map(appNew.id -> appNew), from.version)
+      val to = from.updateApps(PathId.root, _ => Map(appNew.id -> appNew), from.version)
 
       val plan = DeploymentPlan(from, to)
 
@@ -342,7 +342,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val appNew = app.copy(instances = 1) // no change
 
       val from = createRootGroup(apps = Map(app.id -> app))
-      val to = from.updateApps(PathId.empty, _ => Map(appNew.id -> appNew), from.version)
+      val to = from.updateApps(PathId.root, _ => Map(appNew.id -> appNew), from.version)
 
       DeploymentPlan(from, to) should be(empty)
     }
@@ -357,7 +357,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val appNew = app.markedForRestarting
 
       val from = createRootGroup(apps = Map(app.id -> app))
-      val to = from.updateApps(PathId.empty, _ => Map(appNew.id -> appNew), from.version)
+      val to = from.updateApps(PathId.root, _ => Map(appNew.id -> appNew), from.version)
 
       DeploymentPlan(from, to).steps should have size 1
       DeploymentPlan(from, to).steps.head should be(DeploymentStep(Seq(RestartApplication(appNew))))
@@ -402,7 +402,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
       When("We create a scale deployment")
       val app = f.validResident.copy(instances = 123)
-      val rootGroup = f.rootGroup.updateApps(PathId.empty, _ => Map(app.id -> app), f.rootGroup.version)
+      val rootGroup = f.rootGroup.updateApps(PathId.root, _ => Map(app.id -> app), f.rootGroup.version)
       val plan = DeploymentPlan(f.rootGroup, rootGroup)
 
       Then("The deployment is valid")

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentManagerActorTest.scala
@@ -41,7 +41,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"), role = ResourceRole.Unreserved)
+      val app = AppDefinition("app".toAbsolutePath, cmd = Some("sleep"), role = ResourceRole.Unreserved)
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -56,7 +56,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Finished deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"), role = ResourceRole.Unreserved)
+      val app = AppDefinition("app".toAbsolutePath, cmd = Some("sleep"), role = ResourceRole.Unreserved)
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -76,7 +76,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
 
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"), role = "*")
+      val app = AppDefinition("app".toAbsolutePath, cmd = Some("sleep"), role = "*")
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -93,7 +93,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Conflicting not forced deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"), role = "*")
+      val app = AppDefinition("app".toAbsolutePath, cmd = Some("sleep"), role = "*")
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -115,7 +115,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Conflicting forced deployment" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"), role = "*")
+      val app = AppDefinition("app".toAbsolutePath, cmd = Some("sleep"), role = "*")
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -137,7 +137,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Multiple conflicting forced deployments" in {
       val f = new Fixture
       val manager = f.deploymentManager()
-      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"), role = "*")
+      val app = AppDefinition("app".toAbsolutePath, cmd = Some("sleep"), role = "*")
 
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
@@ -187,7 +187,7 @@ class DeploymentManagerActorTest extends AkkaUnitTest with ImplicitSender with G
       val f = new Fixture
       val manager = f.deploymentManager()
 
-      val app = AppDefinition("app".toRootPath, cmd = Some("sleep"), role = "*")
+      val app = AppDefinition("app".toAbsolutePath, cmd = Some("sleep"), role = "*")
       val oldGroup = createRootGroup()
       val newGroup = createRootGroup(Map(app.id -> app))
       val plan = DeploymentPlan(oldGroup, newGroup)

--- a/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/event/impl/stream/HttpEventSSEHandleTest.scala
@@ -86,7 +86,7 @@ class HttpEventSSEHandleTest extends UnitTest with GroupCreation {
     }
   }
 
-  val app = AppDefinition("app".toRootPath, role = "*", cmd = Some("sleep"))
+  val app = AppDefinition("app".toAbsolutePath, role = "*", cmd = Some("sleep"))
   val oldGroup = createRootGroup()
   val newGroup = createRootGroup(Map(app.id -> app))
   val plan = DeploymentPlan(oldGroup, newGroup)

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -50,7 +50,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       groupRepository.root() returns Future.successful(createRootGroup())
 
       intercept[ValidationFailedException] {
-        throw groupManager.updateRoot(PathId.empty, _.putGroup(rootGroup, rootGroup.version), rootGroup.version, force = false).failed.futureValue
+        throw groupManager.updateRoot(PathId.root, _.putGroup(rootGroup, rootGroup.version), rootGroup.version, force = false).failed.futureValue
       }
 
       verify(groupRepository, times(0)).storeRoot(any, any, any, any, any)
@@ -91,13 +91,13 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
           ???
       }
 
-      groupManager.updateRoot(PathId.empty, _.putGroup(group, version = Timestamp(1)), version = Timestamp(1), force = false).futureValue
+      groupManager.updateRoot(PathId.root, _.putGroup(group, version = Timestamp(1)), version = Timestamp(1), force = false).futureValue
       verify(groupRepository).storeRoot(groupWithVersionInfo, Seq(appWithAdditionalInfo), Nil, Nil, Nil)
       verify(groupRepository).storeRootVersion(groupWithVersionInfo, Seq(appWithAdditionalInfo), Nil)
 
       groupChangeSuccess.future.
         futureValue.
-        groupId shouldBe PathId.empty
+        groupId shouldBe PathId.root
     }
 
     "store new apps with correct version infos in groupRepo and appRepo" in new Fixture {
@@ -116,7 +116,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       groupRepository.storeRootVersion(any, any, any) returns Future.successful(Done)
       groupRepository.storeRoot(any, any, any, any, any) returns Future.successful(Done)
 
-      groupManager.updateRoot(PathId.empty, _.putGroup(rootGroup, version = Timestamp(1)), version = Timestamp(1), force = false).futureValue
+      groupManager.updateRoot(PathId.root, _.putGroup(rootGroup, version = Timestamp(1)), version = Timestamp(1), force = false).futureValue
 
       verify(groupRepository).storeRoot(groupWithVersionInfo, Seq(appWithAdditionalInfo), Nil, Nil, Nil)
       verify(groupRepository).storeRootVersion(groupWithVersionInfo, Seq(appWithAdditionalInfo), Nil)
@@ -132,7 +132,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       groupRepository.storeRootVersion(any, any, any) returns Future.successful(Done)
       groupRepository.storeRoot(any, any, any, any, any) returns Future.successful(Done)
 
-      groupManager.updateRoot(PathId.empty, _.putGroup(groupEmpty, version = Timestamp(1)), Timestamp(1), force = false).futureValue
+      groupManager.updateRoot(PathId.root, _.putGroup(groupEmpty, version = Timestamp(1)), Timestamp(1), force = false).futureValue
       verify(groupRepository).storeRootVersion(groupEmpty, Nil, Nil)
       verify(groupRepository).storeRoot(groupEmpty, Nil, Seq("/app1".toPath), Nil, Nil)
     }
@@ -146,7 +146,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
       deploymentService.listRunningDeployments() returns Future.successful(running)
 
       intercept[TooManyRunningDeploymentsException] {
-        throw groupManager.updateRoot(PathId.empty, _.putGroup(rootGroup, rootGroup.version), rootGroup.version, force = false).failed.futureValue
+        throw groupManager.updateRoot(PathId.root, _.putGroup(rootGroup, rootGroup.version), rootGroup.version, force = false).failed.futureValue
       }
 
     }

--- a/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/impl/AssignDynamicServiceLogicTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.test.GroupCreation
 class AssignDynamicServiceLogicTest extends AkkaUnitTest with GroupCreation {
   "applications with port definitions" when {
     "apps with port definitions should map dynamic ports to a non-0 value" in {
-      val app = AppDefinition("/app".toRootPath, role = "*", portDefinitions = Seq(PortDefinition(0), PortDefinition(1)), cmd = Some("sleep"))
+      val app = AppDefinition("/app".toAbsolutePath, role = "*", portDefinitions = Seq(PortDefinition(0), PortDefinition(1)), cmd = Some("sleep"))
       val rootGroup = createRootGroup(Map(app.id -> app))
       val update = AssignDynamicServiceLogic.assignDynamicServicePorts(10.to(20), createRootGroup(), rootGroup)
       update.apps(app.id).portDefinitions.size should equal(2)

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -33,7 +33,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
     """akka.loggers = ["akka.testkit.TestEventListener"]"""
   )
 
-  private val appId = "test".toRootPath
+  private val appId = "test".toAbsolutePath
   private val clock = new SettableClock()
 
   case class Fixture() {
@@ -251,7 +251,7 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
         instanceTracker.forceExpunge(instance.instanceId).futureValue
 
       // one other task of another app
-      val otherAppId = "other".toRootPath
+      val otherAppId = "other".toAbsolutePath
       val otherHealthChecks = Set[HealthCheck](MesosCommandHealthCheck(gracePeriod = 0.seconds, command = Command("true")))
       val (otherInstance, otherApp) = startInstance(otherAppId, Timestamp(42), otherHealthChecks)
 

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -537,7 +537,7 @@ object PodStatusConversionTest {
   } // fakeInstance
 
   def fakeTask(networks: Seq[Protos.NetworkInfo]) = {
-    val instanceId = core.instance.Instance.Id.forRunSpec(PathId.empty)
+    val instanceId = core.instance.Instance.Id.forRunSpec(PathId.root)
     val taskId = core.task.Task.Id(instanceId)
     core.task.Task(
       taskId = taskId,

--- a/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
@@ -25,19 +25,30 @@ class PathIdTest extends UnitTest with ValidationTestLike {
       val reference = PathId("/")
 
       Then("the path is equal")
-      PathId.empty should be(reference)
+      PathId.root should be(reference)
     }
 
     "parse safePath from itself" in {
       When("The path is empty")
-      PathId.fromSafePath(PathId.empty.safePath) should equal(PathId.empty)
+      PathId.fromSafePath(PathId.root.safePath) should equal(PathId.root)
 
       When("The path isn't empty")
       val reference = PathId("a" :: "b" :: "c" :: "d" :: Nil)
       PathId.fromSafePath(reference.safePath) should equal(reference)
     }
 
-    "be written and parsed from string" in {
+    "absolute be written and parsed from string" in {
+      Given("An absolute base id")
+      val path = PathId("/a/b/c/d")
+
+      When("The same path serialized to string and de-serialized again")
+      val reference = PathId(path.toString)
+
+      Then("the path is equal")
+      path should be(reference)
+    }
+
+    "relative be written and parsed from string" in {
       Given("A base id")
       val path = PathId("a/b/c/d")
 
@@ -50,7 +61,7 @@ class PathIdTest extends UnitTest with ValidationTestLike {
 
     "compute the canonical path when path is relative" in {
       Given("A base id")
-      val id = PathId("/a/b/c/d")
+      val id = AbsolutePathId("/a/b/c/d")
 
       When("a relative path is canonized")
       val path = PathId("./test/../e/f/g/./../").canonicalPath(id)
@@ -94,7 +105,7 @@ class PathIdTest extends UnitTest with ValidationTestLike {
       Given("base id's")
       val id1 = PathId("/a/b/c")
       val id2 = PathId("/a")
-      val id3 = PathId.empty
+      val id3 = PathId.root
 
       When("taskTrackerRef ids get computed")
       val parent1 = id1.parent
@@ -103,15 +114,15 @@ class PathIdTest extends UnitTest with ValidationTestLike {
 
       Then("the taskTrackerRef path is correct")
       parent1 should be(PathId("/a/b"))
-      parent2 should be(PathId.empty)
-      parent3 should be(PathId.empty)
+      parent2 should be(PathId.root)
+      parent3 should be(PathId.root)
     }
 
     "convert to a hostname" in {
       Given("base id's")
       val id1 = PathId("/a/b/c")
       val id2 = PathId("/a")
-      val id3 = PathId.empty
+      val id3 = PathId.root
 
       When("hostnames get computed")
       val host1 = id1.toHostname
@@ -127,7 +138,8 @@ class PathIdTest extends UnitTest with ValidationTestLike {
   "PathIds" should {
     "handles root paths" in {
       PathId("/").isRoot shouldBe true
-      PathId("").isRoot shouldBe true
+      PathId("").isEmpty shouldBe true
+      PathId("").isRoot shouldBe false
     }
 
     "match another PathId" in {

--- a/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GcActorTest.scala
@@ -148,7 +148,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       "complete stores immediately and stay idle" in {
         val f = Fixture(2)()()
         val appPromise = Promise[Done]()
-        f.actor ! StoreApp("root".toRootPath, None, appPromise)
+        f.actor ! StoreApp("root".toAbsolutePath, None, appPromise)
         appPromise.future.isCompleted should equal(true)
         f.actor.stateName should be(ReadyForGc)
       }
@@ -158,42 +158,42 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Scanning, UpdatedEntities())
         val appPromise = Promise[Done]()
-        f.actor ! StoreApp("root".toRootPath, None, appPromise)
+        f.actor ! StoreApp("root".toAbsolutePath, None, appPromise)
         appPromise.future.isCompleted should be(true)
-        f.actor.stateData should equal(UpdatedEntities(appsStored = Set("root".toRootPath)))
+        f.actor.stateData should equal(UpdatedEntities(appsStored = Set("root".toAbsolutePath)))
       }
       "track app version stores" in {
         val f = Fixture(2)()()
         f.actor.setState(Scanning, UpdatedEntities())
         val appPromise = Promise[Done]()
         val now = OffsetDateTime.now()
-        f.actor ! StoreApp("root".toRootPath, Some(now), appPromise)
+        f.actor ! StoreApp("root".toAbsolutePath, Some(now), appPromise)
         appPromise.future.isCompleted should be(true)
-        f.actor.stateData should equal(UpdatedEntities(appVersionsStored = Map("root".toRootPath -> Set(now))))
+        f.actor.stateData should equal(UpdatedEntities(appVersionsStored = Map("root".toAbsolutePath -> Set(now))))
       }
       "track pod stores" in {
         val f = Fixture(2)()()
         f.actor.setState(Scanning, UpdatedEntities())
         val promise = Promise[Done]()
-        f.actor ! StorePod("root".toRootPath, None, promise)
+        f.actor ! StorePod("root".toAbsolutePath, None, promise)
         promise.future.isCompleted should be(true)
-        f.actor.stateData should equal(UpdatedEntities(podsStored = Set("root".toRootPath)))
+        f.actor.stateData should equal(UpdatedEntities(podsStored = Set("root".toAbsolutePath)))
       }
       "track pod version stores" in {
         val f = Fixture(2)()()
         f.actor.setState(Scanning, UpdatedEntities())
         val promise = Promise[Done]()
         val now = OffsetDateTime.now()
-        f.actor ! StorePod("root".toRootPath, Some(now), promise)
+        f.actor ! StorePod("root".toAbsolutePath, Some(now), promise)
         promise.future.isCompleted should be(true)
-        f.actor.stateData should equal(UpdatedEntities(podVersionsStored = Map("root".toRootPath -> Set(now))))
+        f.actor.stateData should equal(UpdatedEntities(podVersionsStored = Map("root".toAbsolutePath -> Set(now))))
       }
       "track root stores" in {
         val f = Fixture(2)()()
         f.actor.setState(Scanning, UpdatedEntities())
         val rootPromise = Promise[Done]()
         val now = OffsetDateTime.now()
-        val root = StoredGroup("/".toRootPath, Map("a".toRootPath -> now), Map.empty, Nil, Set.empty, now, None)
+        val root = StoredGroup("/".toAbsolutePath, Map("a".toAbsolutePath -> now), Map.empty, Nil, Set.empty, now, None)
         f.actor ! StoreRoot(root, rootPromise)
         rootPromise.future.isCompleted should be(true)
         f.actor.stateData should equal(UpdatedEntities(appVersionsStored = root.appIds.mapValues(Set(_)), rootsStored = Set(now)))
@@ -202,10 +202,10 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(5)()()
         f.actor.setState(Scanning, UpdatedEntities())
         val deployPromise = Promise[Done]()
-        val app1 = AppDefinition("a".toRootPath, role = "*", cmd = Some("sleep"))
-        val app2 = AppDefinition("b".toRootPath, role = "*", cmd = Some("sleep"))
-        val root1 = createRootGroup(Map("a".toRootPath -> app1))
-        val root2 = createRootGroup(Map("b".toRootPath -> app2))
+        val app1 = AppDefinition("a".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val app2 = AppDefinition("b".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val root1 = createRootGroup(Map("a".toAbsolutePath -> app1))
+        val root2 = createRootGroup(Map("b".toAbsolutePath -> app2))
         f.actor ! StorePlan(DeploymentPlan(root1, root2, Timestamp.now()), deployPromise)
         deployPromise.future.isCompleted should be(true)
         f.actor.stateData should equal(
@@ -225,12 +225,12 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(5)()(compactWaitOnSem(compactedAppIds, compactedAppVersions,
           compactedPodIds, compactedPodVersions, compactedRoots, sem))
         f.actor.setState(Scanning, UpdatedEntities())
-        val app1 = AppDefinition("a".toRootPath, role = "*", cmd = Some("sleep"))
-        val app2 = AppDefinition("b".toRootPath, role = "*", cmd = Some("sleep"))
-        val pod1 = PodDefinition("p1".toRootPath, role = "*")
-        val pod2 = PodDefinition("p2".toRootPath, role = "*")
-        val root1 = createRootGroup(Map("a".toRootPath -> app1), Map(pod1.id -> pod1))
-        val root2 = createRootGroup(Map("b".toRootPath -> app2), Map(pod2.id -> pod2))
+        val app1 = AppDefinition("a".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val app2 = AppDefinition("b".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val pod1 = PodDefinition("p1".toAbsolutePath, role = "*")
+        val pod2 = PodDefinition("p2".toAbsolutePath, role = "*")
+        val root1 = createRootGroup(Map("a".toAbsolutePath -> app1), Map(pod1.id -> pod1))
+        val root2 = createRootGroup(Map("b".toAbsolutePath -> app2), Map(pod2.id -> pod2))
         val updates = UpdatedEntities(
           appVersionsStored = Map(
             app1.id -> Set(app1.version.toOffsetDateTime),
@@ -244,33 +244,33 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
 
         val now = OffsetDateTime.MAX
         f.actor ! ScanDone(
-          appsToDelete = Set(app1.id, app2.id, "c".toRootPath),
+          appsToDelete = Set(app1.id, app2.id, "c".toAbsolutePath),
           appVersionsToDelete = Map(
             app1.id -> Set(app1.version.toOffsetDateTime, now),
             app2.id -> Set(app2.version.toOffsetDateTime, now),
-            "d".toRootPath -> Set(now)),
-          podsToDelete = Set(pod1.id, pod2.id, "p3".toRootPath),
+            "d".toAbsolutePath -> Set(now)),
+          podsToDelete = Set(pod1.id, pod2.id, "p3".toAbsolutePath),
           podVersionsToDelete = Map(
             pod1.id -> Set(pod1.version.toOffsetDateTime, now),
             pod2.id -> Set(pod2.version.toOffsetDateTime, now),
-            "p4".toRootPath -> Set(now)
+            "p4".toAbsolutePath -> Set(now)
           ),
           rootVersionsToDelete = Set(root1.version.toOffsetDateTime, root2.version.toOffsetDateTime, now))
 
         f.actor.stateName should equal(Compacting)
         f.actor.stateData should equal(BlockedEntities(
-          appsDeleting = Set("c".toRootPath),
-          appVersionsDeleting = Map(app1.id -> Set(now), app2.id -> Set(now), "d".toRootPath -> Set(now)),
-          podsDeleting = Set("p3".toRootPath),
-          podVersionsDeleting = Map(pod1.id -> Set(now), pod2.id -> Set(now), "p4".toRootPath -> Set(now)),
+          appsDeleting = Set("c".toAbsolutePath),
+          appVersionsDeleting = Map(app1.id -> Set(now), app2.id -> Set(now), "d".toAbsolutePath -> Set(now)),
+          podsDeleting = Set("p3".toAbsolutePath),
+          podVersionsDeleting = Map(pod1.id -> Set(now), pod2.id -> Set(now), "p4".toAbsolutePath -> Set(now)),
           rootsDeleting = Set(now)))
 
         sem.release()
         eventually(f.actor.stateName shouldEqual ReadyForGc)
-        compactedAppIds.get should equal(Set("c".toRootPath))
-        compactedAppVersions.get should equal(Map(app1.id -> Set(now), app2.id -> Set(now), "d".toRootPath -> Set(now)))
-        compactedPodIds.get should equal(Set("p3".toRootPath))
-        compactedPodVersions.get should equal(Map(pod1.id -> Set(now), pod2.id -> Set(now), "p4".toRootPath -> Set(now)))
+        compactedAppIds.get should equal(Set("c".toAbsolutePath))
+        compactedAppVersions.get should equal(Map(app1.id -> Set(now), app2.id -> Set(now), "d".toAbsolutePath -> Set(now)))
+        compactedPodIds.get should equal(Set("p3".toAbsolutePath))
+        compactedPodVersions.get should equal(Map(pod1.id -> Set(now), pod2.id -> Set(now), "p4".toAbsolutePath -> Set(now)))
         compactedRoots.get should equal(Set(now))
       }
     }
@@ -279,19 +279,19 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Compacting, BlockedEntities())
         val promise = Promise[Done]()
-        f.actor ! StoreApp("a".toRootPath, None, promise)
+        f.actor ! StoreApp("a".toAbsolutePath, None, promise)
         promise.future.isCompleted should be(true)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities())
       }
       "block deleted app stores until compaction completes" in {
         val f = Fixture(2)()()
-        f.actor.setState(Compacting, BlockedEntities(appsDeleting = Set("a".toRootPath)))
+        f.actor.setState(Compacting, BlockedEntities(appsDeleting = Set("a".toAbsolutePath)))
         val promise = Promise[Done]()
-        f.actor ! StoreApp("a".toRootPath, None, promise)
+        f.actor ! StoreApp("a".toAbsolutePath, None, promise)
         promise.future.isCompleted should be(false)
         f.actor.stateName should be(Compacting)
-        f.actor.stateData should be(BlockedEntities(appsDeleting = Set("a".toRootPath), promises = List(promise)))
+        f.actor.stateData should be(BlockedEntities(appsDeleting = Set("a".toAbsolutePath), promises = List(promise)))
         f.actor ! CompactDone
         promise.future.futureValue should be(Done)
       }
@@ -299,7 +299,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Compacting, BlockedEntities())
         val promise = Promise[Done]()
-        f.actor ! StoreApp("a".toRootPath, Some(OffsetDateTime.now), promise)
+        f.actor ! StoreApp("a".toAbsolutePath, Some(OffsetDateTime.now), promise)
         promise.future.isCompleted should be(true)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities())
@@ -307,13 +307,13 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       "block deleted app version stores until compaction completes" in {
         val f = Fixture(2)()()
         val now = OffsetDateTime.now()
-        f.actor.setState(Compacting, BlockedEntities(appVersionsDeleting = Map("a".toRootPath -> Set(now))))
+        f.actor.setState(Compacting, BlockedEntities(appVersionsDeleting = Map("a".toAbsolutePath -> Set(now))))
         val promise = Promise[Done]()
-        f.actor ! StoreApp("a".toRootPath, Some(now), promise)
+        f.actor ! StoreApp("a".toAbsolutePath, Some(now), promise)
         promise.future.isCompleted should be(false)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities(
-          appVersionsDeleting = Map("a".toRootPath -> Set(now)),
+          appVersionsDeleting = Map("a".toAbsolutePath -> Set(now)),
           promises = List(promise)))
         f.actor ! CompactDone
         promise.future.isCompleted should be(true)
@@ -322,19 +322,19 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Compacting, BlockedEntities())
         val promise = Promise[Done]()
-        f.actor ! StorePod("a".toRootPath, None, promise)
+        f.actor ! StorePod("a".toAbsolutePath, None, promise)
         promise.future.isCompleted should be(true)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities())
       }
       "block deleted pod stores until compaction completes" in {
         val f = Fixture(2)()()
-        f.actor.setState(Compacting, BlockedEntities(podsDeleting = Set("a".toRootPath)))
+        f.actor.setState(Compacting, BlockedEntities(podsDeleting = Set("a".toAbsolutePath)))
         val promise = Promise[Done]()
-        f.actor ! StorePod("a".toRootPath, None, promise)
+        f.actor ! StorePod("a".toAbsolutePath, None, promise)
         promise.future.isCompleted should be(false)
         f.actor.stateName should be(Compacting)
-        f.actor.stateData should be(BlockedEntities(podsDeleting = Set("a".toRootPath), promises = List(promise)))
+        f.actor.stateData should be(BlockedEntities(podsDeleting = Set("a".toAbsolutePath), promises = List(promise)))
         f.actor ! CompactDone
         promise.future.futureValue should be(Done)
       }
@@ -342,7 +342,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Compacting, BlockedEntities())
         val promise = Promise[Done]()
-        f.actor ! StorePod("a".toRootPath, Some(OffsetDateTime.now), promise)
+        f.actor ! StorePod("a".toAbsolutePath, Some(OffsetDateTime.now), promise)
         promise.future.isCompleted should be(true)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities())
@@ -350,13 +350,13 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       "block deleted pod version stores until compaction completes" in {
         val f = Fixture(2)()()
         val now = OffsetDateTime.now()
-        f.actor.setState(Compacting, BlockedEntities(podVersionsDeleting = Map("a".toRootPath -> Set(now))))
+        f.actor.setState(Compacting, BlockedEntities(podVersionsDeleting = Map("a".toAbsolutePath -> Set(now))))
         val promise = Promise[Done]()
-        f.actor ! StorePod("a".toRootPath, Some(now), promise)
+        f.actor ! StorePod("a".toAbsolutePath, Some(now), promise)
         promise.future.isCompleted should be(false)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities(
-          podVersionsDeleting = Map("a".toRootPath -> Set(now)),
+          podVersionsDeleting = Map("a".toAbsolutePath -> Set(now)),
           promises = List(promise)))
         f.actor ! CompactDone
         promise.future.isCompleted should be(true)
@@ -365,7 +365,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Compacting, BlockedEntities())
         val promise = Promise[Done]()
-        f.actor ! StoreRoot(StoredGroup("/".toRootPath, Map.empty, Map.empty, Nil, Set.empty, OffsetDateTime.now, None), promise)
+        f.actor ! StoreRoot(StoredGroup("/".toAbsolutePath, Map.empty, Map.empty, Nil, Set.empty, OffsetDateTime.now, None), promise)
         promise.future.isCompleted should be(true)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities())
@@ -375,7 +375,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val now = OffsetDateTime.now
         f.actor.setState(Compacting, BlockedEntities(rootsDeleting = Set(now)))
         val promise = Promise[Done]()
-        f.actor ! StoreRoot(StoredGroup("/".toRootPath, Map.empty, Map.empty, Nil, Set.empty, now, None), promise)
+        f.actor ! StoreRoot(StoredGroup("/".toAbsolutePath, Map.empty, Map.empty, Nil, Set.empty, now, None), promise)
         promise.future.isCompleted should be(false)
         f.actor.stateName should be(Compacting)
         f.actor.stateData should be(BlockedEntities(rootsDeleting = Set(now), promises = List(promise)))
@@ -386,10 +386,10 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val f = Fixture(2)()()
         f.actor.setState(Compacting, BlockedEntities())
         val promise = Promise[Done]()
-        val app1 = AppDefinition("a".toRootPath, role = "*", cmd = Some("sleep"))
-        val app2 = AppDefinition("b".toRootPath, role = "*", cmd = Some("sleep"))
-        val root1 = createRootGroup(Map("a".toRootPath -> app1))
-        val root2 = createRootGroup(Map("b".toRootPath -> app2))
+        val app1 = AppDefinition("a".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val app2 = AppDefinition("b".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val root1 = createRootGroup(Map("a".toAbsolutePath -> app1))
+        val root2 = createRootGroup(Map("b".toAbsolutePath -> app2))
         f.actor ! StorePlan(DeploymentPlan(root1, root2, Timestamp.now()), promise)
         // internally we send two more messages as StorePlan in compacting is the same as StoreRoot x 2
         eventually(f.actor.stateName shouldEqual Compacting)
@@ -398,13 +398,13 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "block plans with deleted roots until compaction completes" in {
         val f = Fixture(2)()()
-        val app1 = AppDefinition("a".toRootPath, role = "*", cmd = Some("sleep"))
-        val root1 = createRootGroup(Map("a".toRootPath -> app1))
+        val app1 = AppDefinition("a".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val root1 = createRootGroup(Map("a".toAbsolutePath -> app1))
 
         f.actor.setState(Compacting, BlockedEntities(rootsDeleting = Set(root1.version.toOffsetDateTime)))
         val promise = Promise[Done]()
-        val app2 = AppDefinition("b".toRootPath, role = "*", cmd = Some("sleep"))
-        val root2 = createRootGroup(Map("b".toRootPath -> app2))
+        val app2 = AppDefinition("b".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val root2 = createRootGroup(Map("b".toAbsolutePath -> app2))
         f.actor ! StorePlan(DeploymentPlan(root1, root2, Timestamp.now()), promise)
         // internally we send two more messages as StorePlan in compacting is the same as StoreRoot x 2
         eventually(f.actor.stateName shouldEqual Compacting)
@@ -474,7 +474,7 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val actor = TestFSMRef(new GcActor(metrics, deployRepo, groupRepo, appRepo, podRepo, 2, 32, 0.seconds))
         actor.setState(Scanning, UpdatedEntities())
         appRepo.delete(any) returns Future.failed(new Exception(""))
-        actor ! ScanDone(appsToDelete = Set("a".toRootPath))
+        actor ! ScanDone(appsToDelete = Set("a".toAbsolutePath))
         eventually(actor.stateName shouldEqual ReadyForGc)
       }
       "do nothing if there are less than max roots" in {
@@ -522,18 +522,18 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
       }
       "delete unused apps, pods, and roots" in {
         val f = Fixture(1)()()
-        val dApp1 = AppDefinition("a".toRootPath, role = "*", cmd = Some("sleep"))
-        val dApp2 = AppDefinition("b".toRootPath, role = "*", cmd = Some("sleep"))
+        val dApp1 = AppDefinition("a".toAbsolutePath, role = "*", cmd = Some("sleep"))
+        val dApp2 = AppDefinition("b".toAbsolutePath, role = "*", cmd = Some("sleep"))
         val dApp1V2 = dApp1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(7)))
-        val app3 = AppDefinition("c".toRootPath, role = "*", cmd = Some("sleep"))
+        val app3 = AppDefinition("c".toAbsolutePath, role = "*", cmd = Some("sleep"))
         f.appRepo.store(dApp1).futureValue
         f.appRepo.storeVersion(dApp2).futureValue
         f.appRepo.store(app3)
 
-        val dPod1 = PodDefinition("p1".toRootPath, role = "*")
-        val dPod2 = PodDefinition("p2".toRootPath, role = "*")
+        val dPod1 = PodDefinition("p1".toAbsolutePath, role = "*")
+        val dPod2 = PodDefinition("p2".toAbsolutePath, role = "*")
         val dPod1V2 = dPod1.copy(versionInfo = VersionInfo.OnlyVersion(Timestamp(7)))
-        val pod3 = PodDefinition("p3".toRootPath, role = "*")
+        val pod3 = PodDefinition("p3".toAbsolutePath, role = "*")
         f.podRepo.store(dPod1).futureValue
         f.podRepo.storeVersion(dPod2).futureValue
         f.podRepo.store(pod3)
@@ -576,14 +576,14 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
         val actor = TestFSMRef(new GcActor(metrics, deployRepo, groupRepo, appRepo, podRepo, 25, 32, 0.seconds))
         actor.setState(Scanning, UpdatedEntities())
         val scanResult = ScanDone(
-          appsToDelete = Set("a".toRootPath),
+          appsToDelete = Set("a".toAbsolutePath),
           appVersionsToDelete = Map(
-            "b".toRootPath -> Set(OffsetDateTime.MIN, OffsetDateTime.MAX),
-            "c".toRootPath -> Set(OffsetDateTime.MIN)),
-          podsToDelete = Set("d".toRootPath),
+            "b".toAbsolutePath -> Set(OffsetDateTime.MIN, OffsetDateTime.MAX),
+            "c".toAbsolutePath -> Set(OffsetDateTime.MIN)),
+          podsToDelete = Set("d".toAbsolutePath),
           podVersionsToDelete = Map(
-            "e".toRootPath -> Set(OffsetDateTime.MIN, OffsetDateTime.MAX),
-            "f".toRootPath -> Set(OffsetDateTime.MIN)
+            "e".toAbsolutePath -> Set(OffsetDateTime.MIN, OffsetDateTime.MAX),
+            "f".toAbsolutePath -> Set(OffsetDateTime.MIN)
           ),
           rootVersionsToDelete = Set(OffsetDateTime.MIN, OffsetDateTime.MAX))
 
@@ -597,14 +597,14 @@ class GcActorTest extends AkkaUnitTest with TestKitBase with GivenWhenThen with 
 
         eventually(actor.stateName shouldEqual ReadyForGc)
 
-        verify(appRepo).delete("a".toRootPath)
-        verify(appRepo).deleteVersion("b".toRootPath, OffsetDateTime.MIN)
-        verify(appRepo).deleteVersion("b".toRootPath, OffsetDateTime.MAX)
-        verify(appRepo).deleteVersion("c".toRootPath, OffsetDateTime.MIN)
-        verify(podRepo).delete("d".toRootPath)
-        verify(podRepo).deleteVersion("e".toRootPath, OffsetDateTime.MIN)
-        verify(podRepo).deleteVersion("e".toRootPath, OffsetDateTime.MAX)
-        verify(podRepo).deleteVersion("f".toRootPath, OffsetDateTime.MIN)
+        verify(appRepo).delete("a".toAbsolutePath)
+        verify(appRepo).deleteVersion("b".toAbsolutePath, OffsetDateTime.MIN)
+        verify(appRepo).deleteVersion("b".toAbsolutePath, OffsetDateTime.MAX)
+        verify(appRepo).deleteVersion("c".toAbsolutePath, OffsetDateTime.MIN)
+        verify(podRepo).delete("d".toAbsolutePath)
+        verify(podRepo).deleteVersion("e".toAbsolutePath, OffsetDateTime.MIN)
+        verify(podRepo).deleteVersion("e".toAbsolutePath, OffsetDateTime.MAX)
+        verify(podRepo).deleteVersion("f".toAbsolutePath, OffsetDateTime.MIN)
         verify(groupRepo).deleteRootVersion(OffsetDateTime.MIN)
         verify(groupRepo).deleteRootVersion(OffsetDateTime.MAX)
         noMoreInteractions(appRepo)

--- a/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/GroupRepositoryTest.scala
@@ -51,10 +51,10 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
       "store new apps when storing the root" in {
         val appRepo = mock[AppRepository]
         val repo = createRepo(appRepo, mock[PodRepository], 1)
-        val apps = Seq(AppDefinition("app1".toRootPath, role = "*"), AppDefinition("app2".toRootPath, role = "*"))
+        val apps = Seq(AppDefinition("app1".toAbsolutePath, role = "*"), AppDefinition("app2".toAbsolutePath, role = "*"))
         val root = repo.root().futureValue
 
-        val newRoot = root.updateApps(PathId.empty, _ => apps.map(app => app.id -> app)(collection.breakOut), root.version)
+        val newRoot = root.updateApps(PathId.root, _ => apps.map(app => app.id -> app)(collection.breakOut), root.version)
 
         appRepo.store(any) returns Future.successful(Done)
 
@@ -69,11 +69,11 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
       "not store the group if updating apps fails" in {
         val appRepo = mock[AppRepository]
         val repo = createRepo(appRepo, mock[PodRepository], 1)
-        val apps = Seq(AppDefinition("app1".toRootPath, role = "*"), AppDefinition("app2".toRootPath, role = "*"))
+        val apps = Seq(AppDefinition("app1".toAbsolutePath, role = "*"), AppDefinition("app2".toAbsolutePath, role = "*"))
         val root = repo.root().futureValue
         repo.storeRoot(root, Nil, Nil, Nil, Nil).futureValue
 
-        val newRoot = root.updateApps(PathId.empty, apps = _ => apps.map(app => app.id -> app)(collection.breakOut), root.version)
+        val newRoot = root.updateApps(PathId.root, apps = _ => apps.map(app => app.id -> app)(collection.breakOut), root.version)
 
         val exception = new Exception("App Store Failed")
         appRepo.store(any) returns Future.failed(exception)
@@ -93,14 +93,14 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
       "store the group if deleting apps fails" in {
         val appRepo = mock[AppRepository]
         val repo = createRepo(appRepo, mock[PodRepository], 1)
-        val app1 = AppDefinition("app1".toRootPath, role = "*")
-        val app2 = AppDefinition("app2".toRootPath, role = "*")
+        val app1 = AppDefinition("app1".toAbsolutePath, role = "*")
+        val app2 = AppDefinition("app2".toAbsolutePath, role = "*")
         val apps = Seq(app1, app2)
         val root = repo.root().futureValue
         repo.storeRoot(root, Nil, Nil, Nil, Nil).futureValue
-        val deleted = "deleteMe".toRootPath
+        val deleted = "deleteMe".toAbsolutePath
 
-        val newRoot = root.updateApps(PathId.empty, _ => apps.map(app => app.id -> app)(collection.breakOut), root.version)
+        val newRoot = root.updateApps(PathId.root, _ => apps.map(app => app.id -> app)(collection.breakOut), root.version)
 
         val exception = new Exception("App Delete Failed")
         appRepo.store(any) returns Future.successful(Done)
@@ -129,14 +129,14 @@ class GroupRepositoryTest extends AkkaUnitTest with Mockito with ZookeeperServer
         val appRepo = AppRepository.inMemRepository(store)
         val repo = createRepo(appRepo, mock[PodRepository], 2)
 
-        val app1 = AppDefinition("app1".toRootPath, role = "*")
-        val app2 = AppDefinition("app2".toRootPath, role = "*")
+        val app1 = AppDefinition("app1".toAbsolutePath, role = "*")
+        val app2 = AppDefinition("app2".toAbsolutePath, role = "*")
 
         val initialRoot = repo.root().futureValue
-        val firstRoot = initialRoot.updateApps(PathId.empty, _ => Map(app1.id -> app1), initialRoot.version)
+        val firstRoot = initialRoot.updateApps(PathId.root, _ => Map(app1.id -> app1), initialRoot.version)
         repo.storeRoot(firstRoot, Seq(app1), Nil, Nil, Nil).futureValue
 
-        val nextRoot = initialRoot.updateApps(PathId.empty, _ => Map(app2.id -> app2), version = Timestamp(1))
+        val nextRoot = initialRoot.updateApps(PathId.root, _ => Map(app2.id -> app2), version = Timestamp(1))
         repo.storeRoot(nextRoot, Seq(app2), Seq(app1.id), Nil, Nil).futureValue
 
         repo.rootVersion(firstRoot.version.toOffsetDateTime).futureValue.value should equal(firstRoot)

--- a/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/PodRepositoryTest.scala
@@ -18,13 +18,13 @@ class PodRepositoryTest extends AkkaUnitTest {
     val someContainers = Seq(MesosContainer(name = "foo", resources = Resources()))
 
     "store and retrieve pods" in {
-      val pod = PodDefinition("a".toRootPath, role = "*", containers = someContainers)
+      val pod = PodDefinition("a".toAbsolutePath, role = "*", containers = someContainers)
       val f = new Fixture()
       f.repo.store(pod).futureValue
       f.repo.get(pod.id).futureValue.value should equal(pod)
     }
     "store and retrieve pods with executor resources" in {
-      val pod = PodDefinition("a".toRootPath, role = "*", containers = someContainers, executorResources = PodDefinition.DefaultExecutorResources.copy(cpus = 10))
+      val pod = PodDefinition("a".toAbsolutePath, role = "*", containers = someContainers, executorResources = PodDefinition.DefaultExecutorResources.copy(cpus = 10))
       val f = new Fixture()
       f.repo.store(pod).futureValue
       f.repo.get(pod.id).futureValue.value should equal(pod)

--- a/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/repository/RepositoryTest.scala
@@ -21,7 +21,7 @@ import org.scalatest.time.{Seconds, Span}
 class RepositoryTest extends AkkaUnitTest with ZookeeperServerTest with GivenWhenThen {
   import PathId._
 
-  def randomAppId = UUID.randomUUID().toString.toRootPath
+  def randomAppId = UUID.randomUUID().toString.toAbsolutePath
   def randomApp = AppDefinition(randomAppId, role = "*", versionInfo = VersionInfo.OnlyVersion(Timestamp.now()))
 
   override implicit lazy val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(30, Seconds))

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -212,9 +212,9 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
     }
 
     "MultipleApps" in new Fixture {
-      val appName1 = "app1".toRootPath
-      val appName2 = "app2".toRootPath
-      val appName3 = "app3".toRootPath
+      val appName1 = "app1".toAbsolutePath
+      val appName2 = "app2".toAbsolutePath
+      val appName3 = "app3".toAbsolutePath
 
       val app1_instance1 = setupTrackerWithRunningInstance(appName1, Timestamp.now(), instanceTracker).futureValue
       val app1_instance2 = setupTrackerWithRunningInstance(appName1, Timestamp.now(), instanceTracker).futureValue

--- a/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/TaskIdTest.scala
@@ -21,34 +21,34 @@ class TaskIdTest extends UnitTest with Inside {
 
     "Old TaskIds can be converted" in {
       val taskId = Task.Id.parse(TaskID.newBuilder().setValue("app_682ebe64-0771-11e4-b05d-e0f84720c54e").build)
-      taskId.runSpecId should equal("app".toRootPath)
+      taskId.runSpecId should equal("app".toAbsolutePath)
     }
 
     "Old TaskIds can be converted even if they have dots in them" in {
       val taskId = Task.Id.parse(TaskID.newBuilder().setValue("app.foo.bar_682ebe64-0771-11e4-b05d-e0f84720c54e").build)
-      taskId.runSpecId should equal("app.foo.bar".toRootPath)
+      taskId.runSpecId should equal("app.foo.bar".toAbsolutePath)
     }
 
     "Old TaskIds can be converted even if they have underscores in them" in {
       val taskId = Task.Id.parse(TaskID.newBuilder().setValue("app_foo_bar_682ebe64-0771-11e4-b05d-e0f84720c54e").build)
-      taskId.runSpecId should equal("/app/foo/bar".toRootPath)
+      taskId.runSpecId should equal("/app/foo/bar".toAbsolutePath)
     }
 
     "TaskIds with encoded InstanceIds could be encoded" in {
       val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._app").build)
-      taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
+      taskId.runSpecId should equal("/test/foo/bla/rest".toAbsolutePath)
       taskId.instanceId.idString should equal("test_foo_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
     }
 
     "TaskIds with encoded InstanceIds could be encoded even with crucial path ids" in {
       val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15._app").build)
-      taskId.runSpecId should equal("/test/foo.instance-/bla/rest".toRootPath)
+      taskId.runSpecId should equal("/test/foo.instance-/bla/rest".toAbsolutePath)
       taskId.instanceId.idString should equal("test_foo.instance-_bla_rest.instance-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
     }
 
     "TaskIds without specific instanceId should use taskId as instanceId" in {
       val taskId = Task.Id.parse(TaskID.newBuilder().setValue("test_foo_bla_rest.62d0f03f-79aa-11e6-a1a0-660c139c5e15").build)
-      taskId.runSpecId should equal("/test/foo/bla/rest".toRootPath)
+      taskId.runSpecId should equal("/test/foo/bla/rest".toAbsolutePath)
       taskId.instanceId.idString should equal("test_foo_bla_rest.marathon-62d0f03f-79aa-11e6-a1a0-660c139c5e15")
     }
 

--- a/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
+++ b/src/test/scala/mesosphere/mesos/ResourceMatcherTest.scala
@@ -46,7 +46,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       offer.getResourcesList.find(_.getName == "disk") should be('empty)
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0),
         role = "*"
@@ -67,7 +67,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources success" in {
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0),
         role = "*"
@@ -88,7 +88,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources success with BRIDGE and portMappings" in {
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = Nil,
@@ -117,7 +117,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources success with USER and portMappings" in {
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = Nil,
@@ -167,7 +167,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
           .build()
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 2.0, mem = 128.0, disk = 2.0),
         portDefinitions = PortDefinitions(0)
@@ -228,7 +228,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
           .build()
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 2.0, mem = 128.0, disk = 2.0),
         portDefinitions = PortDefinitions(0)
@@ -287,7 +287,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
           .build()
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 2.0, mem = 128.0, disk = 2.0),
         portDefinitions = PortDefinitions(0)
@@ -313,7 +313,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
           .build()
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 2.0),
         portDefinitions = PortDefinitions()
@@ -330,7 +330,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources success with preserved roles" in {
       val offer = MarathonTestHelper.makeBasicOffer(role = "marathon").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -351,7 +351,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources failure because of incorrect roles" in {
       val offer = MarathonTestHelper.makeBasicOffer(role = "marathon").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -367,7 +367,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources success with constraints" in {
       val offer = MarathonTestHelper.makeBasicOffer(beginPort = 0, endPort = 0).setHostname("host1").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         constraints = Set(
@@ -387,7 +387,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources fails on constraints" in {
       val offer = MarathonTestHelper.makeBasicOffer(beginPort = 0, endPort = 0).setHostname("host1").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         constraints = Set(
@@ -407,7 +407,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources fail on cpu" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 0.1).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -421,7 +421,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources fail on mem" in {
       val offer = MarathonTestHelper.makeBasicOffer(mem = 0.1).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -435,7 +435,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources should always match constraints and therefore return NoOfferMatchReason.UnfulfilledConstraint in case of no match" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 0.5).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0), // cpu does not match
         constraints = Set(
@@ -458,7 +458,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources fail on disk" in {
       val offer = MarathonTestHelper.makeBasicOffer(disk = 0.1).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 1.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -472,7 +472,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match resources fail on ports" in {
       val offer = MarathonTestHelper.makeBasicOffer(beginPort = 0, endPort = 0).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(1, 2)
@@ -486,7 +486,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "resource matcher should not respond with NoOfferMatchReason.UnfulfilledRole if role matches" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 0.5, role = "A").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0), // make sure it mismatches
         acceptedResourceRoles = Set("A", "B")
@@ -503,7 +503,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "resource matcher should respond with NoOfferMatchReason.UnfulfilledRole if runSpec requires unreserved Role but resources are reserved" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 0.5, role = "A").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0), // make sure it mismatches
         acceptedResourceRoles = Set(ResourceRole.Unreserved)
@@ -520,7 +520,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "resource matcher should respond with NoOfferMatchReason.UnfulfilledRole if runSpec has no role defined" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 0.5, role = "A").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0) // make sure it mismatches
       )
@@ -536,7 +536,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "resource matcher should respond with NoOfferMatchReason.UnfulfilledRole if role mismatches and offer contains other role" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 0.5, role = "C").build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0), // make sure it mismatches
         acceptedResourceRoles = Set("A", "B")
@@ -553,7 +553,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "resource matcher should respond with all NoOfferMatchReason.Insufficient{Cpus, Memory, Gpus, Disk} if mismatches" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 1, mem = 1, disk = 1, gpus = 1).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 2, mem = 2, disk = 2, gpus = 2) // make sure it mismatches
       )
@@ -570,7 +570,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "resource matcher should respond with NoOfferMatchReason.InsufficientPorts if ports mismatch and other requirements matches" in {
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 1, mem = 1, disk = 1, beginPort = 0, endPort = 0).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1, mem = 1, disk = 1),
         portDefinitions = PortDefinitions(1, 2) // this match fails
@@ -588,7 +588,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       // NoOfferMatchReason.InsufficientPorts is calculated lazy and should only be calculated if all other requirements matches
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 1, mem = 1, disk = 1, beginPort = 0, endPort = 0).build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 2, mem = 1, disk = 1), // this match fails
         portDefinitions = PortDefinitions(1, 2) // this would fail as well, but is not evaluated of the resource matcher
@@ -625,7 +625,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         VolumeMount(None, "/var/lib/data"))
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(
           cpus = 1.0,
@@ -650,7 +650,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         .addAttributes(TextAttribute("zone", "pl-east-1b"))
         .build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         versionInfo = OnlyVersion(Timestamp(2)),
@@ -694,7 +694,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         .build()
       val oldVersion = Timestamp(1)
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         versionInfo = FullVersionInfo(
@@ -758,7 +758,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val volume = VolumeWithMount(persistentVolume, mount)
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(
           cpus = 1.0,
@@ -805,7 +805,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         mount = VolumeMount(None, "/var/lib/data"))
 
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(
           cpus = 1.0,
@@ -846,7 +846,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
           mount = VolumeMount(None, "/var/lib/data"))
 
         val app = AppDefinition(
-          id = "/test".toRootPath,
+          id = "/test".toAbsolutePath,
           role = "*",
           resources = Resources(
             cpus = 1.0,
@@ -895,7 +895,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val volume = VolumeWithMount(persistentVolume, mount)
 
       val app = AppDefinition(
-        id = "/test-persistent-volumes-with-unique-constraint".toRootPath,
+        id = "/test-persistent-volumes-with-unique-constraint".toAbsolutePath,
         instances = 3,
         resources = Resources(cpus = 0.1, mem = 32.0, disk = 0.0),
         constraints = Set(Constraint.newBuilder.setField("hostname").
@@ -926,7 +926,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val volume = VolumeWithMount(persistentVolume, mount)
 
       val app = AppDefinition(
-        id = "/test-persistent-volumes-without-unique-constraint".toRootPath,
+        id = "/test-persistent-volumes-without-unique-constraint".toAbsolutePath,
         instances = 3,
         resources = Resources(cpus = 0.1, mem = 32.0, disk = 0.0),
         container = Some(Container.Mesos(
@@ -946,7 +946,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val maintenanceDisabledConf = AllConf.withTestConfig("--disable_maintenance_mode")
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 0.1, mem = 128.0, disk = 0.0)
       )
@@ -964,7 +964,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match offers with maintenance mode and enabled feature should not match" in {
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 0.1, mem = 128.0, disk = 0.0)
       )
@@ -977,7 +977,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match offers with maintenance mode, too many required cpus and enabled feature should not match" in {
       val offer = MarathonTestHelper.makeBasicOfferWithUnavailability(clock.now).build
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1000, mem = 128.0, disk = 0.0)
       )
@@ -991,7 +991,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val maintenanceEnabledConf = AllConf.withTestConfig("--draining_seconds", "300")
       val offer = MarathonTestHelper.makeBasicOffer().build
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1000, mem = 128.0, disk = 0.0)
       )
@@ -1004,7 +1004,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match offers with empty region if localRegion is not available" in {
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -1017,7 +1017,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
     "match offers with empty region if localRegion is available" in {
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -1033,7 +1033,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         .setDomain(MarathonTestHelper.newDomainInfo("region", "zone"))
         .build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -1049,7 +1049,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         .setDomain(MarathonTestHelper.newDomainInfo("region", "zone"))
         .build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -1064,14 +1064,14 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val gpuOffer = MarathonTestHelper.makeBasicOffer(gpus = 4)
         .build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
       )
 
       val gpuApp = AppDefinition(
-        id = "/gpu".toRootPath,
+        id = "/gpu".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0, gpus = 1),
         portDefinitions = PortDefinitions(0, 0)
@@ -1108,14 +1108,14 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val offer = MarathonTestHelper.makeBasicOffer(gpus = 4)
         .build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
       )
 
       val gpuApp = AppDefinition(
-        id = "/gpu".toRootPath,
+        id = "/gpu".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0, gpus = 1),
         portDefinitions = PortDefinitions(0, 0)
@@ -1152,7 +1152,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val offer = MarathonTestHelper.makeBasicOffer(gpus = 4)
         .build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
         portDefinitions = PortDefinitions(0, 0)
@@ -1179,7 +1179,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
       val offer = MarathonTestHelper.makeBasicOffer(gpus = 4)
         .build()
       val app = AppDefinition(
-        id = "/test".toRootPath,
+        id = "/test".toAbsolutePath,
         role = "*",
         resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0, gpus = 2),
         portDefinitions = PortDefinitions(0, 0)
@@ -1283,7 +1283,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         val offer = offerBuilder.build()
 
         val app = AppDefinition(
-          id = "/test".toRootPath,
+          id = "/test".toAbsolutePath,
           role = "*",
           resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
           portDefinitions = PortDefinitions(0, 0)
@@ -1308,7 +1308,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         val offer = offerBuilder.build()
 
         val app = AppDefinition(
-          id = "/test".toRootPath,
+          id = "/test".toAbsolutePath,
           role = "*",
           resources = Resources(cpus = 1.0, mem = 128.0, disk = 1.0),
           portDefinitions = PortDefinitions(0, 0)
@@ -1334,7 +1334,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         val offer = offerBuilder.build()
 
         val app = AppDefinition(
-          id = "/test".toRootPath,
+          id = "/test".toAbsolutePath,
           role = "*",
           resources = Resources(cpus = 1.0, mem = 128.0, disk = 1.0),
           portDefinitions = PortDefinitions(0, 0)
@@ -1371,7 +1371,7 @@ class ResourceMatcherTest extends UnitTest with Inside with TableDrivenPropertyC
         val offer = MarathonTestHelper.makeBasicOffer(gpus = 4)
           .build()
         val app = AppDefinition(
-          id = "/test".toRootPath,
+          id = "/test".toAbsolutePath,
           role = "*",
           resources = Resources(cpus = 1.0, mem = 128.0, disk = 0.0),
           portDefinitions = PortDefinitions(0, 0),

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -59,7 +59,7 @@ trait BaseMarathon extends AutoCloseable with StrictLogging with ScalaFutures {
   lazy val uuid = UUID.randomUUID.toString
   lazy val httpPort = PortAllocator.ephemeralPort()
   lazy val url = conf.get("https_port").fold(s"http://localhost:$httpPort")(httpsPort => s"https://localhost:$httpsPort")
-  lazy val client = new MarathonFacade(url, PathId.empty)
+  lazy val client = new MarathonFacade(url, PathId.root)
 
   val workDir = {
     val f = Files.createTempDirectory(s"marathon-$httpPort").toFile
@@ -258,7 +258,7 @@ trait HealthCheckEndpoint extends StrictLogging with ScalaFutures {
       get {
         path(Segment / Segment / "health") { (uriEncodedAppId, versionId) =>
           import PathId._
-          val appId = URLDecoder.decode(uriEncodedAppId, "UTF-8").toRootPath
+          val appId = URLDecoder.decode(uriEncodedAppId, "UTF-8").toAbsolutePath
 
           def instance = healthChecks(_.find { c => c.appId == appId && c.versionId == versionId })
 
@@ -272,7 +272,7 @@ trait HealthCheckEndpoint extends StrictLogging with ScalaFutures {
           }
         } ~ path(Segment / Segment / Segment / "ready") { (uriEncodedAppId, versionId, taskId) =>
           import PathId._
-          val appId = URLDecoder.decode(uriEncodedAppId, "UTF-8").toRootPath
+          val appId = URLDecoder.decode(uriEncodedAppId, "UTF-8").toAbsolutePath
 
           // Find a fitting registred readiness check. If the check has no task id set we ignore it.
           def check: Option[IntegrationReadinessCheck] = registeredReadinessChecks(_.find { c =>


### PR DESCRIPTION
Summary:
In the case of group-role enforcement, there was a bug in which posting an app
with id 'dev/service' was treated differently than '/dev/service'. This was due
to erroneous handling of relative vs absolute paths.

In this PR, we split out AbsolutePathId from PathId so that code modules can
express, via the type system, that they require an absolute path.

Other improvements were made by improving the consistency of the usage of the
word "absolute" and "root" when working with pathIds, which should alleviate
some confusion.

JIRA Issues: MARATHON-8669
