### PR TITLE
Proper usage of absolute path (instead of relative) in the unit test

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/v2/json/DeploymentFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/DeploymentFormatsTest.scala
@@ -103,6 +103,7 @@ class DeploymentFormatsTest extends UnitTest with GroupCreation {
   def genInt = Random.nextInt(1000)
 
   def genId = UUID.randomUUID().toString.toPath
+  def genAbsoluteId = UUID.randomUUID().toString.toAbsolutePath
 
   def genTimestamp = Timestamp.now()
 
@@ -118,13 +119,13 @@ class DeploymentFormatsTest extends UnitTest with GroupCreation {
   def genGroup(children: Set[Group] = Set.empty) = {
     val app1 = genApp
     val app2 = genApp
-    createGroup(genId.asAbsolutePath, apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId.asAbsolutePath), version = genTimestamp, validate = false)
+    createGroup(genAbsoluteId, apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genAbsoluteId), version = genTimestamp, validate = false)
   }
 
   def genRootGroup(children: Set[Group] = Set.empty) = {
     val app1 = genApp
     val app2 = genApp
-    createRootGroup(apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genId.asAbsolutePath), version = genTimestamp, validate = false)
+    createRootGroup(apps = Map(app1.id -> app1, app2.id -> app2), groups = children, dependencies = Set(genAbsoluteId), version = genTimestamp, validate = false)
   }
 
   def genGroupUpdate(children: Set[GroupUpdate] = Set.empty) =


### PR DESCRIPTION
Summary:
Fixed warnings like:
```WARN Path '14b1aa23-e4eb-4c6e-b89a-809cd7d2d2fa' assumed to be an absolute path, but was relative.``` in the `DeploymentFormatsTest` unit test.