### PR TITLE
Migrate all groups without filter.

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo19100.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo19100.scala
@@ -229,7 +229,7 @@ object MigrationTo19100 extends MaybeStore with StrictLogging {
 
     val countingSink: Sink[Done, NotUsed] = Sink.fold[Int, Done](0) { case (count, Done) => count + 1 }
       .mapMaterializedValue { f =>
-        f.map(i => logger.info(s"$i pods migrated to 1.9.100"))
+        f.map(i => logger.info(s"$i groups migrated to 1.9.100"))
         NotUsed
       }
 
@@ -240,7 +240,7 @@ object MigrationTo19100 extends MaybeStore with StrictLogging {
           case Some(rootGroupVersion) => zkStore.get(RootId, rootGroupVersion).map(group => (group, Some(rootGroupVersion)))
           case None => zkStore.get(RootId).map(group => (group, None))
         }
-        .collect{ case (Some(group), optVersion) if group.enforceRole.isEmpty => (group, optVersion) }
+        .collect{ case (Some(group), optVersion) => (group, optVersion) }
         .map{
           case (rootGroup, optVersion) => (migrateGroup(rootGroup), optVersion)
         }

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -54,7 +54,7 @@ case class StoredGroup(
     appRepository: AppRepository,
     podRepository: PodRepository)(implicit ctx: ExecutionContext): Future[Group] = async { // linter:ignore UnnecessaryElseBranch
 
-    require(enforceRole.isDefined, s"BUG! Group $id has not enforce role filed defined which should be done by migration.")
+    require(enforceRole.isDefined, s"BUG! Group $id has no defined enforce role filed which should be done by migration.")
 
     val appFutures = appIds.map {
       case (appId, appVersion) => appRepository.getVersion(appId, appVersion).recover {
@@ -175,7 +175,6 @@ object StoredGroup {
     // Default to false for top-level group.
     val enforceRole: Option[Boolean] =
       if (proto.hasEnforceRole()) Some(proto.getEnforceRole)
-      else if (id.parent.isRoot) Some(false)
       else None
 
     val groups = proto.getGroupsList.map(StoredGroup(_))

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo19100Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo19100Test.scala
@@ -38,10 +38,6 @@ class MigrationTo19100Test extends AkkaUnitTest {
       updatedInstances.head.instanceId should be(instanceId1)
       updatedInstances.head.role.value should be(mesosDefaultRole)
     }
-
-    "migrate all nested groups" in {
-
-    }
   }
 
   class Fixture {

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo19100Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo19100Test.scala
@@ -38,6 +38,10 @@ class MigrationTo19100Test extends AkkaUnitTest {
       updatedInstances.head.instanceId should be(instanceId1)
       updatedInstances.head.role.value should be(mesosDefaultRole)
     }
+
+    "migrate all nested groups" in {
+
+    }
   }
 
   class Fixture {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
@@ -89,7 +89,7 @@ class MultiRoleIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       Then("One Instance should have the old role, and one the new role")
       var taskList = taskListResult.value
 
-      taskList should have size(1)
+      taskList should have size (1)
       taskList.head.role.value should be(BaseMarathon.defaultRole)
 
       Given("The app is scaled to 2")
@@ -106,7 +106,7 @@ class MultiRoleIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       Then("One Instance should have the old role, and one the new role")
       taskList = taskListResult.value
 
-      taskList should have size(2)
+      taskList should have size (2)
       val instanceRoles = taskList.map(task => task.role.value)
       instanceRoles should contain("dev")
       instanceRoles should contain(BaseMarathon.defaultRole)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
@@ -38,10 +38,10 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
   val marathon16549Artifact = MarathonArtifact("1.6.549", "marathon-1.6.549-aabf74302.tgz")
 
   // Configure Mesos to provide the Mesos containerizer with Docker image support.
-  //  override lazy val mesosConfig = MesosConfig(
-  //    launcher = "linux",
-  //    isolation = Some("filesystem/linux,docker/runtime"),
-  //    imageProviders = Some("docker"))
+  override lazy val mesosConfig = MesosConfig(
+    launcher = "linux",
+    isolation = Some("filesystem/linux,docker/runtime"),
+    imageProviders = Some("docker"))
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/UpgradeIntegrationTest.scala
@@ -38,10 +38,10 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
   val marathon16549Artifact = MarathonArtifact("1.6.549", "marathon-1.6.549-aabf74302.tgz")
 
   // Configure Mesos to provide the Mesos containerizer with Docker image support.
-  override lazy val mesosConfig = MesosConfig(
-    launcher = "linux",
-    isolation = Some("filesystem/linux,docker/runtime"),
-    imageProviders = Some("docker"))
+  //  override lazy val mesosConfig = MesosConfig(
+  //    launcher = "linux",
+  //    isolation = Some("filesystem/linux,docker/runtime"),
+  //    imageProviders = Some("docker"))
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -248,7 +248,7 @@ class UpgradeIntegrationTest extends AkkaIntegrationTest with MesosClusterTest w
     val app_16549_fail = appProxy(testBasePath / "app-16549-fail", "v1", instances = 1, healthCheck = None)
     marathon16549.client.createAppV2(app_16549_fail) should be(Created)
 
-    val app_16549 = appProxy(testBasePath / "app-16549", "v1", instances = 1, healthCheck = None)
+    val app_16549 = appProxy(testBasePath / "prod" / "db" / "app-16549", "v1", instances = 1, healthCheck = None)
     marathon16549.client.createAppV2(app_16549) should be(Created)
 
     patienceConfig


### PR DESCRIPTION
Summary:
Nested groups would not be migrated because we had a filter on the
groups that would filter out groups since the protobuf conversion set an
arbitrary `enforceRole` field.

JIRA issues: MARATHON-8673