### PR TITLE
Compose group visitors.

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -4,7 +4,8 @@ package state
 import java.util.concurrent.TimeUnit
 
 import mesosphere.marathon.core.pod.BridgeNetwork
-import mesosphere.marathon.api.v2.Validation
+import mesosphere.marathon.api.v2.{GroupNormalization, Validation}
+import mesosphere.marathon.raml.{GroupConversion, GroupUpdateConversionVisitor, Raml}
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
@@ -14,6 +15,7 @@ import scala.util.Random
 class GroupBenchmark {
 
   val version = VersionInfo.forNewConfig(Timestamp(1))
+  val config: AllConf = AllConf.withTestConfig()
 
   def makeApp(path: PathId) =
     AppDefinition(
@@ -26,13 +28,20 @@ class GroupBenchmark {
         Container.Docker(Nil, "alpine", List(Container.PortMapping(2015, Some(0), 10000, "tcp", Some("thing")))))
     )
 
-  @Param(value = Array("2", "10", "100", "1000"))
+  def makeAppRaml(pathId: PathId) = Raml.toRaml(makeApp(pathId))
+
+  //@Param(value = Array("2", "10", "100", "1000"))
+  @Param(value = Array("10"))
   var appsPerGroup: Int = _
   lazy val appIds = 0 until appsPerGroup
 
-  @Param(value = Array("5", "10", "20"))
+  //@Param(value = Array("5", "10", "20"))
+  @Param(value = Array("5"))
   var groupDepth: Int = _
   lazy val groupIds = 0 until groupDepth
+
+  @Param(value = Array("5"))
+  var groupsPerLevel: Int = _
 
   lazy val groupPaths: Vector[PathId] = groupIds.foldLeft(Vector[PathId]()) { (allPaths, nextChild) =>
     val nextChildPath = allPaths.lastOption.getOrElse(PathId.root) / s"group-$nextChild"
@@ -40,6 +49,23 @@ class GroupBenchmark {
   }
 
   lazy val rootGroup: RootGroup = fillRootGroup()
+
+  lazy val groupRaml: raml.GroupUpdate = {
+    raml.GroupUpdate(id = Some("/"), groups = Some(buildChildGroups(0, PathId.root)))
+  }
+
+  def buildChildGroups(level: Int, parent: AbsolutePathId): Set[raml.GroupUpdate] = {
+    if (level == groupDepth) return Set.empty
+
+    (0 to groupsPerLevel).map { gid =>
+      val groupPath = (parent / s"group-$gid").asAbsolutePath
+      raml.GroupUpdate(
+        id = Some(groupPath.toString),
+        apps = Some((0 to appsPerGroup).map { aid => makeAppRaml(groupPath / s"app-$aid") }.toSet),
+        groups = Some(buildChildGroups(level + 1, groupPath))
+      )
+    }.toSet
+  }
 
   // Create apps and add them to each group on each level
   def fillRootGroup(): RootGroup = {
@@ -83,5 +109,17 @@ class RootGroupBenchmark extends GroupBenchmark {
   @Benchmark
   def validateRootGroup(hole: Blackhole): Unit = {
     Validation.validateOrThrow(rootGroup)(RootGroup.validRootGroup(AllConf.withTestConfig()))
+  }
+
+  @Benchmark
+  def serializationRoundtrip(hole: Blackhole): Unit = {
+    val normalized = GroupNormalization.updateNormalization(config, PathId.root, rootGroup).normalized(groupRaml)
+    //    val groupValidator = Group.validNestedGroupUpdateWithBase(PathId.root, rootGroup)
+    //    groupValidator(normalized)
+    val appConversionFunc: (raml.App => AppDefinition) = Raml.fromRaml[raml.App, AppDefinition]
+    val visitor = GroupUpdateConversionVisitor(rootGroup, version.version, appConversionFunc)
+    val converted: Group = GroupConversion.dispatch(normalized, PathId.root, visitor)
+    //    println(s"Group tree:\n ${converted.prettyTree()}")
+    hole.consume(converted)
   }
 }

--- a/ci/releases.sc
+++ b/ci/releases.sc
@@ -114,7 +114,6 @@ def uploadLinuxPackagesToRepos(tagName: String): Unit = {
     ""
 
   val mappings = Seq(
-    "debian8" -> s"debian/jessie${pkgType}",
     "debian9" -> s"debian/stretch${pkgType}",
     "ubuntu1604" -> s"ubuntu/xenial${pkgType}",
     "ubuntu1404" -> s"ubuntu/trusty${pkgType}",

--- a/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
+++ b/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
@@ -50,8 +50,6 @@ class GroupApiService(groupManager: GroupManager)(implicit authorizer: Authorize
       val visitor = GroupUpdateConversionVisitor(rootGroup, newVersion, appConversionFunc)
       val updatedGroup: Group = GroupConversion.dispatch(groupUpdate, groupId, visitor)
 
-      println("updated group")
-
       if (maybeExistingGroup.isEmpty) checkAuthorizationOrThrow(CreateGroup, updatedGroup)
 
       rootGroup.putGroup(updatedGroup, newVersion)

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupNormalization.scala
@@ -23,7 +23,7 @@ case class RootGroupVisitor(conf: MarathonConf) extends GroupNormalizationVisito
 
   override def appVisitor(): AppNormalizationVisitor = AppNormalizeVisitor(conf, conf.mesosRole())
 
-  override def done(base: AbsolutePathId, thisGroup: GroupUpdate, children: Option[Iterator[GroupUpdate]], apps: Option[Iterator[raml.App]]): GroupUpdate = {
+  override def done(base: AbsolutePathId, thisGroup: GroupUpdate, children: Option[Vector[GroupUpdate]], apps: Option[Vector[raml.App]]): GroupUpdate = {
     thisGroup.copy(groups = children.map(_.toSet), apps = apps.map(_.toSet))
   }
 }
@@ -52,7 +52,7 @@ case class TopLevelGroupVisitor(conf: MarathonConf) extends GroupNormalizationVi
 
   override def appVisitor(): AppNormalizationVisitor = AppNormalizeVisitor(conf, defaultRole)
 
-  override def done(base: AbsolutePathId, thisGroup: GroupUpdate, children: Option[Iterator[GroupUpdate]], apps: Option[Iterator[raml.App]]): GroupUpdate = {
+  override def done(base: AbsolutePathId, thisGroup: GroupUpdate, children: Option[Vector[GroupUpdate]], apps: Option[Vector[raml.App]]): GroupUpdate = {
     thisGroup.copy(groups = children.map(_.toSet), apps = apps.map(_.toSet))
   }
 }
@@ -75,7 +75,7 @@ case class ChildGroupVisitor(conf: MarathonConf, defaultRole: Role) extends Grou
 
   override val appVisitor: AppNormalizationVisitor = AppNormalizeVisitor(conf, defaultRole)
 
-  override def done(base: AbsolutePathId, thisGroup: GroupUpdate, children: Option[Iterator[GroupUpdate]], apps: Option[Iterator[raml.App]]): GroupUpdate = {
+  override def done(base: AbsolutePathId, thisGroup: GroupUpdate, children: Option[Vector[GroupUpdate]], apps: Option[Vector[raml.App]]): GroupUpdate = {
     thisGroup.copy(groups = children.map(_.toSet), apps = apps.map(_.toSet))
   }
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupNormalization.scala
@@ -134,6 +134,16 @@ object GroupNormalization {
     } else update
   }
 
+  def normalizationVisitor(conf: MarathonConf, base: AbsolutePathId, originalRootGroup: RootGroup): GroupNormalizationVisitor = {
+    // TODO: Only update if this is not a scale or rollback
+    if (base.isRoot) RootGroupVisitor(conf)
+    else if (base.isTopLevel) TopLevelGroupVisitor(conf)
+    else {
+      val defaultRole = inferDefaultRole(conf, base, originalRootGroup)
+      ChildGroupVisitor(conf, defaultRole)
+    }
+  }
+
   /**
     * Infers the enforce role field for a top-level group based on the update value and the default behavior.
     *

--- a/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/Validation.scala
@@ -277,7 +277,13 @@ trait Validation {
       failure = _ -> failureMessage
     )
 
-  def validateAll[T](x: T, all: Validator[T]*): Result = all.map(v => validate(x)(v)).fold(Success)(_ and _)
+  def validateAll[T](x: T, all: Vector[Validator[T]]): Result = {
+    var acc: Result = Success
+    all.foreach { v =>
+      acc = acc.and(validate(x)(v))
+    }
+    acc
+  }
 
   /**
     * Given a wix accord violation, return a sequence of our own ConstraintViolation model, rendering the wix accord
@@ -317,7 +323,7 @@ object Validation extends Validation {
   case class ConstraintViolation(path: String, constraint: String)
 
   def forAll[T](all: Validator[T]*): Validator[T] = new Validator[T] {
-    override def apply(x: T): Result = validateAll(x, all: _*)
+    override def apply(x: T): Result = validateAll(x, all.toVector)
   }
 
   /**

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -27,17 +27,21 @@ case class GroupUpdateConversionVisitor(originalRootGroup: RootGroup, timestamp:
 
   override val appVisitor: AppVisitor[raml.App, AppDefinition] = AppConversionVisitor(appConversion, timestamp)
 
-  override def done(base: AbsolutePathId, thisGroup: CoreGroup, children: Option[Iterator[CoreGroup]], apps: Option[Iterator[AppDefinition]]): CoreGroup = {
+  override def done(base: AbsolutePathId, thisGroup: CoreGroup, children: Option[Vector[CoreGroup]], apps: Option[Vector[AppDefinition]]): CoreGroup = {
 
     // Accumulate child groups.
-    val effectiveGroups: Map[PathId, CoreGroup] = children.fold(thisGroup.groupsById)(_.map { childGroup =>
-      childGroup.id -> childGroup
-    }.toMap)
+    val effectiveGroups: Map[PathId, CoreGroup] = children.fold(thisGroup.groupsById) { children =>
+      val builder = Map.newBuilder[PathId, CoreGroup]
+      children.foreach { childGroup => builder += childGroup.id -> childGroup }
+      builder.result()
+    }
 
     // Accumulate apps.
-    val effectiveApps: Map[AppDefinition.AppKey, AppDefinition] = apps.fold(thisGroup.apps)(_.map { app =>
-      app.id -> app
-    }.toMap)
+    val effectiveApps: Map[AppDefinition.AppKey, AppDefinition] = apps.fold(thisGroup.apps){ apps =>
+      val builder = Map.newBuilder[AppDefinition.AppKey, AppDefinition]
+      apps.foreach{ app => builder += app.id -> app }
+      builder.result()
+    }
 
     CoreGroup(
       id = base,

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -11,7 +11,6 @@ case class GroupUpdateConversionVisitor(originalRootGroup: RootGroup, timestamp:
     assert(thisGroup.enforceRole.isDefined, s"BUG! The group normalization should have set enforceRole for ${thisGroup.id}.")
 
     val current = originalRootGroup.group(AbsolutePathId(thisGroup.id.get)).getOrElse(CoreGroup.empty(AbsolutePathId(thisGroup.id.get)))
-    println(s"current: $current")
     val effectiveDependencies = thisGroup.dependencies.fold(current.dependencies)(_.map(PathId(_).canonicalPath(current.id.asAbsolutePath)))
 
     CoreGroup(

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -3,7 +3,7 @@ package raml
 
 import mesosphere.marathon.state.{AbsolutePathId, AppDefinition, PathId, RootGroup, Timestamp, Group => CoreGroup, VersionInfo => CoreVersionInfo}
 
-case class GroupUpdateConversionVisitor(originalRootGroup: RootGroup, timestamp: Timestamp, appConversion: App => AppDefinition) extends GroupUpdateVisitor[AppDefinition, CoreGroup] {
+case class GroupUpdateConversionVisitor(originalRootGroup: RootGroup, timestamp: Timestamp, appConversion: App => AppDefinition) extends GroupUpdateVisitor[GroupUpdate, raml.App, AppDefinition, CoreGroup] {
 
   override def visit(thisGroup: GroupUpdate): CoreGroup = {
     require(thisGroup.scaleBy.isEmpty, "For a structural update, no scale should be given.")
@@ -23,9 +23,9 @@ case class GroupUpdateConversionVisitor(originalRootGroup: RootGroup, timestamp:
       enforceRole = thisGroup.enforceRole.get)
   }
 
-  override def childGroupVisitor(): GroupUpdateVisitor[AppDefinition, CoreGroup] = GroupUpdateConversionVisitor(originalRootGroup, timestamp, appConversion)
+  override def childGroupVisitor(): GroupUpdateVisitor[GroupUpdate, raml.App, AppDefinition, CoreGroup] = GroupUpdateConversionVisitor(originalRootGroup, timestamp, appConversion)
 
-  override val appVisitor: AppVisitor[AppDefinition] = AppConversionVisitor(appConversion, timestamp)
+  override val appVisitor: AppVisitor[raml.App, AppDefinition] = AppConversionVisitor(appConversion, timestamp)
 
   override def done(base: AbsolutePathId, thisGroup: CoreGroup, children: Option[Iterator[CoreGroup]], apps: Option[Iterator[AppDefinition]]): CoreGroup = {
 
@@ -51,13 +51,13 @@ case class GroupUpdateConversionVisitor(originalRootGroup: RootGroup, timestamp:
 }
 
 // TODO: convert without a function
-case class AppConversionVisitor(convert: App => AppDefinition, version: Timestamp) extends AppVisitor[AppDefinition] {
+case class AppConversionVisitor(convert: App => AppDefinition, version: Timestamp) extends AppVisitor[raml.App, AppDefinition] {
   override def visit(app: App, groupId: AbsolutePathId): AppDefinition = convert(app).copy(versionInfo = CoreVersionInfo.OnlyVersion(version))
 }
 
 object GroupConversion {
 
-  def dispatch(groupUpdate: raml.GroupUpdate, base: AbsolutePathId, visitor: GroupUpdateVisitor[AppDefinition, CoreGroup]): CoreGroup =
+  def dispatch(groupUpdate: raml.GroupUpdate, base: AbsolutePathId, visitor: GroupUpdateVisitor[GroupUpdate, raml.App, AppDefinition, CoreGroup]): CoreGroup =
     GroupUpdateVisitor.dispatch(groupUpdate, base, visitor)
 }
 

--- a/src/main/scala/mesosphere/marathon/raml/Visitor.scala
+++ b/src/main/scala/mesosphere/marathon/raml/Visitor.scala
@@ -48,7 +48,7 @@ trait GroupUpdateVisitor[I, AI, AR, G] {
     * @param apps The result from all visits to apps in this group.
     * @return The final accumulated result.
     */
-  def done(base: AbsolutePathId, thisGroup: G, children: Option[Iterator[G]], apps: Option[Iterator[AR]]): G
+  def done(base: AbsolutePathId, thisGroup: G, children: Option[Vector[G]], apps: Option[Vector[AR]]): G
 
   def andThen[A2R, G2](other: GroupUpdateVisitor[G, AR, A2R, G2]): GroupUpdateVisitor[I, AI, A2R, G2] = GroupUpdateVisitorCompose(this, other)
 }
@@ -60,7 +60,7 @@ case class GroupUpdateVisitorCompose[I, A1I, A1R, A2R, G1, G2](first: GroupUpdat
 
   override def appVisitor(): AppVisitor[A1I, A2R] = AppVisitorCompose(first.appVisitor(), other.appVisitor())
 
-  override def done(base: AbsolutePathId, thisGroup: G2, children: Option[Iterator[G2]], apps: Option[Iterator[A2R]]): G2 = other.done(base, thisGroup, children, apps)
+  override def done(base: AbsolutePathId, thisGroup: G2, children: Option[Vector[G2]], apps: Option[Vector[A2R]]): G2 = other.done(base, thisGroup, children, apps)
 }
 
 /**
@@ -98,14 +98,14 @@ object GroupUpdateVisitor {
 
     // Visit each child group.
     val childGroupVisitor = visitor.childGroupVisitor()
-    val visitedChildren: Option[Iterator[R]] = groupUpdate.groups.map(_.toIterator.map { childGroup =>
+    val visitedChildren: Option[Vector[R]] = groupUpdate.groups.map(_.toVector.map { childGroup =>
       val absoluteChildGroupPath = PathId(childGroup.id.get).canonicalPath(base)
       dispatch(childGroup, absoluteChildGroupPath, childGroupVisitor)
     })
 
     // Visit each app.
     val appVisitor = visitor.appVisitor()
-    val visitedApps: Option[Iterator[A]] = groupUpdate.apps.map(_.toIterator.map { app =>
+    val visitedApps: Option[Vector[A]] = groupUpdate.apps.map(_.toVector.map { app =>
       appVisitor.visit(app, base)
     })
 

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -132,6 +132,30 @@ class Group(
   /** @return a copy of this group with the removed `enforceRole` field. */
   def withoutEnforceRole(): Group =
     new Group(this.id, this.apps, this.pods, this.groupsById, this.dependencies, this.version, false)
+
+  def prettyTree(): String = {
+    val builder = new StringBuilder()
+    prettyTree(builder, "").toString()
+  }
+
+  private def prettyTree(builder: StringBuilder, indent: String): StringBuilder = {
+
+    builder.append(id.path.lastOption.getOrElse("/"))
+
+    // append apps and pods info
+    builder.append(s"\n$indent├── apps(${apps.size})")
+    builder.append(s"\n$indent├── pods(${pods.size})")
+
+    // append groups
+    // TODO: check last child
+    groupsById.valuesIterator.foreach { childGroup =>
+      val newIndent = indent + "│   "
+      builder.append("\n").append(indent).append("├── ")
+      childGroup.prettyTree(builder, indent = newIndent)
+    }
+
+    builder
+  }
 }
 
 object Group extends StrictLogging {
@@ -264,8 +288,6 @@ object Group extends StrictLogging {
       if (base.isRoot) RootGroupValidationVisitor(originalRootGroup)
       else if (base.isTopLevel) TopLevelGroupValidationVisitor(originalRootGroup)
       else ChildGroupValidationVisitor(originalRootGroup)
-
-    println(s"validating $base")
 
     (groupUpdate: raml.GroupUpdate) => dispatch(base, groupUpdate, visitor)
   }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -322,13 +322,19 @@ object Group extends StrictLogging {
 
     override def childGroupVisitor(): GroupValidationVisitor = this
 
-    override def done(base: AbsolutePathId, thisGroup: Result, children: Option[Iterator[Result]], apps: Option[Iterator[Result]]): Result = {
-      val childrenResult = children.fold[Result](Success)(groups => groups.foldLeft[Result](Success) { (acc, childGroup) =>
-        acc.and(childGroup)
-      })
-      val appsResult = apps.fold[Result](Success)(apps => apps.foldLeft[Result](Success) { (acc, app) =>
-        acc.and(app)
-      })
+    override def done(base: AbsolutePathId, thisGroup: Result, children: Option[Vector[Result]], apps: Option[Vector[Result]]): Result = {
+      val childrenResult = children.fold[Result](Success) { groups =>
+        var acc: Result = Success
+        groups.foreach { childGroup => acc = acc.and(childGroup) }
+        acc
+      }
+
+      val appsResult = apps.fold[Result](Success) { apps =>
+        var acc: Result = Success
+        apps.foreach { app => acc = acc.and(app) }
+        acc
+      }
+
       thisGroup.and(childrenResult).and(appsResult)
     }
   }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -292,7 +292,7 @@ object Group extends StrictLogging {
     (groupUpdate: raml.GroupUpdate) => dispatch(base, groupUpdate, visitor)
   }
 
-  trait GroupValidationVisitor extends GroupUpdateVisitor[Result, Result] {
+  trait GroupValidationVisitor extends GroupUpdateVisitor[raml.GroupUpdate, raml.App, Result, Result] {
     val originalRootGroup: RootGroup
     val groupUpdateValidator = validator[raml.GroupUpdate] { group =>
       group is notNull
@@ -318,7 +318,7 @@ object Group extends StrictLogging {
 
     override def visit(thisGroup: raml.GroupUpdate): Result = groupUpdateValidator(thisGroup)
 
-    override def appVisitor(): AppVisitor[Result] = AppValidationVisitor()
+    override def appVisitor(): AppVisitor[raml.App, Result] = AppValidationVisitor()
 
     override def childGroupVisitor(): GroupValidationVisitor = this
 
@@ -352,7 +352,7 @@ object Group extends StrictLogging {
     override def childGroupVisitor(): GroupValidationVisitor = this
   }
 
-  case class AppValidationVisitor() extends AppVisitor[Result] {
+  case class AppValidationVisitor() extends AppVisitor[raml.App, Result] {
     override def visit(app: raml.App, groupId: AbsolutePathId): Result = AppValidation.validNestedApp(groupId)(app)
   }
 

--- a/tests/package/Makefile
+++ b/tests/package/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -rf target/*
 
 purge: | clean
-	docker rmi -f marathon-package-test:debian8 || echo "Couldn't remove debian8"
+	docker rmi -f marathon-package-test:debian9 || echo "Couldn't remove debian9"
 	docker rmi -f marathon-package-test:centos6 || echo "Couldn't remove centos6"
 	docker rmi -f marathon-package-test:centos7 || echo "Couldn't remove centos7"
 	docker rmi -f marathon-package-test:ubuntu1404 || echo "Couldn't remove ubuntu1404"

--- a/version
+++ b/version
@@ -19,8 +19,10 @@ Usage $0 [options]
 
 Non-arg params
 
-- commit: output just the formatted commit hash
-- docker: output the version as used by the Docker tag
+* commit - output just the formatted commit hash
+* docker - output the version as used by the Docker tag
+* package - output the version with the commit hash, ie 1.9.34-a122edcb4
+
 EOF
 }
 
@@ -47,18 +49,30 @@ done
 COMMIT_NUMBER="$(git rev-list --count --first-parent $BRANCH_POINT..$REF)"
 COMMIT_HASH=$(git rev-parse --short $REF)
 
-# Echo commit hash
-if [ "${OTHERARGS[0]}" == "commit" ]; then
+case ${OTHERARGS[0]} in
+  commit)
+    # Echo commit hash
     echo "$COMMIT_HASH"
-    exit 0
-fi
-
-# Version for Docker image, e.g. v1.7.42
-if [ "${OTHERARGS[0]}" == "docker" ]; then
+    ;;
+  package)
+    # Echo package version plus hash
+    echo "$MAJOR.$MINOR.$COMMIT_NUMBER-$COMMIT_HASH"
+    ;;
+  docker)
+    # Version for Docker image, e.g. v1.7.42
     echo "v$MAJOR.$MINOR.$COMMIT_NUMBER"
-    exit 0
-fi
+    ;;
+  "")
+    # Echo version
+    # E.g. 1.7.42
+    echo "$MAJOR.$MINOR.$COMMIT_NUMBER"
+    ;;
+  *)
+    echo "ERROR: ${OTHERARGS[0]} is not a version format"
+    echo
+    help
+    exit 1
+    ;;
 
-# Echo verion
-# E.g. 1.7.42
-echo "$MAJOR.$MINOR.$COMMIT_NUMBER"
+
+esac


### PR DESCRIPTION
Summary:
Builds upon #6998 and illustrates how visitors can be composed and reduce overhead
allocations.

The benchmarks without composition take 7270.872ms on average. This change takes 6542.126ms. The current master takes 7967.838ms.