### PR TITLE
 Release an unstable EE Docker image.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,11 @@ ansiColor('xterm') {
 
     stage('Release unstable MoM EE Docker Image') {
       if (env.BRANCH_NAME == 'master') {
-        build job: '/Marathon/job/marathon-dcos-plugins/job/release-mom-ee-docker-image/job/master/', parameters: [string(name: 'from_image_tag', value: 'unstable')], propagate: true
+        build(
+             job: '/Marathon/job/marathon-dcos-plugins/job/release-mom-ee-docker-image/job/master/',
+             parameters: [string(name: 'from_image_tag', value: 'unstable'), string(name: 'target_tag', value: 'unstable')],
+             propagate: true
+        )
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,5 +31,10 @@ ansiColor('xterm') {
         archive includes: "*log.tar.gz"
       }
     }
+
+    // TODO: only run when on master
+    stage('Release unstable MoM EE Docker Image') {
+      build job: '/Marathon/job/marathon-dcos-plugins/job/release-mom-ee-docker-image/job/master/', parameters: [string(name: 'from_image_tag', value: 'unstable')], propagate: true
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,7 @@ ansiColor('xterm') {
     }
 
     stage('Release unstable MoM EE Docker Image') {
-      when { branch: 'master' }
-      steps {
+      if (env.BRANCH_NAME == 'master') {
         build job: '/Marathon/job/marathon-dcos-plugins/job/release-mom-ee-docker-image/job/master/', parameters: [string(name: 'from_image_tag', value: 'unstable')], propagate: true
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,9 +32,11 @@ ansiColor('xterm') {
       }
     }
 
-    // TODO: only run when on master
     stage('Release unstable MoM EE Docker Image') {
-      build job: '/Marathon/job/marathon-dcos-plugins/job/release-mom-ee-docker-image/job/master/', parameters: [string(name: 'from_image_tag', value: 'unstable')], propagate: true
+      when { branch: 'master' }
+      steps {
+        build job: '/Marathon/job/marathon-dcos-plugins/job/release-mom-ee-docker-image/job/master/', parameters: [string(name: 'from_image_tag', value: 'unstable')], propagate: true
+      }
     }
   }
 }

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -194,15 +194,19 @@ def build(runTests: Boolean = true, buildName: String = "run"): SemVer = {
 
 /**
   * Builds docker and linux native packages, then runs the tests in tests/package/test.sc
+  *
+  * @return Tag of Docker image
   */
 @main
-def buildDockerAndLinuxPackages(): Unit = {
+def buildDockerAndLinuxPackages(): String = {
   utils.stage("Package Docker Image, Debian and RedHat Packages") {
     %('sbt, "docker:publishLocal")
 
     val toolPath = pwd/'tools/'packager
     %('make, "clean")(toolPath)
     %('make, "all", "-j")(toolPath)
+
+    %%("./version", "docker").out.string.trim
   }
 }
 
@@ -246,7 +250,7 @@ def buildMaster(): Unit = {
 
   val buildNumber = sys.env.get("BUILD_NUMBER").getOrElse("0")
   val version = build(buildName = s"master-$buildNumber")
-  buildDockerAndLinuxPackages()
+  val dockerTag = buildDockerAndLinuxPackages()
   testDockerAndLinuxPackages()
   // dcos.buildRegistry(version) The packaging is broken on master https://jira.mesosphere.com/browse/MARATHON-8442.
 
@@ -255,6 +259,10 @@ def buildMaster(): Unit = {
   maybeArtifact.foreach { artifact =>
     updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
   }
+
+  // Publish Docker image as `unstable`
+  %('docker, "tag", s"mesosphere/marathon:${dockerTag}", "mesosphere/marathon:unstable")
+  %('docker, "push", "mesosphere/marathon:unstable")
 }
 
 /**


### PR DESCRIPTION
Summary:
Each master build should release an unstable EE Docker image. This helps
us finding issues with the EE build faster and enables us to soak the
latest Marathon before pushing it to DC/OS.