### PR TITLE
Added maintenance mode to info endpoint 1.8

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -70,7 +70,8 @@ class InfoResource @Inject() (
     "task_lost_expunge_initial_delay" -> config.taskLostExpungeInitialDelay.toMillis,
     "task_lost_expunge_interval" -> config.taskLostExpungeInterval.toMillis,
     "task_reservation_timeout" -> config.taskReservationTimeout.toOption,
-    "webui_url" -> config.webuiUrl.toOption
+    "webui_url" -> config.webuiUrl.toOption,
+    "maintenance_mode" -> config.maintenanceMode.toOption
   )
 
   // ZooKeeper congiurations


### PR DESCRIPTION
Added the config status of maintenance mode to info endpoint

JIRA issues: MARATHON-8660

(cherry picked from commit 80abdd77506166825aad0c30d97431ab10c69b6c)

<<Replace this line with your Revision Title>>

Summary:
For more details follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html.

JIRA issues:
