### PR TITLE
Fix SI `test_launch_app_timed` test

### DIFF
--- a/src/main/scala/mesosphere/marathon/GroupRoleBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/GroupRoleBehavior.scala
@@ -5,7 +5,7 @@ package mesosphere.marathon
   *
   *  - [[GroupRoleBehavior.Off]] indicates that groups will not enforce their role and apps will use
   *    the default Mesos role.
-  *  - [[GroupRoleBehavior.Top]] indicates that only top-level groups, ie groups directly unser `/`
+  *  - [[GroupRoleBehavior.Top]] indicates that only top-level groups, ie groups directly under `/`
   *    will enforce their role, thus assign their name as the role for any [[raml.App]] or [[raml.Pod]].
   */
 sealed trait GroupRoleBehavior {

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -211,15 +211,14 @@ def test_launch_app_timed():
     """
 
     app_def = apps.mesos_app(app_id='/timed-launch-app')
+    app_id = app_def["id"]
 
     client = marathon.create_client()
     client.add_app(app_def)
 
-    # if not launched in 3 sec fail
-    time.sleep(3)
-    tasks = client.get_tasks(app_def["id"])
-
-    assert len(tasks) == 1, "The number of tasks is {} after deployment, but 1 was expected".format(len(tasks))
+    # if not launched in 10 sec fail
+    assert_that(lambda: client.get_tasks(app_id),
+                eventually(has_len(equal_to(1)), max_attempts=10))
 
 
 def test_ui_available(marathon_service_name):

--- a/tools/dcos-versions.sc
+++ b/tools/dcos-versions.sc
@@ -5,7 +5,7 @@ import $ivy.`com.typesafe.play::play-json:2.6.0`
 import scalaj.http._
 import play.api.libs.json.Json
 
-val minorVersions = Seq(10, 11, 12)
+val minorVersions = Seq(10, 11, 12, 13)
 
 case class ContentResponse(download_url: String)
 implicit val contentResponseFormat = Json.format[ContentResponse]


### PR DESCRIPTION
by increasing used timeout. Seems that recent suppress/revive changes had an effect on the baseline take launch time.