### PR TITLE
Benchmark RAML normalization and conversion.

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -4,7 +4,7 @@ package state
 import java.util.concurrent.TimeUnit
 
 import mesosphere.marathon.core.pod.BridgeNetwork
-import mesosphere.marathon.api.v2.{GroupNormalization, Validation}
+import mesosphere.marathon.api.v2.{GroupNormalization, GroupsResource, Validation}
 import mesosphere.marathon.raml.{GroupConversion, Raml}
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
@@ -113,12 +113,13 @@ class RootGroupBenchmark extends GroupBenchmark {
 
   @Benchmark
   def serializationRoundtrip(hole: Blackhole): Unit = {
-    val normalized = GroupNormalization.updateNormalization(config, PathId.root).normalized(groupRaml)
+    val normalizedGroup = GroupNormalization.updateNormalization(config, PathId.root).normalized(groupRaml)
     //    val groupValidator = Group.validNestedGroupUpdateWithBase(PathId.root, rootGroup)
     //    groupValidator(normalized)
+    GroupsResource.normalizeApps(rootGroup, PathId.root, normalizedGroup, config)
     val appConversionFunc: (raml.App => AppDefinition) = Raml.fromRaml[raml.App, AppDefinition]
     val converted = Raml.fromRaml(
-      GroupConversion(normalized, rootGroup, version.version) -> appConversionFunc)
+      GroupConversion(normalizedGroup, rootGroup, version.version) -> appConversionFunc)
     //    println(s"Group tree:\n ${converted.prettyTree()}")
     hole.consume(converted)
   }

--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -116,11 +116,12 @@ class RootGroupBenchmark extends GroupBenchmark {
     val normalizedGroup = GroupNormalization.updateNormalization(config, PathId.root).normalized(groupRaml)
     //    val groupValidator = Group.validNestedGroupUpdateWithBase(PathId.root, rootGroup)
     //    groupValidator(normalized)
-    GroupsResource.normalizeApps(rootGroup, PathId.root, normalizedGroup, config)
+    val apps = GroupsResource.normalizeApps(rootGroup, PathId.root, normalizedGroup, config)
     val appConversionFunc: (raml.App => AppDefinition) = Raml.fromRaml[raml.App, AppDefinition]
     val converted = Raml.fromRaml(
       GroupConversion(normalizedGroup, rootGroup, version.version) -> appConversionFunc)
     //    println(s"Group tree:\n ${converted.prettyTree()}")
+    hole.consume(apps)
     hole.consume(converted)
   }
 }

--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -114,8 +114,6 @@ class RootGroupBenchmark extends GroupBenchmark {
   @Benchmark
   def serializationRoundtrip(hole: Blackhole): Unit = {
     val normalizedGroup = GroupNormalization.updateNormalization(config, PathId.root).normalized(groupRaml)
-    //    val groupValidator = Group.validNestedGroupUpdateWithBase(PathId.root, rootGroup)
-    //    groupValidator(normalized)
     val apps = GroupsResource.normalizeApps(rootGroup, PathId.root, normalizedGroup, config)
     val appConversionFunc: (raml.App => AppDefinition) = Raml.fromRaml[raml.App, AppDefinition]
     val converted = Raml.fromRaml(

--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -120,7 +120,6 @@ class RootGroupBenchmark extends GroupBenchmark {
     val appConversionFunc: (raml.App => AppDefinition) = Raml.fromRaml[raml.App, AppDefinition]
     val converted = Raml.fromRaml(
       GroupConversion(normalizedGroup, rootGroup, version.version) -> appConversionFunc)
-    //    println(s"Group tree:\n ${converted.prettyTree()}")
     hole.consume(apps)
     hole.consume(converted)
   }

--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -58,7 +58,7 @@ class GroupBenchmark {
     if (level == groupDepth) return Set.empty
 
     (0 to groupsPerLevel).map { gid =>
-      val groupPath = (parent / s"group-$gid").asAbsolutePath
+      val groupPath = (parent / s"group-$gid")
       raml.GroupUpdate(
         id = Some(groupPath.toString),
         apps = Some((0 to appsPerGroup).map { aid => makeAppRaml(groupPath / s"app-$aid") }.toSet),

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -146,8 +146,9 @@ class Group(
     builder.append(s"\n$indent├── pods(${pods.size})")
 
     // append groups
+    // TODO: check last child
     groupsById.valuesIterator.foreach { childGroup =>
-      val newIndent = indent + "    "
+      val newIndent = indent + "│   "
       builder.append("\n").append(indent).append("├── ")
       childGroup.prettyTree(builder, indent = newIndent)
     }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -131,6 +131,29 @@ class Group(
   /** @return a copy of this group with the removed `enforceRole` field. */
   def withoutEnforceRole(): Group =
     new Group(this.id, this.apps, this.pods, this.groupsById, this.dependencies, this.version, false)
+
+  def prettyTree(): String = {
+    val builder = new StringBuilder()
+    prettyTree(builder, "").toString()
+  }
+
+  private def prettyTree(builder: StringBuilder, indent: String): StringBuilder = {
+
+    builder.append(id.path.lastOption.getOrElse("/"))
+
+    // append apps and pods info
+    builder.append(s"\n$indent├── apps(${apps.size})")
+    builder.append(s"\n$indent├── pods(${pods.size})")
+
+    // append groups
+    groupsById.valuesIterator.foreach { childGroup =>
+      val newIndent = indent + "    "
+      builder.append("\n").append(indent).append("├── ")
+      childGroup.prettyTree(builder, indent = newIndent)
+    }
+
+    builder
+  }
 }
 
 object Group extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -168,7 +168,6 @@ class Group(
     }
 
     // append groups
-    // TODO: check last child
     val iter = groupsById.valuesIterator
     while (iter.hasNext) {
       val childGroup = iter.next()

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -141,10 +141,10 @@ class Group(
     * ├── pods(0)
     * ├── def
     * │    ├── apps(3)
-    * │    └──  pods(0)
+    * │    └── pods(0)
     * └── prod
     *     ├── apps(3)
-    *     └──  pods(0)
+    *     └── pods(0)
     * }}}
     *
     * @return the tree as a string.

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -46,7 +46,7 @@ object RoleSettings extends StrictLogging {
         // If the topLevelGroup is empty, we might have run into the case where a user creates
         // a group with runSpecs in a single action. The group isn't yet created, therefore we can't lookup
         // the enforceRole flag.
-        logger.warn(s"Calculating role settings for $servicePathId, but unable to access top level group $topLevelGroupPath, using default for enforceRole flag: $enforceRole")
+        //        logger.warn(s"Calculating role settings for $servicePathId, but unable to access top level group $topLevelGroupPath, using default for enforceRole flag: $enforceRole")
       }
 
       // Look up any previously set group on the specified runSpec, and add that to the validRoles set if it exists

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -46,7 +46,7 @@ object RoleSettings extends StrictLogging {
         // If the topLevelGroup is empty, we might have run into the case where a user creates
         // a group with runSpecs in a single action. The group isn't yet created, therefore we can't lookup
         // the enforceRole flag.
-        //        logger.warn(s"Calculating role settings for $servicePathId, but unable to access top level group $topLevelGroupPath, using default for enforceRole flag: $enforceRole")
+        logger.warn(s"Calculating role settings for $servicePathId, but unable to access top level group $topLevelGroupPath, using default for enforceRole flag: $enforceRole")
       }
 
       // Look up any previously set group on the specified runSpec, and add that to the validRoles set if it exists


### PR DESCRIPTION
Summary:
This introduces a simple benchmark that creates a nested `raml.GroupUpdate`, normalizes
and converts it to a `state.Group`.

It also provides a pretty tree print for groups
```
/
├── apps(0)
├── pods(0)
├── dev
│   ├── apps(3)
│   └── pods(0)
└── prod
    ├── apps(3)
    └── pods(0)
```

The results are for
```
sbt "benchmark/jmh:run -prof jmh.extras.JFR -i 1 -wi 1 -f1 -t1   *RootGroupBenchmark.serializationRoundtrip"
```

```
Master with App Normalization
[info] Benchmark                                      (appsPerGroup)  (groupDepth)  (groupsPerLevel)  Mode  Cnt     Score     Error  Units
[info] RootGroupBenchmark.serializationRoundtrip                  10             5                 5  avgt   10  7967.838 ± 185.261  ms/op
```