### PR TITLE
Fix uneccesary latency with suppress/revive logic when rate-limited

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
@@ -75,6 +75,7 @@ object ReviveOffersStreamLogic extends StrictLogging {
       .via(RateLimiterFlow.apply(minReviveOffersInterval))
       .map(_.roleReviveVersions)
       .via(reviveDirectiveFlow(enableSuppress))
+      .map(l => { logger.info(s"Issuing following suppress/revive directives: = ${l}"); l })
       .via(reviveRepeaterWithTicks)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.update.{InstanceChangeOrSnapshot, InstanceDeleted, InstanceUpdated, InstancesSnapshot}
 import mesosphere.marathon.core.launchqueue.impl.ReviveOffersState.Role
 import mesosphere.marathon.state.RunSpecConfigRef
-import mesosphere.marathon.stream.TimedEmitter
+import mesosphere.marathon.stream.{RateLimiterFlow, TimedEmitter}
 
 import scala.concurrent.duration._
 
@@ -72,11 +72,9 @@ object ReviveOffersStreamLogic extends StrictLogging {
 
     reviveStateFromInstancesAndDelays(defaultRole)
       .buffer(1, OverflowStrategy.dropHead) // While we are back-pressured, we drop older interim frames
-      .throttle(1, minReviveOffersInterval)
+      .via(RateLimiterFlow.apply(minReviveOffersInterval))
       .map(_.roleReviveVersions)
-      .map(l => { logger.info(s"roleReviveVersions = ${l}"); l })
       .via(reviveDirectiveFlow(enableSuppress))
-      .map(l => { logger.info(s"reviveDirectiveFlow = ${l}"); l })
       .via(reviveRepeaterWithTicks)
   }
 

--- a/src/main/scala/mesosphere/marathon/stream/RateLimiterFlow.scala
+++ b/src/main/scala/mesosphere/marathon/stream/RateLimiterFlow.scala
@@ -1,0 +1,67 @@
+package mesosphere.marathon
+package stream
+
+import java.time.{Clock, Duration => JavaDuration}
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+import akka.stream.stage._
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+
+import scala.compat.java8.DurationConverters
+import scala.concurrent.duration.FiniteDuration
+
+class RateLimiterFlow[U] private (rate: FiniteDuration, clock: Clock = Clock.systemUTC()) extends GraphStage[FlowShape[U, U]] {
+  val input = Inlet[U]("rate-limiter-input")
+  val output = Outlet[U]("rate-limiter-output")
+
+  override val shape = FlowShape(input, output)
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new TimerGraphStageLogic(shape) with StageLogging {
+
+    var nextPullAllowed = clock.instant()
+
+    setHandler(input, new InHandler {
+      override def onPush(): Unit = {
+        push(output, grab(input))
+      }
+    })
+
+    setHandler(output, new OutHandler {
+      override def onPull(): Unit = {
+        val now = clock.instant()
+        if (now.isAfter(nextPullAllowed)) {
+          doPull()
+        } else {
+          val pendingTime = JavaDuration.between(now, nextPullAllowed)
+          scheduleOnce("pull", DurationConverters.toScala(pendingTime))
+        }
+      }
+    })
+
+    private def doPull(): Unit = {
+      pull(input)
+      nextPullAllowed = clock.instant().plus(DurationConverters.toJava(rate))
+    }
+
+    override def onTimer(timerKey: Any): Unit = {
+      timerKey match {
+        case "pull" =>
+          doPull()
+        case other =>
+          log.error(s"Bug! We received a timer key ${other} that was not of type TimerKey")
+      }
+    }
+  }
+}
+
+object RateLimiterFlow {
+  /**
+    * A component similar to Akka stream's built-in throttle, with the important difference that it does not buffer a
+    * single element while the rate is exceeded.
+    *
+    * @param rate The time to wait between each pull
+    * @param clock Clock used to judge the current time when calculating delays. Note, advancing this clock has no effect on already-scheduled delays
+    */
+  def apply[U](rate: FiniteDuration, clock: Clock = Clock.systemUTC()): Flow[U, U, NotUsed] =
+    Flow.fromGraph(new RateLimiterFlow[U](rate, clock))
+}

--- a/src/main/scala/mesosphere/marathon/stream/RateLimiterFlow.scala
+++ b/src/main/scala/mesosphere/marathon/stream/RateLimiterFlow.scala
@@ -29,11 +29,11 @@ class RateLimiterFlow[U] private (rate: FiniteDuration, clock: Clock = Clock.sys
     setHandler(output, new OutHandler {
       override def onPull(): Unit = {
         val now = clock.instant()
-        if (now.isAfter(nextPullAllowed)) {
-          doPull()
-        } else {
+        if (now.isBefore(nextPullAllowed)) {
           val pendingTime = JavaDuration.between(now, nextPullAllowed)
           scheduleOnce("pull", DurationConverters.toScala(pendingTime))
+        } else {
+          doPull()
         }
       }
     })

--- a/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogicTest.scala
+++ b/src/test/java/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogicTest.scala
@@ -39,11 +39,6 @@ class ReviveOffersStreamLogicTest extends AkkaUnitTest with Inside {
       When("An initial snapshot with a launched instance is offered")
       input.offer(Left(InstancesSnapshot(List(launchedInstance)))).futureValue
 
-      And("3 instance updates are sent for the role 'web'")
-      Future.sequence(Seq(instance1, instance2, instance3).map { i =>
-        input.offer(Left(InstanceUpdated(i, None, Nil)))
-      }).futureValue
-
       Then("An update framework event is issued with the role suppressed in response to the snapshot")
       inside(output.pull().futureValue) {
         case Some(UpdateFramework(roleState, newlyRevived, newlySuppressed)) =>
@@ -51,6 +46,11 @@ class ReviveOffersStreamLogicTest extends AkkaUnitTest with Inside {
           newlyRevived shouldBe Set.empty
           newlySuppressed shouldBe Set.empty
       }
+
+      And("3 instance updates are sent for the role 'web'")
+      Future.sequence(Seq(instance1, instance2, instance3).map { i =>
+        input.offer(Left(InstanceUpdated(i, None, Nil)))
+      }).futureValue
 
       Then("The revives from the instances get combined in to a single update framework call")
       inside(output.pull().futureValue) {

--- a/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
+++ b/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
@@ -1,0 +1,70 @@
+package mesosphere.marathon
+package stream
+
+import java.time.{Instant, Duration => JavaDuration}
+
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.test.SettableClock
+
+import scala.compat.java8.DurationConverters
+import scala.concurrent.duration._
+
+class RateLimiterFlowTest extends AkkaUnitTest {
+  def durationOf(f: => Unit): FiniteDuration = {
+    val now = Instant.now
+    f
+    DurationConverters.toScala(JavaDuration.between(now, Instant.now))
+  }
+
+  "rate limiter" should {
+    "delay the pulling of elements by the specified rate" in {
+      val clock = new SettableClock()
+
+      Given("a stream connected to a rate limiter flow with a rate limit of 1/100ms")
+      val (input, output) =
+        Source.queue[Int](16, OverflowStrategy.fail)
+          .via(RateLimiterFlow[Int](100.millis, clock))
+          .toMat(Sink.queue())(Keep.both)
+          .run
+
+      val start = Instant.now()
+      When("the first element is published")
+      input.offer(1)
+
+      Then("it should take less than 100ms to come through")
+      output.pull().futureValue shouldBe Some(1)
+      val e1Time = Instant.now
+      JavaDuration.between(start, e1Time).toMillis should be < 100L
+
+      When("another element is published at the same time")
+      input.offer(2)
+      Then("it should take more than 100ms from the start to come through")
+      output.pull().futureValue shouldBe Some(2)
+      val e2Time = Instant.now
+      JavaDuration.between(start, e2Time).toMillis should be >= 100L
+
+      When("the clock is advanced by 200 ms")
+      clock.+=(200.millis)
+      And("element 3 is published")
+      input.offer(3)
+
+      Then("then element 3 is received less than 100ms after element 2")
+      output.pull().futureValue shouldBe Some(3)
+      val e3Time = Instant.now
+      JavaDuration.between(e2Time, e3Time).toMillis should be >= 100L
+    }
+
+    "should not deliver a termination signal until all elements are processed" in {
+      val input = List(1, 2, 3, 4, 5)
+      val output = Source(List(1, 2, 3, 4, 5))
+        .via(RateLimiterFlow[Int](50.millis))
+        .runWith(Sink.seq)
+        .futureValue
+
+      output shouldBe input
+    }
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
+++ b/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
@@ -18,53 +18,52 @@ class RateLimiterFlowTest extends AkkaUnitTest {
     DurationConverters.toScala(JavaDuration.between(now, Instant.now))
   }
 
-  "rate limiter" should {
-    "delay the pulling of elements by the specified rate" in {
-      val clock = new SettableClock()
+  "delay the pulling of elements by the specified rate" in {
+    val clock = new SettableClock()
 
-      Given("a stream connected to a rate limiter flow with a rate limit of 1/100ms")
-      val (input, output) =
-        Source.queue[Int](16, OverflowStrategy.fail)
-          .via(RateLimiterFlow[Int](100.millis, clock))
-          .toMat(Sink.queue())(Keep.both)
-          .run
+    Given("a stream connected to a rate limiter flow with a rate limit of 1/100ms")
+    val (input, output) =
+      Source.queue[Int](16, OverflowStrategy.fail)
+        .via(RateLimiterFlow[Int](100.millis, clock))
+        .toMat(Sink.queue())(Keep.both)
+        .run
 
-      val start = Instant.now()
-      When("the first element is published")
-      input.offer(1)
+    val start = Instant.now()
+    When("the first element is published")
+    input.offer(1)
 
-      Then("it should take less than 100ms to come through")
-      output.pull().futureValue shouldBe Some(1)
-      val e1Time = Instant.now
-      JavaDuration.between(start, e1Time).toMillis should be < 100L
+    Then("it should take less than 100ms to come through")
+    output.pull().futureValue shouldBe Some(1)
+    val e1Time = Instant.now
+    JavaDuration.between(start, e1Time).toMillis should be < 100L
 
-      When("another element is published at the same time")
-      input.offer(2)
-      Then("it should take more than 100ms from the start to come through")
-      output.pull().futureValue shouldBe Some(2)
-      val e2Time = Instant.now
-      JavaDuration.between(start, e2Time).toMillis should be >= 100L
+    When("another element is published at the same time")
+    input.offer(2)
+    Then("it should take more than 100ms from the start to come through")
+    output.pull().futureValue shouldBe Some(2)
+    val e2Time = Instant.now
+    JavaDuration.between(start, e2Time).toMillis should be >= 100L
 
-      When("the clock is advanced by 200 ms")
-      clock.+=(200.millis)
-      And("element 3 is published")
-      input.offer(3)
+    When("the clock is advanced by 200 ms")
+    clock.+=(200.millis)
+    And("element 3 is published")
+    input.offer(3)
 
-      Then("then element 3 is received less than 100ms after element 2")
-      output.pull().futureValue shouldBe Some(3)
-      val e3Time = Instant.now
-      JavaDuration.between(e2Time, e3Time).toMillis should be >= 100L
-    }
-
-    "should not deliver a termination signal until all elements are processed" in {
-      val input = List(1, 2, 3, 4, 5)
-      val output = Source(List(1, 2, 3, 4, 5))
-        .via(RateLimiterFlow[Int](50.millis))
-        .runWith(Sink.seq)
-        .futureValue
-
-      output shouldBe input
-    }
+    Then("then element 3 is received less than 100ms after element 2")
+    output.pull().futureValue shouldBe Some(3)
+    val e3Time = Instant.now
+    JavaDuration.between(e2Time, e3Time).toMillis should be >= 100L
   }
+
+  "not deliver a termination signal until all elements are processed" in {
+    val input = List(1, 2, 3, 4, 5)
+    val output = Source(List(1, 2, 3, 4, 5))
+      .via(RateLimiterFlow[Int](50.millis))
+      .runWith(Sink.seq)
+      .futureValue
+
+    output shouldBe input
+  }
+
 
 }


### PR DESCRIPTION
Previously, we used Akka streams throttle to rate limit. A disadvantage to this
component was it would buffer a single element in the event of an overflow,
precluding our debounce logic from dropping it in favor of a more fresh
snapshot of the state.

By introducing and using RateLimiterFlow, our debouncing logic always presents
the latest available snapshot as allowed by the rate limiter

JIRA Issues: MARATHON-8664
