### PR TITLE
Type group id as absolute path.

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/core/storage/store/impl/zk/ZkPersistenceStoreBenchmark.scala
@@ -10,6 +10,7 @@ import akka.stream.{ActorMaterializer, Materializer}
 import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.base.{JvmExitsCrashStrategy, LifecycleState}
 import mesosphere.marathon.metrics.dummy.DummyMetrics
+import mesosphere.marathon.state.{AppDefinition, PathId}
 import mesosphere.marathon.storage.{CuratorZk, StorageConf, StorageConfig}
 import mesosphere.marathon.storage.repository.StoredGroup
 import mesosphere.marathon.storage.store.ZkStoreSerialization
@@ -53,8 +54,8 @@ class ZkPersistenceStoreBenchmark {
   def storeAndRemoveGroup(hole: Blackhole): Unit = {
     val done = Promise[Done]
     val pipeline: Future[Done] = async {
-      await(zkStore.store(storedGroup.id, storedGroup))
-      val delete = Future.sequence(rootGroup.groupsById.keys.map { id => zkStore.deleteAll(id)(appDefResolver) })
+      await(zkStore.store[PathId, StoredGroup](storedGroup.id, storedGroup))
+      val delete = Future.sequence(rootGroup.groupsById.keys.map { id => zkStore.deleteAll[PathId, AppDefinition](id)(appDefResolver) })
       await(delete)
       Done
     }

--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -34,8 +34,8 @@ class GroupBenchmark {
   var groupDepth: Int = _
   lazy val groupIds = 0 until groupDepth
 
-  lazy val groupPaths: Vector[PathId] = groupIds.foldLeft(Vector[PathId]()) { (allPaths, nextChild) =>
-    val nextChildPath = allPaths.lastOption.getOrElse(PathId.root) / s"group-$nextChild"
+  lazy val groupPaths: Vector[AbsolutePathId] = groupIds.foldLeft(Vector[AbsolutePathId]()) { (allPaths, nextChild) =>
+    val nextChildPath = (allPaths.lastOption.getOrElse(PathId.root) / s"group-$nextChild").asAbsolutePath
     allPaths :+ nextChildPath
   }
 

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/DependencyGraphBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/DependencyGraphBenchmark.scala
@@ -54,11 +54,11 @@ object DependencyGraphBenchmark {
       }(breakOut)
 
     val subGroups: Map[GroupKey, Group] = groupIds.map { groupId =>
-      val id = s"/supergroup-${superGroupId}/group-${groupId}".toPath
+      val id = s"/supergroup-${superGroupId}/group-${groupId}".toAbsolutePath
       id -> Group(id = id)
     }(breakOut)
 
-    val id = s"/supergroup-${superGroupId}".toPath
+    val id = s"/supergroup-${superGroupId}".toAbsolutePath
     id -> Group(
       id = id,
       groupsById = subGroups

--- a/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
+++ b/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
@@ -20,7 +20,7 @@ class GroupApiService(groupManager: GroupManager)(implicit authorizer: Authorize
     */
   def updateGroup(
     rootGroup: RootGroup,
-    groupId: PathId,
+    groupId: AbsolutePathId,
     groupUpdate: raml.GroupUpdate,
     newVersion: Timestamp)(implicit identity: Identity): Future[RootGroup] = async {
     val group = rootGroup.group(groupId).getOrElse(Group.empty(groupId))

--- a/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanReverter.scala
+++ b/src/main/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanReverter.scala
@@ -23,7 +23,7 @@ private[deployment] object DeploymentPlanReverter extends StrictLogging {
     */
   def revert(original: RootGroup, target: RootGroup, newVersion: Timestamp = Group.defaultVersion): RootGroup => RootGroup = {
 
-    def changesOnIds[T](originalById: Map[PathId, T], targetById: Map[PathId, T]): Seq[(Option[T], Option[T])] = {
+    def changesOnIds[T](originalById: Map[Group.GroupKey, T], targetById: Map[Group.GroupKey, T]): Seq[(Option[T], Option[T])] = {
       val ids = originalById.keys ++ targetById.keys
       ids.map { id => originalById.get(id) -> targetById.get(id) }(collection.breakOut)
     }
@@ -55,12 +55,12 @@ private[deployment] object DeploymentPlanReverter extends StrictLogging {
     version: Timestamp,
     groupChanges: Seq[(Option[Group], Option[Group])])(rootGroup: RootGroup): RootGroup = {
 
-    def revertGroupRemoval(oldGroup: Group)(dependencies: Set[PathId]): Set[PathId] = {
+    def revertGroupRemoval(oldGroup: Group)(dependencies: Set[AbsolutePathId]): Set[AbsolutePathId] = {
       logger.debug("re-adding group {} with dependencies {}", Seq(oldGroup.id, oldGroup.dependencies): _*)
       if ((oldGroup.dependencies -- dependencies).nonEmpty) dependencies ++ oldGroup.dependencies else dependencies
     }
 
-    def revertDependencyChanges(oldGroup: Group, newGroup: Group)(dependencies: Set[PathId]): Set[PathId] = {
+    def revertDependencyChanges(oldGroup: Group, newGroup: Group)(dependencies: Set[AbsolutePathId]): Set[AbsolutePathId] = {
       val removedDependencies = oldGroup.dependencies -- newGroup.dependencies
       val addedDependencies = newGroup.dependencies -- oldGroup.dependencies
 

--- a/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/group/impl/GroupManagerImpl.scala
@@ -75,7 +75,7 @@ class GroupManagerImpl(
   override def versions(id: PathId): Source[Timestamp, NotUsed] = {
     groupRepository.rootVersions().mapAsync(RepositoryConstants.maxConcurrency) { version =>
       groupRepository.rootVersion(version)
-    }.collect { case Some(g) if g.group(id).isDefined => g.version }
+    }.collect { case Some(g) if g.group(id.asAbsolutePath).isDefined => g.version }
   }
 
   override def appVersions(id: PathId): Source[OffsetDateTime, NotUsed] = {
@@ -94,11 +94,11 @@ class GroupManagerImpl(
     groupRepository.podVersion(id, version)
   }
 
-  override def group(id: PathId): Option[Group] = rootGroup().group(id)
+  override def group(id: PathId): Option[Group] = rootGroup().group(id.asAbsolutePath)
 
   override def group(id: PathId, version: Timestamp): Future[Option[Group]] = async {
     val root = await(groupRepository.rootVersion(version.toOffsetDateTime))
-    root.flatMap(_.group(id))
+    root.flatMap(_.group(id.asAbsolutePath))
   }
 
   override def runSpec(id: PathId): Option[RunSpec] = app(id).orElse(pod(id))

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -331,7 +331,7 @@ class InstanceOpFactoryImpl(
     val topLevelGroup = if (topLevelPath.isEmpty)
       None
     else
-      rootGroupRetriever.rootGroup().group(topLevelPath)
+      rootGroupRetriever.rootGroup().group(topLevelPath.asAbsolutePath)
 
     topLevelGroup
       .map { _.enforceRole }

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package raml
 
-import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp, Group => CoreGroup, VersionInfo => CoreVersionInfo}
+import mesosphere.marathon.state.{AbsolutePathId, AppDefinition, PathId, Timestamp, Group => CoreGroup, VersionInfo => CoreVersionInfo}
 
 trait GroupConversion {
 
@@ -30,8 +30,8 @@ object UpdateGroupStructureOp {
 
   import Normalization._
 
-  private def requireGroupPath(groupUpdate: GroupUpdate)(implicit normalPaths: Normalization[PathId]): PathId = {
-    groupUpdate.id.map(PathId(_).normalize).getOrElse(
+  private def requireGroupPath(groupUpdate: GroupUpdate): PathId = {
+    groupUpdate.id.map(PathId(_)).getOrElse(
       // validation should catch this..
       throw SerializationFailedException("No group id was given!")
     )
@@ -45,7 +45,7 @@ object UpdateGroupStructureOp {
   /**
     * Creates a new [[state.Group]] from a [[GroupUpdate]], performing both normalization and conversion.
     */
-  private def createGroup(groupUpdate: GroupUpdate, gid: PathId, version: Timestamp)(implicit cf: App => AppDefinition): CoreGroup = {
+  private def createGroup(groupUpdate: GroupUpdate, gid: AbsolutePathId, version: Timestamp)(implicit cf: App => AppDefinition): CoreGroup = {
     implicit val pathNormalization: Normalization[PathId] = Normalization(_.canonicalPath(gid.asAbsolutePath))
     implicit val appNormalization = normalizeApp(version)
 
@@ -54,9 +54,10 @@ object UpdateGroupStructureOp {
       app.id -> app
     }(collection.breakOut)
 
-    val groupsById: Map[PathId, CoreGroup] = groupUpdate.groups.getOrElse(Seq.empty).map { currentGroup =>
+    val groupsById: Map[CoreGroup.GroupKey, CoreGroup] = groupUpdate.groups.getOrElse(Seq.empty).map { currentGroup =>
       // TODO: tailrec needed
-      val group = createGroup(currentGroup, requireGroupPath(currentGroup), version)
+      val id = requireGroupPath(currentGroup).canonicalPath(gid)
+      val group = createGroup(currentGroup, id, version)
       group.id -> group
     }(collection.breakOut)
 
@@ -65,7 +66,7 @@ object UpdateGroupStructureOp {
       apps = appsById,
       pods = Map.empty,
       groupsById = groupsById,
-      dependencies = groupUpdate.dependencies.fold(Set.empty[PathId])(_.map(PathId(_).normalize)),
+      dependencies = groupUpdate.dependencies.fold(Set.empty[AbsolutePathId])(_.map(PathId(_).canonicalPath(gid))),
       version = version
     )
   }
@@ -84,12 +85,12 @@ object UpdateGroupStructureOp {
     require(groupUpdate.version.isEmpty, "For a structural update, no version should be given.")
     assert(groupUpdate.enforceRole.isDefined, s"BUG! The group normalization should have set enforceRole for ${groupUpdate.id}.")
 
-    implicit val pathNormalization: Normalization[PathId] = Normalization(_.canonicalPath(current.id.asAbsolutePath))
+    implicit val pathNormalization: Normalization[PathId] = Normalization(_.canonicalPath(current.id))
     implicit val appNormalization = normalizeApp(timestamp)
 
-    val effectiveGroups: Map[PathId, CoreGroup] = groupUpdate.groups.fold(current.groupsById) { updates =>
+    val effectiveGroups: Map[CoreGroup.GroupKey, CoreGroup] = groupUpdate.groups.fold(current.groupsById) { updates =>
       updates.map { groupUpdate =>
-        val gid = requireGroupPath(groupUpdate)
+        val gid = requireGroupPath(groupUpdate).canonicalPath(current.id)
         val newGroup = current.groupsById.get(gid).map { group =>
           execute(groupUpdate, group, timestamp) // TODO: tailrec needed
         }.getOrElse(createGroup(groupUpdate, gid, timestamp))
@@ -105,7 +106,7 @@ object UpdateGroupStructureOp {
       }(collection.breakOut)
     }
 
-    val effectiveDependencies = groupUpdate.dependencies.fold(current.dependencies)(_.map(PathId(_).normalize))
+    val effectiveDependencies = groupUpdate.dependencies.fold(current.dependencies)(_.map(PathId(_).canonicalPath(current.id)))
 
     CoreGroup(
       id = current.id,

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -37,13 +37,13 @@ sealed trait PathId extends Ordered[PathId] with plugin.PathId with Product {
   @deprecated("Assuming an absolute path where it may not be is a source of bugs; avoid using this method if possible")
   def asAbsolutePath: AbsolutePathId
 
-  lazy val parent: PathId = path match {
-    case Nil => this
-    case head +: Nil => PathId(Nil, absolute)
-    case head +: rest => PathId(path.init, absolute)
+  lazy val parent: AbsolutePathId = path match {
+    case Nil => PathId.root
+    case head +: Nil => PathId.root
+    case head +: rest => AbsolutePathId(path.init)
   }
 
-  def allParents: List[PathId] = if (isRoot) Nil else {
+  def allParents: List[AbsolutePathId] = if (isRoot) Nil else {
     val p = parent
     p :: p.allParents
   }
@@ -155,7 +155,7 @@ case class RelativePathId(path: Seq[String]) extends PathId with StrictLogging {
 }
 
 object PathId {
-  def fromSafePath(in: String): PathId = {
+  def fromSafePath(in: String): AbsolutePathId = {
     if (in.isEmpty) PathId.root
     else AbsolutePathId(in.split("_").toList)
   }

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -123,6 +123,14 @@ case class AbsolutePathId(path: Seq[String]) extends PathId {
   override def asAbsolutePath: AbsolutePathId = this
   protected def toString(delimiter: String): String =
     path.mkString("/", delimiter, "")
+
+  override def rootPath: AbsolutePathId = AbsolutePathId(path.headOption.map(_ :: Nil).getOrElse(Nil))
+
+  override def append(id: PathId): AbsolutePathId = AbsolutePathId(path ++ id.path)
+
+  override def append(id: String): AbsolutePathId = append(PathId(id))
+
+  override def /(id: String): AbsolutePathId = append(id)
 }
 
 object AbsolutePathId {

--- a/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/storage/repository/GroupRepositoryImpl.scala
@@ -16,7 +16,7 @@ import mesosphere.marathon.core.storage.repository.impl.PersistenceStoreVersione
 import mesosphere.marathon.core.storage.store.impl.BasePersistenceStore
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
 import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
-import mesosphere.marathon.state.{AppDefinition, Group, RootGroup, PathId, Timestamp}
+import mesosphere.marathon.state._
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.marathon.util.{RichLock, toRichFuture}
 
@@ -28,11 +28,11 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Success}
 
 case class StoredGroup(
-    id: PathId,
+    id: AbsolutePathId,
     appIds: Map[PathId, OffsetDateTime],
     podIds: Map[PathId, OffsetDateTime],
     storedGroups: Seq[StoredGroup],
-    dependencies: Set[PathId],
+    dependencies: Set[AbsolutePathId],
     version: OffsetDateTime,
     enforceRole: Option[Boolean]) extends StrictLogging {
 
@@ -101,7 +101,7 @@ case class StoredGroup(
         pod.id -> pod
     }(collection.breakOut)
 
-    val groups: Map[PathId, Group] = await(Future.sequence(groupFutures)).map { group =>
+    val groups: Map[Group.GroupKey, Group] = await(Future.sequence(groupFutures)).map { group =>
       group.id -> group
     }(collection.breakOut)
 

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -34,7 +34,7 @@ object RoleSettings extends StrictLogging {
       // We have a service in the root group, no enforced role here
       RoleSettings(validRoles = Set(defaultRole), defaultRole = defaultRole)
     } else {
-      val topLevelGroupPath = servicePathId.rootPath
+      val topLevelGroupPath = servicePathId.rootPath.asAbsolutePath
       val topLevelGroupRole = topLevelGroupPath.root
       val topLevelGroup = rootGroup.group(topLevelGroupPath)
 

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -34,7 +34,7 @@ object RoleSettings extends StrictLogging {
       // We have a service in the root group, no enforced role here
       RoleSettings(validRoles = Set(defaultRole), defaultRole = defaultRole)
     } else {
-      val topLevelGroupPath = servicePathId.rootPath.asAbsolutePath
+      val topLevelGroupPath = servicePathId.rootPath
       val topLevelGroupRole = topLevelGroupPath.root
       val topLevelGroup = rootGroup.group(topLevelGroupPath)
 

--- a/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonSchedulerActorTest.scala
@@ -230,14 +230,14 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
         role = "*"
       )
       val probe = TestProbe()
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
+      val origGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app.id -> app))))
 
       val appNew = app.copy(
         cmd = Some("cmd new"),
         versionInfo = VersionInfo.forNewConfig(Timestamp(1000))
       )
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(appNew.id -> appNew))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(appNew.id -> appNew))))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, Nil, Timestamp.now())
 
@@ -266,8 +266,8 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
       )
       val probe = TestProbe()
       val instance = TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance()
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"))))
+      val origGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app.id -> app))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"))))
 
       val plan = DeploymentPlan("d2", origGroup, targetGroup, List(DeploymentStep(List(StopApplication(app)))), Timestamp.now())
 
@@ -294,7 +294,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
         versionInfo = VersionInfo.forNewConfig(Timestamp(0)),
         role = "*"
       )
-      val rootGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
+      val rootGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app.id -> app))))
 
       val plan = DeploymentPlan(createRootGroup(), rootGroup, id = Some("d3"))
 
@@ -323,7 +323,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
         versionInfo = VersionInfo.forNewConfig(Timestamp(0)),
         role = "*"
       )
-      val rootGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
+      val rootGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app.id -> app))))
 
       val plan = DeploymentPlan(createRootGroup(), rootGroup, id = Some("d4"))
 
@@ -344,7 +344,7 @@ class MarathonSchedulerActorTest extends AkkaUnitTest with ImplicitSender with G
     "Forced deployment" in withFixture() { f =>
       import f._
       val app = AppDefinition(id = PathId("/foo/app1"), cmd = Some("cmd"), instances = 2, upgradeStrategy = UpgradeStrategy(0.5), role = "*")
-      val rootGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
+      val rootGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app.id -> app))))
 
       val plan = DeploymentPlan(createRootGroup(), rootGroup, id = Some("d1"))
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -95,13 +95,13 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val normed = normalize(app)
       val appDef = Raml.fromRaml(normed)
 
-      def buildParentGroup(path: PathId, childGroup: Group): Group = {
+      def buildParentGroup(path: AbsolutePathId, childGroup: Group): Group = {
         val group = createGroup(path, groups = Set(childGroup))
         groupManager.group(path) returns Some(group)
         if (path.parent.isRoot) group else buildParentGroup(path.parent, group)
       }
 
-      def buildGroupWithApp(path: PathId): Group = {
+      def buildGroupWithApp(path: AbsolutePathId): Group = {
         val group = createGroup(path, apps = Map(appDef.id -> appDef))
         groupManager.group(path) returns Some(group)
         if (path.parent.isRoot) group else buildParentGroup(path.parent, group)
@@ -120,19 +120,19 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
     }
 
     def prepareGroup(groupId: String, groupManager: GroupManager) = {
-      def buildParentGroup(path: PathId, childGroup: Group): Group = {
+      def buildParentGroup(path: AbsolutePathId, childGroup: Group): Group = {
         val group = createGroup(path, groups = Set(childGroup))
         groupManager.group(path) returns Some(group)
         if (path.parent.isRoot) group else buildParentGroup(path.parent, group)
       }
 
-      def buildGroup(path: PathId): Group = {
+      def buildGroup(path: AbsolutePathId): Group = {
         val group = createGroup(path)
         groupManager.group(path) returns Some(group)
         if (path.parent.isRoot) group else buildParentGroup(path.parent, group)
       }
 
-      val groupPath = PathId(groupId)
+      val groupPath = AbsolutePathId(groupId)
       val group = buildGroup(groupPath)
 
       val rootGroup = createRootGroup(groups = Set(group), validate = false, enabledFeatures = Set.empty)
@@ -2221,7 +2221,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
     }
 
-    "Create a new app inside a top-group with enforceRole applies the proper group-role default" in new FixtureWithRealGroupManager(initialRoot = createRootGroup(groups = Set(createGroup("/dev".toPath, enforceRole = true)))) {
+    "Create a new app inside a top-group with enforceRole applies the proper group-role default" in new FixtureWithRealGroupManager(initialRoot = createRootGroup(groups = Set(createGroup("/dev".toAbsolutePath, enforceRole = true)))) {
       service.deploy(any, any) returns Future.successful(Done)
 
       Given("group /dev with enforceRole: true")

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -77,13 +77,13 @@ class ModelValidationTest extends UnitTest with GroupCreation with ValidationTes
       val validApp = AppDefinition("/test/group1/valid".toPath, cmd = Some("foo"), role = "*")
       val invalidApp = AppDefinition("/test/group1/invalid".toPath, role = "*")
       val rootGroup = createRootGroup(
-        groups = Set(createGroup("/test".toPath, groups = Set(
-          createGroup("/test/group1".toPath, Map(
+        groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+          createGroup("/test/group1".toAbsolutePath, Map(
             validApp.id -> validApp,
             invalidApp.id -> invalidApp),
             validate = false
           ),
-          createGroup("/test/group2".toPath, validate = false)),
+          createGroup("/test/group2".toAbsolutePath, validate = false)),
           validate = false)),
         validate = false
       )
@@ -96,7 +96,7 @@ class ModelValidationTest extends UnitTest with GroupCreation with ValidationTes
     "PortDefinition should be allowed to contain tcp and udp as protocol." in {
       val validApp = AppDefinition("/test/app".toPath, cmd = Some("foo"), portDefinitions = Seq(PortDefinition(port = 80, protocol = "udp,tcp")), role = "*")
 
-      val rootGroup = createRootGroup(groups = Set(createGroup("/test".toPath, apps = Map(validApp.id -> validApp))))
+      val rootGroup = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath, apps = Map(validApp.id -> validApp))))
 
       val result = validate(rootGroup)(RootGroup.validRootGroup(emptyConfig))
       result.isSuccess should be(true)

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -23,7 +23,7 @@ import mesosphere.marathon.core.pod.{MesosContainer, PodDefinition, PodManager}
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer}
 import mesosphere.marathon.raml.{EnvVarSecret, ExecutorResources, FixedPodScalingPolicy, NetworkMode, PersistentVolumeInfo, PersistentVolumeType, Pod, PodPersistentVolume, PodSecretVolume, PodState, PodStatus, Raml, Resources, VolumeMount}
 import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.{AppDefinition, Group, PathId, ResourceRole, Timestamp, UnreachableStrategy, VersionInfo}
+import mesosphere.marathon.state._
 import mesosphere.marathon.test.{GroupCreation, JerseyTest, Mockito, SettableClock}
 import mesosphere.marathon.util.SemanticVersion
 import play.api.libs.json._
@@ -2001,7 +2001,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
   ) extends GroupCreation {
 
     def prepareGroup(groupId: String, pods: Map[PathId, PodDefinition] = Group.defaultPods): Unit = {
-      val groupPath = PathId(groupId)
+      val groupPath = AbsolutePathId(groupId)
 
       val group = createGroup(groupPath, pods = pods)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/DeploymentFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/DeploymentFormatsTest.scala
@@ -118,13 +118,13 @@ class DeploymentFormatsTest extends UnitTest with GroupCreation {
   def genGroup(children: Set[Group] = Set.empty) = {
     val app1 = genApp
     val app2 = genApp
-    createGroup(genId, apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId), version = genTimestamp, validate = false)
+    createGroup(genId.asAbsolutePath, apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId.asAbsolutePath), version = genTimestamp, validate = false)
   }
 
   def genRootGroup(children: Set[Group] = Set.empty) = {
     val app1 = genApp
     val app2 = genApp
-    createRootGroup(apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId), version = genTimestamp, validate = false)
+    createRootGroup(apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId.asAbsolutePath), version = genTimestamp, validate = false)
   }
 
   def genGroupUpdate(children: Set[GroupUpdate] = Set.empty) =

--- a/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
@@ -59,8 +59,8 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       Given("A group with updates of existing nodes")
       val blaApp = AppDefinition("/test/bla".toPath, Some("foo"), role = "*")
       val actual = createRootGroup(groups = Set(
-        createGroup("/test".toPath, apps = Map(blaApp.id -> blaApp)),
-        createGroup("/apps".toPath, groups = Set(createGroup("/apps/foo".toPath)))
+        createGroup("/test".toAbsolutePath, apps = Map(blaApp.id -> blaApp)),
+        createGroup("/apps".toAbsolutePath, groups = Set(createGroup("/apps/foo".toAbsolutePath)))
       ))
       val update = GroupUpdate(
         Some(PathId.root.toString),
@@ -108,10 +108,10 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       val app1 = AppDefinition("/test/group1/app1".toPath, Some("foo"), role = "*")
       val app2 = AppDefinition("/test/group2/app2".toPath, Some("foo"), role = "*")
       val current = createGroup(
-        "/test".toPath,
+        "/test".toAbsolutePath,
         groups = Set(
-          createGroup("/test/group1".toPath, Map(app1.id -> app1)),
-          createGroup("/test/group2".toPath, Map(app2.id -> app2))
+          createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
+          createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
         )
       )
 
@@ -141,14 +141,14 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       Then("The update is reflected in the current group")
       result.id.toString should be("/")
       result.apps should be('empty)
-      val group0 = result.group("/test".toPath).get
+      val group0 = result.group("/test".toAbsolutePath).get
       group0.id.toString should be("/test")
       group0.apps should be('empty)
       group0.groupsById should have size 2
-      val group1 = result.group("/test/group1".toPath).get
-      group1.id should be("/test/group1".toPath)
+      val group1 = result.group("/test/group1".toAbsolutePath).get
+      group1.id should be("/test/group1".toAbsolutePath)
       group1.apps.head._1 should be("/test/group1/app3".toPath)
-      val group3 = result.group("/test/group3".toPath).get
+      val group3 = result.group("/test/group3".toAbsolutePath).get
       group3.id should be("/test/group3".toPath)
       group3.apps should be('empty)
     }
@@ -189,7 +189,7 @@ class GroupUpdateTest extends UnitTest with GroupCreation {
       val group = result.group("test-group".toAbsolutePath)
       group should be('defined)
       group.get.apps should have size 2
-      val dependentApp = group.get.app("/test-group/test-app2".toPath).get
+      val dependentApp = group.get.app("/test-group/test-app2".toAbsolutePath).get
       dependentApp.dependencies should be (Set("/test-group/test-app1".toPath))
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/DefaultInfoServiceTest.scala
@@ -116,7 +116,7 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     "queryForGroupId" in {
       Given("a group repo with some apps below the queried group id")
       val f = new Fixture
-      f.groupManager.group(PathId("/nested")) returns someGroupWithNested.group(PathId("/nested"))
+      f.groupManager.group(PathId("/nested")) returns someGroupWithNested.group(AbsolutePathId("/nested"))
       f.baseData.appInfoFuture(any, any) answers { args =>
         Future.successful(AppInfo(args.head.asInstanceOf[AppDefinition]))
       }
@@ -139,7 +139,7 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     "queryForGroupId passes embed infos along" in {
       Given("a group repo with some apps below the queried group id")
       val f = new Fixture
-      f.groupManager.group(PathId("/nested")) returns someGroupWithNested.group(PathId("/nested"))
+      f.groupManager.group(PathId("/nested")) returns someGroupWithNested.group(AbsolutePathId("/nested"))
       f.baseData.appInfoFuture(any, any) answers { args =>
         Future.successful(AppInfo(args.head.asInstanceOf[AppDefinition]))
       }
@@ -220,7 +220,7 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
       val rootApp = AppDefinition(PathId("/app"), cmd = Some("sleep"), role = "*")
       val nestedApp1 = AppDefinition(PathId("/group/app1"), cmd = Some("sleep"), role = "*")
       val nestedApp2 = AppDefinition(PathId("/group/app2"), cmd = Some("sleep"), role = "*")
-      val nestedGroup = createGroup(PathId("/group"), Map(nestedApp1.id -> nestedApp1, nestedApp2.id -> nestedApp2))
+      val nestedGroup = createGroup(AbsolutePathId("/group"), Map(nestedApp1.id -> nestedApp1, nestedApp2.id -> nestedApp2))
       val rootGroup = createRootGroup(Map(rootApp.id -> rootApp), groups = Set(nestedGroup))
 
       f.baseData.appInfoFuture(any, any) answers { args =>
@@ -281,7 +281,7 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     apps = someApps,
     groups = Set(
       createGroup(
-        id = PathId("/nested"),
+        id = AbsolutePathId("/nested"),
         apps = someNestedApps
       )
     ))
@@ -296,14 +296,14 @@ class DefaultInfoServiceTest extends UnitTest with GroupCreation {
     val otherGroupApp1 = AppDefinition(PathId("/other/group/app1"), cmd = Some("sleep"), role = "*")
 
     createRootGroup(Map(app1.id -> app1), groups = Set(
-      createGroup(PathId("/visible"), Map(visibleApp1.id -> visibleApp1), groups = Set(
-        createGroup(PathId("/visible/group"), Map(visibleGroupApp1.id -> visibleGroupApp1))
+      createGroup(AbsolutePathId("/visible"), Map(visibleApp1.id -> visibleApp1), groups = Set(
+        createGroup(AbsolutePathId("/visible/group"), Map(visibleGroupApp1.id -> visibleGroupApp1))
       )),
-      createGroup(PathId("/secure"), Map(secureApp1.id -> secureApp1), groups = Set(
-        createGroup(PathId("/secure/group"), Map(secureGroupApp1.id -> secureGroupApp1))
+      createGroup(AbsolutePathId("/secure"), Map(secureApp1.id -> secureApp1), groups = Set(
+        createGroup(AbsolutePathId("/secure/group"), Map(secureGroupApp1.id -> secureGroupApp1))
       )),
-      createGroup(PathId("/other"), Map(otherApp1.id -> otherApp1), groups = Set(
-        createGroup(PathId("/other/group"), Map(otherGroupApp1.id -> otherGroupApp1)
+      createGroup(AbsolutePathId("/other"), Map(otherApp1.id -> otherApp1), groups = Set(
+        createGroup(AbsolutePathId("/other/group"), Map(otherGroupApp1.id -> otherGroupApp1)
         ))
       )))
   }

--- a/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/DeploymentPlanTest.scala
@@ -30,11 +30,11 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val d = AppDefinition(dId, dependencies = Set(bId), cmd = Some("sleep"), role = "*")
 
       val rootGroup = createRootGroup(groups = Set(createGroup(
-        id = "/test".toPath,
+        id = "/test".toAbsolutePath,
         apps = Map(c.id -> c, d.id -> d),
         groups = Set(
-          createGroup("/test/database".toPath, Map(a.id -> a)),
-          createGroup("/test/service".toPath, Map(b.id -> b))
+          createGroup("/test/database".toAbsolutePath, Map(a.id -> a)),
+          createGroup("/test/service".toAbsolutePath, Map(b.id -> b))
         )
       )))
 
@@ -85,8 +85,8 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
     "start from empty group" in {
       val app = AppDefinition("/group/app".toPath, instances = 2, cmd = Some("sleep"), role = "*")
-      val from = createRootGroup(groups = Set(createGroup("/group".toPath, Map.empty, groups = Set.empty)))
-      val to = createRootGroup(groups = Set(createGroup("/group".toPath, Map(app.id -> app))))
+      val from = createRootGroup(groups = Set(createGroup("/group".toAbsolutePath, Map.empty, groups = Set.empty)))
+      val to = createRootGroup(groups = Set(createGroup("/group".toAbsolutePath, Map(app.id -> app))))
       val plan = DeploymentPlan(from, to)
 
       actionsOf(plan) should contain(StartApplication(app))
@@ -103,8 +103,8 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val apps = Map(app1.id -> app1, app2.id -> app2, app3.id -> app3)
       val update = Map(updatedApp1.id -> updatedApp1, updatedApp2.id -> updatedApp2, app4.id -> app4)
 
-      val from = createRootGroup(groups = Set(createGroup("/group".toPath, apps)))
-      val to = createRootGroup(groups = Set(createGroup("/group".toPath, update)))
+      val from = createRootGroup(groups = Set(createGroup("/group".toAbsolutePath, apps)))
+      val to = createRootGroup(groups = Set(createGroup("/group".toAbsolutePath, update)))
       val plan = DeploymentPlan(from, to)
 
       val actions = plan.steps.flatMap(s => s.actions)
@@ -133,8 +133,8 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
         unchanged.id -> unchanged
       )
 
-      val from = createRootGroup(groups = Set(createGroup("/group".toPath, apps)))
-      val to = createRootGroup(groups = Set(createGroup("/group".toPath, update)))
+      val from = createRootGroup(groups = Set(createGroup("/group".toAbsolutePath, apps)))
+      val to = createRootGroup(groups = Set(createGroup("/group".toAbsolutePath, update)))
       val plan = DeploymentPlan(from, to)
 
       plan.affectedRunSpecIds should equal(Set("/group/app".toPath, "/group/app2".toPath, "/group/app3".toPath, "/group/app4".toPath))
@@ -162,17 +162,17 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
           )
 
       val from = createRootGroup(groups = Set(createGroup(
-        id = "/test".toPath,
+        id = "/test".toAbsolutePath,
         groups = Set(
-          createGroup("/test/database".toPath, Map(mongo._1.id -> mongo._1)),
-          createGroup("/test/service".toPath, Map(service._1.id -> service._1))
+          createGroup("/test/database".toAbsolutePath, Map(mongo._1.id -> mongo._1)),
+          createGroup("/test/service".toAbsolutePath, Map(service._1.id -> service._1))
         )
       )
       ))
 
-      val to = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
-        createGroup("/test/database".toPath, Map(mongo._2.id -> mongo._2)),
-        createGroup("/test/service".toPath, Map(service._2.id -> service._2))
+      val to = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+        createGroup("/test/database".toAbsolutePath, Map(mongo._2.id -> mongo._2)),
+        createGroup("/test/service".toAbsolutePath, Map(service._2.id -> service._2))
       ))))
 
       When("the deployment plan is computed")
@@ -186,7 +186,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
     "when starting apps without dependencies, they are first started and then scaled parallely" in {
       Given("an empty group and the same group but now including four independent apps")
-      val emptyGroup = createRootGroup(groups = Set(createGroup(id = "/test".toPath)))
+      val emptyGroup = createRootGroup(groups = Set(createGroup(id = "/test".toAbsolutePath)))
 
       val instances: Int = 10
 
@@ -196,7 +196,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       }(collection.breakOut)
 
       val targetGroup = createRootGroup(groups = Set(createGroup(
-        id = "/test".toPath,
+        id = "/test".toAbsolutePath,
         apps = apps,
         groups = Set()
       )))
@@ -228,14 +228,14 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
         AppDefinition(serviceId, Some("srv1"), instances = 4, upgradeStrategy = strategy, versionInfo = versionInfo, role = "*") ->
           AppDefinition(serviceId, Some("srv2"), instances = 10, upgradeStrategy = strategy, versionInfo = versionInfo, role = "*")
 
-      val from = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
-        createGroup("/test/database".toPath, Map(mongo._1.id -> mongo._1)),
-        createGroup("/test/service".toPath, Map(service._1.id -> service._1))
+      val from = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+        createGroup("/test/database".toAbsolutePath, Map(mongo._1.id -> mongo._1)),
+        createGroup("/test/service".toAbsolutePath, Map(service._1.id -> service._1))
       ))))
 
-      val to = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
-        createGroup("/test/database".toPath, Map(mongo._2.id -> mongo._2)),
-        createGroup("/test/service".toPath, Map(service._2.id -> service._2))
+      val to = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+        createGroup("/test/database".toAbsolutePath, Map(mongo._2.id -> mongo._2)),
+        createGroup("/test/service".toAbsolutePath, Map(service._2.id -> service._2))
       ))))
 
       When("the deployment plan is computed")
@@ -271,16 +271,16 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val toStop = AppDefinition("/test/service/to-stop".toPath, instances = 1, dependencies = Set(mongoId), cmd = Some("sleep"), role = "*")
       val toStart = AppDefinition("/test/service/to-start".toPath, instances = 2, dependencies = Set(serviceId), cmd = Some("sleep"), role = "*")
 
-      val from = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
-        createGroup("/test/database".toPath, Map(mongo._1.id -> mongo._1)),
-        createGroup("/test/service".toPath, Map(service._1.id -> service._1, toStop.id -> toStop)),
-        createGroup("/test/independent".toPath, Map(independent._1.id -> independent._1))
+      val from = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+        createGroup("/test/database".toAbsolutePath, Map(mongo._1.id -> mongo._1)),
+        createGroup("/test/service".toAbsolutePath, Map(service._1.id -> service._1, toStop.id -> toStop)),
+        createGroup("/test/independent".toAbsolutePath, Map(independent._1.id -> independent._1))
       ))))
 
-      val to = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
-        createGroup("/test/database".toPath, Map(mongo._2.id -> mongo._2)),
-        createGroup("/test/service".toPath, Map(service._2.id -> service._2, toStart.id -> toStart)),
-        createGroup("/test/independent".toPath, Map(independent._2.id -> independent._2))
+      val to = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+        createGroup("/test/database".toAbsolutePath, Map(mongo._2.id -> mongo._2)),
+        createGroup("/test/service".toAbsolutePath, Map(service._2.id -> service._2, toStart.id -> toStart)),
+        createGroup("/test/independent".toAbsolutePath, Map(independent._2.id -> independent._2))
       ))))
 
       When("the deployment plan is computed")
@@ -303,10 +303,10 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
       val strategy = UpgradeStrategy(0.75)
       val app = AppDefinition("/test/independent/app".toPath, Some("app2"), instances = 3, upgradeStrategy = strategy, role = "*") -> None
       val from = createRootGroup(
-        groups = Set(createGroup("/test".toPath, groups = Set(
-          createGroup("/test/independent".toPath, Map(app._1.id -> app._1))
+        groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+          createGroup("/test/independent".toAbsolutePath, Map(app._1.id -> app._1))
         ))))
-      val to = createRootGroup(groups = Set(createGroup("/test".toPath)))
+      val to = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath)))
 
       When("the deployment plan is computed")
       val plan = DeploymentPlan(from, to)
@@ -370,17 +370,17 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
       When("A deployment plan is generated")
       val originalGroup = createRootGroup(groups = Set(createGroup(
-        id = "/test".toPath,
+        id = "/test".toAbsolutePath,
         groups = Set(
-          createGroup("/test/some".toPath, Map(oldAppA.id -> oldAppA))
+          createGroup("/test/some".toAbsolutePath, Map(oldAppA.id -> oldAppA))
         )
       )))
 
       val newAppA = oldAppA.copy(instances = 5)
       val targetGroup = createRootGroup(groups = Set(createGroup(
-        id = "/test".toPath,
+        id = "/test".toAbsolutePath,
         groups = Set(
-          createGroup("/test/some".toPath, Map(newAppA.id -> newAppA))
+          createGroup("/test/some".toAbsolutePath, Map(newAppA.id -> newAppA))
         )
       )))
 
@@ -415,7 +415,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
 
       When("We update the upgrade strategy to the default strategy")
       val app2 = f.validResident.copy(upgradeStrategy = AppDefinition.DefaultUpgradeStrategy)
-      val rootGroup2 = f.rootGroup.updateApps(PathId("/test"), _ => Map(app2.id -> app2), f.rootGroup.version)
+      val rootGroup2 = f.rootGroup.updateApps(AbsolutePathId("/test"), _ => Map(app2.id -> app2), f.rootGroup.version)
       val plan2 = DeploymentPlan(f.rootGroup, rootGroup2)
 
       Then("The deployment is not valid")
@@ -433,15 +433,15 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
           AppDefinition(mongoId, Some("mng2"), instances = 0, upgradeStrategy = strategy, versionInfo = versionInfo, role = "*")
 
       val from = createRootGroup(groups = Set(createGroup(
-        id = "/test".toPath,
+        id = "/test".toAbsolutePath,
         groups = Set(
-          createGroup("/test/database".toPath, Map(mongo._1.id -> mongo._1))
+          createGroup("/test/database".toAbsolutePath, Map(mongo._1.id -> mongo._1))
         )
       )
       ))
 
-      val to = createRootGroup(groups = Set(createGroup("/test".toPath, groups = Set(
-        createGroup("/test/database".toPath, Map(mongo._2.id -> mongo._2))
+      val to = createRootGroup(groups = Set(createGroup("/test".toAbsolutePath, groups = Set(
+        createGroup("/test/database".toAbsolutePath, Map(mongo._2.id -> mongo._2))
       ))))
 
       When("the deployment plan is computed")
@@ -471,7 +471,7 @@ class DeploymentPlanTest extends UnitTest with GroupCreation {
     val vol2 = persistentVolume("bla")
     val vol3 = persistentVolume("test")
     val validResident = residentApp("/test/app1", Seq(vol1, vol2)).copy(upgradeStrategy = zero)
-    val rootGroup = createRootGroup(groups = Set(createGroup(PathId("/test"), apps = Map(validResident.id -> validResident))))
+    val rootGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/test"), apps = Map(validResident.id -> validResident))))
     val marathonConf = MarathonTestHelper.defaultConfig()
     val validator = DeploymentPlan.deploymentPlanValidator()
   }

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentActorTest.scala
@@ -97,7 +97,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val app2 = AppDefinition(id = PathId("/foo/app2"), role = "*", cmd = Some("cmd"), instances = 1)
       val app3 = AppDefinition(id = PathId("/foo/app3"), role = "*", cmd = Some("cmd"), instances = 1)
       val app4 = AppDefinition(id = PathId("/foo/app4"), role = "*", cmd = Some("cmd"))
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(
+      val origGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(
         app1.id -> app1,
         app2.id -> app2,
         app4.id -> app4))))
@@ -106,7 +106,7 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val app1New = app1.copy(instances = 1, versionInfo = version2)
       val app2New = app2.copy(instances = 2, cmd = Some("otherCmd"), versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(
+      val targetGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(
         app1New.id -> app1New,
         app2New.id -> app2New,
         app3.id -> app3))))
@@ -175,12 +175,12 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
     "Restart app" in new Fixture {
       val managerProbe = TestProbe()
       val app = AppDefinition(id = PathId("/foo/app1"), role = "*", cmd = Some("cmd"), instances = 2)
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
+      val origGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app.id -> app))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val appNew = app.copy(cmd = Some("cmd new"), versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(appNew.id -> appNew))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(appNew.id -> appNew))))
 
       val instance1_1 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app.id, version = app.version).addTaskRunning(startedAt = Timestamp(1000)).getInstance()
@@ -215,11 +215,11 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
       val managerProbe = TestProbe()
 
       val app = AppDefinition(id = PathId("/foo/app1"), role = "*", cmd = Some("cmd"), instances = 0)
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app.id -> app))))
+      val origGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app.id -> app))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val appNew = app.copy(cmd = Some("cmd new"), versionInfo = version2)
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(appNew.id -> appNew))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(appNew.id -> appNew))))
 
       val plan = DeploymentPlan("foo", origGroup, targetGroup, List(DeploymentStep(List(RestartApplication(appNew)))), Timestamp.now())
 
@@ -236,12 +236,12 @@ class DeploymentActorTest extends AkkaUnitTest with GroupCreation {
     "Scale with tasksToKill" in new Fixture {
       val managerProbe = TestProbe()
       val app1 = AppDefinition(id = PathId("/foo/app1"), role = "*", cmd = Some("cmd"), instances = 3)
-      val origGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app1.id -> app1))))
+      val origGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app1.id -> app1))))
 
       val version2 = VersionInfo.forNewConfig(Timestamp(1000))
       val app1New = app1.copy(instances = 2, versionInfo = version2)
 
-      val targetGroup = createRootGroup(groups = Set(createGroup(PathId("/foo"), Map(app1New.id -> app1New))))
+      val targetGroup = createRootGroup(groups = Set(createGroup(AbsolutePathId("/foo"), Map(app1New.id -> app1New))))
 
       val instance1_1 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp.zero).getInstance()
       val instance1_2 = TestInstanceBuilder.newBuilder(app1.id, version = app1.version).addTaskRunning(startedAt = Timestamp(500)).getInstance()

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
@@ -342,7 +342,7 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
               createGroup(
                 id,
                 apps = Group.defaultApps,
-                groups = Set(createGroup((id / "some").asAbsolutePath)),
+                groups = Set(createGroup(id / "some")),
                 dependencies = Set() // dependencies were introduce with first deployment, should be gone now
               )
             },
@@ -461,9 +461,9 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
                   ),
                   groups = Set(
                     createGroup(
-                      (id / "some").asAbsolutePath,
+                      id / "some",
                       groups = Set(
-                        createGroup((id / "some" / "b").asAbsolutePath)
+                        createGroup(id / "some" / "b")
                       )
                     )
                   )
@@ -508,10 +508,10 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
                 ),
                 groups = Set(
                   createGroup(
-                    (id / "some").asAbsolutePath,
+                    id / "some",
                     groups = Set(
                       createGroup(
-                        (id / "some" / "b").asAbsolutePath,
+                        id / "some" / "b",
                         apps = Map(
                           appBA.id -> appBA,
                           appBB.id -> appBB,

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
@@ -338,11 +338,11 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             createGroup("othergroup2".toAbsolutePath),
             createGroup("othergroup3".toAbsolutePath),
             {
-              val id = "withdeps".toAbsolutePath // withdeps still exists because of the subgroup
+              val id = "/withdeps".toAbsolutePath // withdeps still exists because of the subgroup
               createGroup(
                 id,
                 apps = Group.defaultApps,
-                groups = Set(createGroup(id / "some")),
+                groups = Set(createGroup((id / "some").asAbsolutePath)),
                 dependencies = Set() // dependencies were introduce with first deployment, should be gone now
               )
             },
@@ -461,9 +461,9 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
                   ),
                   groups = Set(
                     createGroup(
-                      id / "some",
+                      (id / "some").asAbsolutePath,
                       groups = Set(
-                        createGroup(id / "some" / "b")
+                        createGroup((id / "some" / "b").asAbsolutePath)
                       )
                     )
                   )
@@ -508,10 +508,10 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
                 ),
                 groups = Set(
                   createGroup(
-                    id / "some",
+                    (id / "some").asAbsolutePath,
                     groups = Set(
                       createGroup(
-                        id / "some" / "b",
+                        (id / "some" / "b").asAbsolutePath,
                         apps = Map(
                           appBA.id -> appBA,
                           appBB.id -> appBB,

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
@@ -23,7 +23,7 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
       val rootGroup = createRootGroup(
         groups = Set(
           createGroup(
-            id = PathId("/nested"),
+            id = AbsolutePathId("/nested"),
             apps = Map(
               app1.id -> app1,
               app2.id -> app2
@@ -48,7 +48,7 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
       val rootGroup = createRootGroup(
         groups = Set(
           createGroup(
-            id = PathId("/nested"),
+            id = AbsolutePathId("/nested"),
             apps = Map(
               app1.id -> app1,
               app2.id -> app2

--- a/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/group/GroupManagerTest.scala
@@ -45,7 +45,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
 
     "not store invalid groups" in new Fixture {
       val app1 = AppDefinition("/app1".toPath, role = "*")
-      val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toPath)), validate = false)
+      val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toAbsolutePath)), validate = false)
 
       groupRepository.root() returns Future.successful(createRootGroup())
 
@@ -67,7 +67,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
 
     "publishes GroupChangeSuccess with the appropriate GID on successful deployment" in new Fixture {
       val app: AppDefinition = AppDefinition("/group/app1".toPath, role = "*", cmd = Some("sleep 3"), portDefinitions = Seq.empty)
-      val group = createGroup("/group".toPath, apps = Map(app.id -> app), version = Timestamp(1))
+      val group = createGroup("/group".toAbsolutePath, apps = Map(app.id -> app), version = Timestamp(1))
 
       groupRepository.root() returns Future.successful(createRootGroup())
       deploymentService.deploy(any, any) returns Future.successful(Done)
@@ -80,7 +80,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
         version = Timestamp(1),
         groups = Set(
           createGroup(
-            "/group".toPath, apps = Map(appWithAdditionalInfo.id -> appWithAdditionalInfo), version = Timestamp(1))))
+            "/group".toAbsolutePath, apps = Map(appWithAdditionalInfo.id -> appWithAdditionalInfo), version = Timestamp(1))))
       groupRepository.storeRootVersion(any, any, any) returns Future.successful(Done)
       groupRepository.storeRoot(any, any, any, any, any) returns Future.successful(Done)
       val groupChangeSuccess = Promise[GroupChangeSuccess]
@@ -139,7 +139,7 @@ class GroupManagerTest extends AkkaUnitTest with GroupCreation {
 
     "dismiss deployments when max_running_deployments limit is achieved" in new Fixture(maxRunningDeployments = 5) {
       val app1 = AppDefinition("/app1".toPath, role = "*")
-      val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toPath)), validate = false)
+      val rootGroup = createRootGroup(Map(app1.id -> app1), groups = Set(createGroup("/app1".toAbsolutePath)), validate = false)
       groupRepository.root() returns Future.successful(createRootGroup())
 
       val running = (1.to(maxRunningDeployments).map(_ => mock[DeploymentStepInfo]))

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -21,9 +21,9 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app2 = AppDefinition("/test/group2/app2".toPath, role = "*", cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/group1".toPath, Map(app1.id -> app1)),
-            createGroup("/test/group2".toPath, Map(app2.id -> app2))
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
+            createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
           ))))
 
       When("an app with a specific path is requested")
@@ -51,9 +51,9 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app2 = AppDefinition("/test/group2/app2".toPath, role = "*", cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/group1".toPath, Map(app1.id -> app1)),
-            createGroup("/test/group2".toPath, Map(app2.id -> app2))
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
+            createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
           ))))
 
       When("a group with a specific path is requested")
@@ -69,13 +69,13 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app2 = AppDefinition("/test/group2/app2".toPath, role = "*", cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/group1".toPath, Map(app1.id -> app1)),
-            createGroup("/test/group2".toPath, Map(app2.id -> app2))
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
+            createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
           ))))
 
       When("a group with a specific path is requested")
-      val path = PathId("/test/group1")
+      val path = AbsolutePathId("/test/group1")
 
       Then("the group is found")
       current.group(path) should be('defined)
@@ -87,13 +87,13 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app2 = AppDefinition("/test/group2/app2".toPath, role = "*", cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/group1".toPath, Map(app1.id -> app1)),
-            createGroup("/test/group2".toPath, Map(app2.id -> app2))
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
+            createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
           ))))
 
       When("a group with a specific path is requested")
-      val path = PathId("/test/unknown")
+      val path = AbsolutePathId("/test/unknown")
 
       Then("the group is not found")
       current.group(path) should be('empty)
@@ -101,14 +101,14 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "can delete a node based in the path" in {
       Given("an existing group with two subgroups")
-      val current = createRootGroup().makeGroup("/test/foo/one".toPath).makeGroup("/test/bla/two".toPath)
+      val current = createRootGroup().makeGroup("/test/foo/one".toAbsolutePath).makeGroup("/test/bla/two".toAbsolutePath)
 
       When("a node will be deleted based on path")
-      val rootGroup = current.removeGroup("/test/foo".toPath)
+      val rootGroup = current.removeGroup("/test/foo".toAbsolutePath)
 
       Then("the update has been applied")
-      rootGroup.group("/test/foo".toPath) should be('empty)
-      rootGroup.group("/test/bla".toPath) should be('defined)
+      rootGroup.group("/test/foo".toAbsolutePath) should be('empty)
+      rootGroup.group("/test/bla".toAbsolutePath) should be('defined)
     }
 
     "can make groups specified by a path" in {
@@ -117,27 +117,27 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app2 = AppDefinition("/test/group2/app2".toPath, role = "*", cmd = Some("sleep"))
       val current = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/group1".toPath, Map(app1.id -> app1)),
-            createGroup("/test/group2".toPath, Map(app2.id -> app2))
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
+            createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
           ))))
 
       When("a non existing path is requested")
-      val path = PathId("/test/group3/group4/group5")
+      val path = AbsolutePathId("/test/group3/group4/group5")
       val rootGroup = current.makeGroup(path)
 
       Then("the path has been created")
       rootGroup.group(path) should be('defined)
 
       When("a partly existing path is requested")
-      val path2 = PathId("/test/group1/group4/group5")
+      val path2 = AbsolutePathId("/test/group1/group4/group5")
       val rootGroup2 = current.makeGroup(path2)
 
       Then("only the missing path has been created")
       rootGroup2.group(path2) should be('defined)
 
       When("the path is already existent")
-      val path3 = PathId("/test/group1")
+      val path3 = AbsolutePathId("/test/group1")
       val rootGroup3 = current.makeGroup(path3)
 
       Then("nothing has been changed")
@@ -152,8 +152,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group /some/nested which does not directly or indirectly contain apps")
       val current =
         createRootGroup()
-          .makeGroup("/some/nested/path".toPath)
-          .makeGroup("/some/nested/path2".toPath)
+          .makeGroup("/some/nested/path".toAbsolutePath)
+          .makeGroup("/some/nested/path2".toAbsolutePath)
 
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2"))
@@ -176,8 +176,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group /some/nested which does contain an app")
       val current =
         createRootGroup()
-          .makeGroup("/some/nested/path".toPath)
-          .makeGroup("/some/nested/path2".toPath)
+          .makeGroup("/some/nested/path".toAbsolutePath)
+          .makeGroup("/some/nested/path2".toAbsolutePath)
           .updateApp(
             "/some/nested/path2/app".toPath,
             _ => AppDefinition("/some/nested/path2/app".toPath, role = "*", cmd = Some("true")),
@@ -208,8 +208,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group /some/nested which does contain an pod")
       val current =
         createRootGroup()
-          .makeGroup("/some/nested/path".toPath)
-          .makeGroup("/some/nested/path2".toPath)
+          .makeGroup("/some/nested/path".toAbsolutePath)
+          .makeGroup("/some/nested/path2".toAbsolutePath)
           .updatePod(
             "/some/nested/path2/pod".toPath,
             _ => PodDefinition(id = PathId("/some/nested/path2/pod"), role = "*"),
@@ -241,8 +241,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group /some/nested which does contain an pod")
       val current =
         createRootGroup()
-          .makeGroup("/some/nested/path".toPath)
-          .makeGroup("/some/nested/path2".toPath)
+          .makeGroup("/some/nested/path".toAbsolutePath)
+          .makeGroup("/some/nested/path2".toAbsolutePath)
           .updatePod(
             "/some/nested/path2/pod".toPath,
             _ => PodDefinition(id = PathId("/some/nested/path2/pod"), role = "*"),
@@ -284,22 +284,27 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val cacheApp = AppDefinition("/test/cache/c1/c1".toPath, role = "*", cmd = Some("sleep"))
       val current: RootGroup = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/database".toPath, groups = Set(
-              createGroup("/test/database/redis".toPath, Map(redisApp.id -> redisApp)),
-              createGroup("/test/database/memcache".toPath, Map(memcacheApp.id -> memcacheApp), dependencies = Set("/test/database/mongo".toPath, "/test/database/redis".toPath)),
-              createGroup("/test/database/mongo".toPath, Map(mongoApp.id -> mongoApp), dependencies = Set("/test/database/redis".toPath))
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/database".toAbsolutePath, groups = Set(
+              createGroup("/test/database/redis".toAbsolutePath, Map(redisApp.id -> redisApp)),
+              createGroup("/test/database/memcache".toAbsolutePath, Map(memcacheApp.id -> memcacheApp),
+                dependencies = Set("/test/database/mongo".toAbsolutePath, "/test/database/redis".toAbsolutePath)),
+              createGroup("/test/database/mongo".toAbsolutePath, Map(mongoApp.id -> mongoApp),
+                dependencies = Set("/test/database/redis".toAbsolutePath))
             )),
-            createGroup("/test/service".toPath, groups = Set(
-              createGroup("/test/service/service1".toPath, Map(serviceApp1.id -> serviceApp1), dependencies = Set("/test/database/memcache".toPath)),
-              createGroup("/test/service/service2".toPath, Map(serviceApp2.id -> serviceApp2), dependencies = Set("/test/database".toPath, "/test/service/service1".toPath))
+            createGroup("/test/service".toAbsolutePath, groups = Set(
+              createGroup("/test/service/service1".toAbsolutePath, Map(serviceApp1.id -> serviceApp1),
+                dependencies = Set("/test/database/memcache".toAbsolutePath)),
+              createGroup("/test/service/service2".toAbsolutePath, Map(serviceApp2.id -> serviceApp2),
+                dependencies = Set("/test/database".toAbsolutePath, "/test/service/service1".toAbsolutePath))
             )),
-            createGroup("/test/frontend".toPath, groups = Set(
-              createGroup("/test/frontend/app1".toPath, Map(frontendApp1.id -> frontendApp1), dependencies = Set("/test/service/service2".toPath)),
-              createGroup("/test/frontend/app2".toPath, Map(frontendApp2.id -> frontendApp2), dependencies = Set("/test/service".toPath, "/test/database/mongo".toPath, "/test/frontend/app1".toPath))
+            createGroup("/test/frontend".toAbsolutePath, groups = Set(
+              createGroup("/test/frontend/app1".toAbsolutePath, Map(frontendApp1.id -> frontendApp1), dependencies = Set("/test/service/service2".toAbsolutePath)),
+              createGroup("/test/frontend/app2".toAbsolutePath, Map(frontendApp2.id -> frontendApp2),
+                dependencies = Set("/test/service".toAbsolutePath, "/test/database/mongo".toAbsolutePath, "/test/frontend/app1".toAbsolutePath))
             )),
-            createGroup("/test/cache".toPath, groups = Set(
-              createGroup("/test/cache/c1".toPath, Map(cacheApp.id -> cacheApp)) //has no dependencies
+            createGroup("/test/cache".toAbsolutePath, groups = Set(
+              createGroup("/test/cache/c1".toAbsolutePath, Map(cacheApp.id -> cacheApp)) //has no dependencies
             ))
           ))))
       current.hasNonCyclicDependencies should equal(true)
@@ -357,21 +362,21 @@ class RootGroupTest extends UnitTest with GroupCreation {
       //has no dependencies
       val current: RootGroup = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/database".toPath, Map(
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/database".toAbsolutePath, Map(
               redisApp.id -> redisApp,
               memcacheApp.id -> memcacheApp,
               mongoApp.id -> mongoApp
             )),
-            createGroup("/test/service".toPath, Map(
+            createGroup("/test/service".toAbsolutePath, Map(
               serviceApp1.id -> serviceApp1,
               serviceApp2.id -> serviceApp2
             )),
-            createGroup("/test/frontend".toPath, Map(
+            createGroup("/test/frontend".toAbsolutePath, Map(
               frontendApp1.id -> frontendApp1,
               frontendApp2.id -> frontendApp2
             )),
-            createGroup("/test/cache".toPath, Map(cacheApp.id -> cacheApp))))
+            createGroup("/test/cache".toAbsolutePath, Map(cacheApp.id -> cacheApp))))
         ))
       current.hasNonCyclicDependencies should equal(true)
 
@@ -424,22 +429,22 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val cacheApp1 = AppDefinition("/test/cache/c1/cache1".toPath, role = "*", cmd = Some("sleep"))
       val current: RootGroup = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/database".toPath, groups = Set(
-              createGroup("/test/database/redis".toPath, Map(redisApp.id -> redisApp)),
-              createGroup("/test/database/memcache".toPath, Map(memcacheApp.id -> memcacheApp)),
-              createGroup("/test/database/mongo".toPath, Map(mongoApp.id -> mongoApp))
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/database".toAbsolutePath, groups = Set(
+              createGroup("/test/database/redis".toAbsolutePath, Map(redisApp.id -> redisApp)),
+              createGroup("/test/database/memcache".toAbsolutePath, Map(memcacheApp.id -> memcacheApp)),
+              createGroup("/test/database/mongo".toAbsolutePath, Map(mongoApp.id -> mongoApp))
             )),
-            createGroup("/test/service".toPath, groups = Set(
-              createGroup("/test/service/service1".toPath, Map(serviceApp1.id -> serviceApp1)),
-              createGroup("/test/service/service2".toPath, Map(serviceApp2.id -> serviceApp2))
+            createGroup("/test/service".toAbsolutePath, groups = Set(
+              createGroup("/test/service/service1".toAbsolutePath, Map(serviceApp1.id -> serviceApp1)),
+              createGroup("/test/service/service2".toAbsolutePath, Map(serviceApp2.id -> serviceApp2))
             )),
-            createGroup("/test/frontend".toPath, groups = Set(
-              createGroup("/test/frontend/app1".toPath, Map(frontendApp1.id -> frontendApp1)),
-              createGroup("/test/frontend/app2".toPath, Map(frontendApp2.id -> frontendApp2))
+            createGroup("/test/frontend".toAbsolutePath, groups = Set(
+              createGroup("/test/frontend/app1".toAbsolutePath, Map(frontendApp1.id -> frontendApp1)),
+              createGroup("/test/frontend/app2".toAbsolutePath, Map(frontendApp2.id -> frontendApp2))
             )),
-            createGroup("/test/cache".toPath, groups = Set(
-              createGroup("/test/cache/c1".toPath, Map(cacheApp1.id -> cacheApp1))
+            createGroup("/test/cache".toAbsolutePath, groups = Set(
+              createGroup("/test/cache/c1".toAbsolutePath, Map(cacheApp1.id -> cacheApp1))
             ))
           ))))
       current.hasNonCyclicDependencies should equal(true)
@@ -457,12 +462,12 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val serviceApp1 = AppDefinition("/test/service/service1/srv1".toPath, role = "*", dependencies = Set("/test/database".toPath), cmd = Some("sleep"))
       val current: RootGroup = createRootGroup(
         groups = Set(
-          createGroup("/test".toPath, groups = Set(
-            createGroup("/test/database".toPath, groups = Set(
-              createGroup("/test/database/mongo".toPath, Map(mongoApp.id -> mongoApp), validate = false)
+          createGroup("/test".toAbsolutePath, groups = Set(
+            createGroup("/test/database".toAbsolutePath, groups = Set(
+              createGroup("/test/database/mongo".toAbsolutePath, Map(mongoApp.id -> mongoApp), validate = false)
             ), validate = false),
-            createGroup("/test/service".toPath, groups = Set(
-              createGroup("/test/service/service1".toPath, Map(serviceApp1.id -> serviceApp1), validate = false)
+            createGroup("/test/service".toAbsolutePath, groups = Set(
+              createGroup("/test/service/service1".toAbsolutePath, Map(serviceApp1.id -> serviceApp1), validate = false)
             ), validate = false)
           ))), validate = false)
 
@@ -474,9 +479,9 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("a group with subgroups having the same name")
       val serviceApp = AppDefinition("/test/service/test/app".toPath, role = "*", cmd = Some("Foobar"))
       val reference: Group = createRootGroup(groups = Set(
-        createGroup("/test".toPath, groups = Set(
-          createGroup("/test/service".toPath, groups = Set(
-            createGroup("/test/service/test".toPath, Map(serviceApp.id -> serviceApp))
+        createGroup("/test".toAbsolutePath, groups = Set(
+          createGroup("/test/service".toAbsolutePath, groups = Set(
+            createGroup("/test/service/test".toAbsolutePath, Map(serviceApp.id -> serviceApp))
           ))
         ))
       ))
@@ -496,8 +501,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app1 = AppDefinition("/group/app1".toPath, role = "*", cmd = Some("foo"))
       val app2 = AppDefinition("/group/subgroup/app2".toPath, role = "*", cmd = Some("bar"), dependencies = Set("../app1".toPath))
       val rootGroup = createRootGroup(groups = Set(
-        createGroup("/group".toPath, apps = Map(app1.id -> app1),
-          groups = Set(createGroup("/group/subgroup".toPath, Map(app2.id -> app2))))
+        createGroup("/group".toAbsolutePath, apps = Map(app1.id -> app1),
+          groups = Set(createGroup("/group/subgroup".toAbsolutePath, Map(app2.id -> app2))))
       ))
 
       When("group is validated")
@@ -511,7 +516,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(PathId("/root"), role = "*", cmd = Some("test"))
       val invalid = createRootGroup(groups = Set(
-        createGroup(PathId("nested"), apps = Map(app.id -> app), validate = false)
+        createGroup(AbsolutePathId("nested"), apps = Map(app.id -> app), validate = false)
       ), validate = false)
 
       When("group is validated")
@@ -524,8 +529,8 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "Group with group in wrong group is not valid" in {
       Given("Group with nested app of wrong path")
       val invalid = createRootGroup(groups = Set(
-        createGroup(PathId("nested"), groups = Set(
-          createGroup(PathId("/root"), validate = false)
+        createGroup(AbsolutePathId("nested"), groups = Set(
+          createGroup(AbsolutePathId("/root"), validate = false)
         ), validate = false)
       ), validate = false)
 
@@ -552,7 +557,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(PathId("/nested/foo"), role = "*", cmd = Some("test"))
       val valid = createRootGroup(groups = Set(
-        createGroup(PathId("/nested"), apps = Map(app.id -> app))
+        createGroup(AbsolutePathId("/nested"), apps = Map(app.id -> app))
       ))
 
       When("group is validated")
@@ -567,10 +572,10 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app = AppDefinition(appPath, role = "*", cmd = Some("sleep"))
 
       val groupUpdate = createGroup(
-        PathId("/domain/developers"),
+        AbsolutePathId("/domain/developers"),
         groups = Set(
           createGroup(
-            PathId("/domain/developers/gitlab"),
+            AbsolutePathId("/domain/developers/gitlab"),
             apps = Map(appPath -> app))))
 
       val newVersion = Timestamp.now()
@@ -583,12 +588,12 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app = AppDefinition(appPath, role = "*", cmd = Some("sleep"))
 
       val groupUpdate = createGroup(
-        PathId("/domain"),
+        AbsolutePathId("/domain"),
         groups = Set(createGroup(
-          PathId("/domain/developers"),
+          AbsolutePathId("/domain/developers"),
           groups = Set(
             createGroup(
-              PathId("/domain/developers/gitlab"),
+              AbsolutePathId("/domain/developers/gitlab"),
               apps = Map(appPath -> app))))))
 
       val newVersion = Timestamp.now()
@@ -601,7 +606,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       val app = AppDefinition(appPath, role = "*", cmd = Some("sleep"))
 
       val groupUpdate = createGroup(
-        PathId("/domain/developers/gitlab"),
+        AbsolutePathId("/domain/developers/gitlab"),
         apps = Map(appPath -> app))
 
       val newVersion = Timestamp.now()
@@ -613,39 +618,39 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("a three level hierarchy")
       val current: RootGroup = createRootGroup(
         groups = Set(
-          createGroup("/top".toPath, groups = Set(
-            createGroup("/top/mid".toPath, groups = Set(
-              createGroup("/top/mid/end".toPath)
+          createGroup("/top".toAbsolutePath, groups = Set(
+            createGroup("/top/mid".toAbsolutePath, groups = Set(
+              createGroup("/top/mid/end".toAbsolutePath)
             ))
           )),
-          createGroup("/side".toPath)
+          createGroup("/side".toAbsolutePath)
         ))
 
       When("we update the dependency of the mid-level group")
-      val updatedRoot = current.updateDependencies("/top/mid".toPath, _ => Set("/side".toPath))
+      val updatedRoot = current.updateDependencies("/top/mid".toAbsolutePath, _ => Set("/side".toAbsolutePath))
 
       Then("the update should be reflected in the new root group")
-      updatedRoot.group("/top/mid".toPath).value.dependencies should be(Set("/side".toPath))
+      updatedRoot.group("/top/mid".toAbsolutePath).value.dependencies should be(Set("/side".toPath))
     }
 
     "update a top-level group parameter" in {
       Given("a three level hierarchy")
       val current: RootGroup = createRootGroup(
         groups = Set(
-          createGroup("/top".toPath, groups = Set(
-            createGroup("/top/mid".toPath, groups = Set(
-              createGroup("/top/mid/end".toPath)
+          createGroup("/top".toAbsolutePath, groups = Set(
+            createGroup("/top/mid".toAbsolutePath, groups = Set(
+              createGroup("/top/mid/end".toAbsolutePath)
             ))
           )),
-          createGroup("/side".toPath)
+          createGroup("/side".toAbsolutePath)
         ))
 
       When("we update the enforce role parameter of the top-level group")
-      val groupUpdate = current.group("/top".toPath).value.withEnforceRole(true)
+      val groupUpdate = current.group("/top".toAbsolutePath).value.withEnforceRole(true)
       val updatedRoot = current.putGroup(groupUpdate)
 
       Then("the update should be reflected in the new root group")
-      updatedRoot.group("/top".toPath).value.enforceRole should be(true)
+      updatedRoot.group("/top".toAbsolutePath).value.enforceRole should be(true)
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -205,7 +205,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
 
     "enforceRole property is propagated to task environment for pods" in {
       val f = new Fixture
-      f.rootGroup = f.rootGroup.putGroup(Group(PathId("/dev"), enforceRole = true))
+      f.rootGroup = f.rootGroup.putGroup(Group(AbsolutePathId("/dev"), enforceRole = true))
       val podId = PathId("/dev/testing")
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(podId, f.clock.now()).getInstance()
@@ -236,7 +236,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
 
     "enforceRole property is propagated to task environment for apps" in {
       val f = new Fixture
-      f.rootGroup = f.rootGroup.putGroup(Group(PathId("/dev"), enforceRole = true))
+      f.rootGroup = f.rootGroup.putGroup(Group(AbsolutePathId("/dev"), enforceRole = true))
       val appId = PathId("/dev/testing")
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, f.clock.now()).getInstance()

--- a/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
+++ b/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
@@ -10,7 +10,7 @@ trait GroupCreation {
     apps: Map[AppDefinition.AppKey, AppDefinition] = Group.defaultApps,
     pods: Map[PathId, PodDefinition] = Group.defaultPods,
     groups: Set[Group] = Set.empty,
-    dependencies: Set[PathId] = Group.defaultDependencies,
+    dependencies: Set[AbsolutePathId] = Group.defaultDependencies,
     version: Timestamp = Group.defaultVersion,
     validate: Boolean = true,
     enabledFeatures: Set[String] = Set.empty): RootGroup = {
@@ -26,11 +26,11 @@ trait GroupCreation {
   }
 
   def createGroup(
-    id: PathId,
+    id: AbsolutePathId,
     apps: Map[AppDefinition.AppKey, AppDefinition] = Group.defaultApps,
     pods: Map[PathId, PodDefinition] = Group.defaultPods,
     groups: Set[Group] = Set.empty,
-    dependencies: Set[PathId] = Group.defaultDependencies,
+    dependencies: Set[AbsolutePathId] = Group.defaultDependencies,
     version: Timestamp = Group.defaultVersion,
     validate: Boolean = true,
     enabledFeatures: Set[String] = Set.empty,

--- a/src/test/scala/mesosphere/marathon/upgrade/GroupVersioningUtilTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/GroupVersioningUtilTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package upgrade
 
 import mesosphere.UnitTest
-import mesosphere.marathon.state.{AppDefinition, PathId, Timestamp, VersionInfo}
+import mesosphere.marathon.state._
 import mesosphere.marathon.test.GroupCreation
 
 class GroupVersioningUtilTest extends UnitTest with GroupCreation {
@@ -13,7 +13,7 @@ class GroupVersioningUtilTest extends UnitTest with GroupCreation {
   val nestedApp = createRootGroup(
     groups = Set(
       createGroup(
-        id = PathId("/nested"),
+        id = AbsolutePathId("/nested"),
         apps = Map(app.id -> app),
         version = Timestamp(2)
       )
@@ -27,7 +27,7 @@ class GroupVersioningUtilTest extends UnitTest with GroupCreation {
   val nestedAppScaled = createRootGroup(
     groups = Set(
       createGroup(
-        id = PathId("/nested"),
+        id = AbsolutePathId("/nested"),
         apps = Map(scaledApp.id -> scaledApp),
         version = Timestamp(2)
       )
@@ -40,7 +40,7 @@ class GroupVersioningUtilTest extends UnitTest with GroupCreation {
   val nestedAppUpdated = createRootGroup(
     groups = Set(
       createGroup(
-        id = PathId("/nested"),
+        id = AbsolutePathId("/nested"),
         apps = Map(updatedApp.id -> updatedApp),
         version = Timestamp(2)
       )


### PR DESCRIPTION
Summary:
The group update conversion noramlizes the group id to an absolute path.
The protobuf to `StoredGroup` conversion also loads an absolute path.
Thus the group id should always be an absolute path.