### PR TITLE
Accept default Mesos role for `acceptedResourceRoles`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,24 @@
 ## Changes from 1.8.194 to 1.9.xxx
 
+## Changes from 1.8.212 to 1.9.xxx
+
+### Multirole Support
+???
+#### Changes in `acceptedResourceRoles` Behavior
+`acceptedResourceRole` field defines what *reserved* resources would be used by the service. Previously, a Marathon instance started with `--mesos_role *` would accept following service definition:
+```json
+{
+   "id": "/sleep",
+   "cmd": "sleep 3600"
+   "acceptedResourceRoles": ["foo"]
+}
+``` 
+but wouldn't be able to start the task since it is not subscribed for the role `foo`. 
+
+This behavior has been changed with the implementation of the Multirole support. A new deprecated feature flag was introduced: `sanitize_accepted_resource_roles` which is `true` by default in 1.9. With this feature flag active, Marathon would sanitize the `acceptedResourceRoles` array, removing all invalid roles and leaving `*` (unreserved) by default. In the example above, the service definition will be still accepted, however, `foo` will be removed and `"acceptedResourceRoles": ["*"]` would be used instead so that the task *will start*. 
+
+Starting with Marathon 1.10, one will have to set the feature flag manually, otherwise a validation error will be returned for the above example.     
+ 
 ### Introduce SharedMemory/IPC configuration to Marathon Apps and Pods
 
 When running Marathon Apps or Pods it is now possible to configure the IPC separation level and shared memory size.

--- a/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
@@ -18,9 +18,12 @@ object AppHelpers {
 
     validateOrThrow(app)(AppValidation.validateOldAppAPI)
     val migrated = AppNormalization.forDeprecated(config).normalized(app)
+    val normalized = AppNormalization(config).normalized(migrated)
+    println(app.acceptedResourceRoles)
+    println(migrated.acceptedResourceRoles)
+    println(normalized.acceptedResourceRoles)
     validateOrThrow(migrated)(AppValidation.validateCanonicalAppAPI(config.enabledFeatures, () => config.defaultNetworkName, validRoles))
-    AppNormalization(config).normalized(migrated)
-
+    normalized
   }
 
   def appUpdateNormalization(config: AppNormalization.Config): Normalization[raml.AppUpdate] = Normalization { app =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
@@ -17,9 +17,11 @@ object AppHelpers {
   def appNormalization(config: AppNormalization.Config, validRoles: Set[String]): Normalization[raml.App] = Normalization { app =>
 
     validateOrThrow(app)(AppValidation.validateOldAppAPI)
-    val migrated = AppNormalization.forDeprecated(config).normalized(app)
-    validateOrThrow(migrated)(AppValidation.validateCanonicalAppAPI(config.enabledFeatures, () => config.defaultNetworkName, validRoles))
-    AppNormalization(config).normalized(migrated)
+
+    val app1 = AppNormalization.forDeprecated(config).normalized(app)
+    val app2 = AppNormalization.forPreValidation(config).normalized(app1)
+    validateOrThrow(app2)(AppValidation.validateCanonicalAppAPI(config.enabledFeatures, () => config.defaultNetworkName, validRoles))
+    AppNormalization.forPostValidation(config).normalized(app2)
   }
 
   def appUpdateNormalization(config: AppNormalization.Config): Normalization[raml.AppUpdate] = Normalization { app =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
@@ -18,10 +18,10 @@ object AppHelpers {
 
     validateOrThrow(app)(AppValidation.validateOldAppAPI)
 
-    val app1 = AppNormalization.forDeprecated(config).normalized(app)
-    val app2 = AppNormalization.forPreValidation(config).normalized(app1)
-    validateOrThrow(app2)(AppValidation.validateCanonicalAppAPI(config.enabledFeatures, () => config.defaultNetworkName, validRoles))
-    AppNormalization.forPostValidation(config).normalized(app2)
+    val migrated = AppNormalization.forDeprecated(config).normalized(app)
+    val preNormalized = AppNormalization.forPreValidation(config).normalized(migrated)
+    validateOrThrow(preNormalized)(AppValidation.validateCanonicalAppAPI(config.enabledFeatures, () => config.defaultNetworkName, validRoles))
+    AppNormalization.forPostValidation(config).normalized(preNormalized)
   }
 
   def appUpdateNormalization(config: AppNormalization.Config): Normalization[raml.AppUpdate] = Normalization { app =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppHelpers.scala
@@ -18,12 +18,8 @@ object AppHelpers {
 
     validateOrThrow(app)(AppValidation.validateOldAppAPI)
     val migrated = AppNormalization.forDeprecated(config).normalized(app)
-    val normalized = AppNormalization(config).normalized(migrated)
-    println(app.acceptedResourceRoles)
-    println(migrated.acceptedResourceRoles)
-    println(normalized.acceptedResourceRoles)
     validateOrThrow(migrated)(AppValidation.validateCanonicalAppAPI(config.enabledFeatures, () => config.defaultNetworkName, validRoles))
-    normalized
+    AppNormalization(config).normalized(migrated)
   }
 
   def appUpdateNormalization(config: AppNormalization.Config): Normalization[raml.AppUpdate] = Normalization { app =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -297,6 +297,10 @@ object AppNormalization {
     )
   }
 
+/** 
+ * This is a partial normalization, which currently only normalizes the [[App.role]] and [[App.acceptedResourceRoles]] fields.
+ * We do this because app validation is relying on these fields being set correctly.
+ */
   def forPreValidation(config: Config): Normalization[App] = Normalization{ app =>
     val role = app.role.getOrElse(config.defaultRole)
 
@@ -334,8 +338,8 @@ object AppNormalization {
   }
 
   def apply(config: Config): Normalization[App] = Normalization { app =>
-    val app1 = forPreValidation(config).normalized(app)
-    forPostValidation(config).normalized(app1)
+    val preNormalized = forPreValidation(config).normalized(app)
+    forPostValidation(config).normalized(preNormalized)
   }
 
   /** dynamic app normalization configuration, useful for migration and/or testing */

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -99,6 +99,7 @@ class AppsResource @Inject() (
       implicit val identity = await(authenticatedAsync(req))
 
       val ramlApp = Json.parse(body).as[raml.App]
+      println(s"Raw: ${ramlApp.acceptedResourceRoles}")
 
       implicit val (normalize, validate) = createValidatorAndNormalizerForApp(PathId(ramlApp.id).canonicalPath(PathId.root))
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -99,7 +99,6 @@ class AppsResource @Inject() (
       implicit val identity = await(authenticatedAsync(req))
 
       val ramlApp = Json.parse(body).as[raml.App]
-      println(s"Raw: ${ramlApp.acceptedResourceRoles}")
 
       implicit val (normalize, validate) = createValidatorAndNormalizerForApp(PathId(ramlApp.id).canonicalPath(PathId.root))
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2246,7 +2246,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         cmd = Some("cmd"),
         acceptedResourceRoles = Some(Set("customMesosRole")))
 
-      val (body, _) = prepareApp(app, groupManager)
+      val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
       clock += 5.seconds

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -113,8 +113,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val rootGroup = createRootGroup(groups = Set(group), validate = validate, enabledFeatures = enabledFeatures)
       val plan = DeploymentPlan(rootGroup, rootGroup)
       val body = Json.stringify(Json.toJson(normed)).getBytes("UTF-8")
-      println(s"Before ${app.acceptedResourceRoles}")
-      println(s"Normed ${normed.acceptedResourceRoles}")
       groupManager.updateApp(any, any, any, any, any) returns Future.successful(plan)
       groupManager.rootGroup() returns rootGroup
       groupManager.app(appDef.id) returns Some(appDef)

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -59,7 +59,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       config.defaultNetworkName.toOption,
       config.mesosBridgeName(),
       config.availableFeatures,
-      ResourceRole.Unreserved,
+      config.mesosRole(),
       config.availableDeprecatedFeatures.isEnabled(DeprecatedFeatures.sanitizeAcceptedResourceRoles))
     implicit lazy val appDefinitionValidator = AppDefinition.validAppDefinition(config.availableFeatures, ValidationHelper.roleSettings())(PluginManager.None)
 
@@ -113,6 +113,8 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val rootGroup = createRootGroup(groups = Set(group), validate = validate, enabledFeatures = enabledFeatures)
       val plan = DeploymentPlan(rootGroup, rootGroup)
       val body = Json.stringify(Json.toJson(normed)).getBytes("UTF-8")
+      println(s"Before ${app.acceptedResourceRoles}")
+      println(s"Normed ${normed.acceptedResourceRoles}")
       groupManager.updateApp(any, any, any, any, any) returns Future.successful(plan)
       groupManager.rootGroup() returns rootGroup
       groupManager.app(appDef.id) returns Some(appDef)

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2047,7 +2047,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates a validation error")
         response.getStatus should be(422)
         response.getEntity.toString should include("/role")
@@ -2067,7 +2066,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates success")
         response.getStatus should be(201)
       }
@@ -2089,7 +2087,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates a validation error")
         response.getStatus should be(422)
         response.getEntity.toString should include("/role")
@@ -2112,7 +2109,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates success")
         response.getStatus should be(201)
       }
@@ -2135,7 +2131,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates a validation error")
         response.getStatus should be(422)
         response.getEntity.toString should include("/role")
@@ -2155,7 +2150,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates success")
         response.getStatus should be(201)
       }
@@ -2173,7 +2167,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates success")
         response.getStatus should be(201)
       }
@@ -2195,7 +2188,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates success")
         response.getStatus should be(422)
         response.getEntity.toString should include("/role")
@@ -2215,7 +2207,6 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       withClue(response.getEntity.toString) {
-        println("Response Status: " + response.getStatus + " >> " + response.getEntity.toString)
         Then("The return code indicates success")
         response.getStatus should be(201)
       }
@@ -2248,5 +2239,21 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       app.role shouldBe "dev"
     }
 
+    "Create an app in root with configured Mesos role" in new Fixture(configArgs = Seq("--mesos_role", "customMesosRole")) {
+      Given("An app with the default Mesos role")
+      val app = App(id = "/app-with-default", cmd = Some("cmd"), acceptedResourceRoles = Some(Set(config.mesosRole())))
+      val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
+
+      When("The create request is made")
+      clock += 5.seconds
+      val response = asyncRequest { r =>
+        appsResource.create(body, force = false, auth.request, r)
+      }
+
+      withClue(response.getEntity.toString) {
+        Then("The return code indicates success")
+        response.getStatus should be(201)
+      }
+    }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2239,25 +2239,25 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       app.role shouldBe "dev"
     }
 
-    "Create an app in root with configured Mesos role" in new Fixture(configArgs = Seq("--mesos_role", "slave_public")) {
-      Given("An app with acceptedResourceRoles = the default Mesos role")
+    "Create an app in root with acceptedResourceRoles = default Mesos role" in new Fixture(configArgs = Seq("--mesos_role", "customMesosRole")) {
+      Given("An app with the mesos_role role")
+      val app = App(
+        id = "/app-with-accepted-default-mesos-role",
+        cmd = Some("cmd"),
+        acceptedResourceRoles = Some(Set("customMesosRole")))
+
+      val (body, _) = prepareApp(app, groupManager)
+
+      When("The create request is made")
+      clock += 5.seconds
       val response = asyncRequest { r =>
-        val body =
-          """
-            |{
-            |  "id": "app-with-accepted-mesos-default-role",
-            |  "cmd": "sleep 3600",
-            |  "instances": 1,
-            |  "cpus": 0.05,
-            |  "mem": 128,
-            |  "acceptedResourceRoles": ["slave_public"]
-            |}
-          """.stripMargin
-        appsResource.create(body.getBytes, force = false, auth.request, r)
+        appsResource.create(body, force = false, auth.request, r)
       }
 
-      Then("the app should be created successfully")
-      response.getStatus should be(201)
+      withClue(response.getEntity.toString) {
+        Then("The return code indicates success")
+        response.getStatus should be(201)
+      }
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -211,9 +211,10 @@ class AppDefinitionFormatsTest extends UnitTest
       appDef.acceptedResourceRoles should equal(Set(ResourceRole.Unreserved))
     }
 
-    "FromJSON should fail when 'acceptedResourceRoles' is defined but empty" in {
+    "FromJSON should is sanitized when 'acceptedResourceRoles' is defined but empty" in {
       val json = Json.parse(""" { "id": "test", "cmd": "foo", "acceptedResourceRoles": [] }""")
-      a[ValidationFailedException] shouldBe thrownBy { normalizeAndConvert(json.as[raml.App]) }
+      val appDef = normalizeAndConvert(json.as[raml.App])
+      appDef.acceptedResourceRoles should equal(Set(ResourceRole.Unreserved))
     }
 
     "FromJSON should read the default upgrade strategy" in {


### PR DESCRIPTION
Fixing a regression where a valid case of having an `acceptedResourceRoles: [--mesos_role]` would fail validation. Additionally, `acceptedResourceRole` is now sanitized when `sanitize_accepted_resource_roles` is active: 
- if an invalid resource role is passed, it is removed
- If `acceptedResourceRole` array is empty, `*` (Unreserved) is used

JIRA: MARATHON-8683