### PR TITLE
Fix SI `test_declined_offer_due_to_resource_role`

### DIFF
--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -994,10 +994,17 @@ def test_default_user():
 
 @common.marathon_1_4
 def test_declined_offer_due_to_resource_role():
-    """Tests that an offer gets declined because the role doesn't exist."""
+    """Tests that an offer gets declined because the role doesn't exist.
+       In the multi role world Marathon does not accept an `acceptedResourceRole` which is not also
+       the app `role` (it doesn't make sense, since the app will never start).
+       In oder to use an acceptedResourceRoles: ["very-random-role"] we need to deploy the app
+       in a top-level group with the same name ("very-random-role") and since enforceRole is by
+       default false, we also set the role field explicitly (to the same value).
+    """
 
-    app_def = apps.sleep_app()
-    app_def["acceptedResourceRoles"] = ["very_random_role"]
+    app_def = apps.sleep_app(app_id="/very-random-role/sleep-that-doesnt-start-because-no-resources")
+    app_def["role"] = "very-random-role"
+    app_def["acceptedResourceRoles"] = ["very-random-role"]
     _test_declined_offer(app_def, 'UnfulfilledRole')
 
 

--- a/tests/system/marathon_common_tests.py
+++ b/tests/system/marathon_common_tests.py
@@ -994,7 +994,7 @@ def test_default_user():
 
 @common.marathon_1_4
 def test_declined_offer_due_to_resource_role():
-    """Tests that an offer gets declined because the role doesn't exist.
+    """Tests that an offer gets declined because no resources are allocated for the role.
        In the multi role world Marathon does not accept an `acceptedResourceRole` which is not also
        the app `role` (it doesn't make sense, since the app will never start).
        In oder to use an acceptedResourceRoles: ["very-random-role"] we need to deploy the app


### PR DESCRIPTION
Summary:
Previously, the `acceptedResourceRoles" = ["very-random-role"]` was removed by normalization (see `sanitize_accepted_resource_roles` deprecated feature which
is enabled by default) so the app could deploy successfully.  In order for the test to
work, we need to deploy it into the proper top-level group (`/very-random-role`)
using `role` with the same value.