### PR TITLE
Rename SettableClock mutating methods to be more clear

### DIFF
--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -204,7 +204,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val result = Try {
         val response = asyncRequest { r =>
           appsResource.create(body, force = false, auth.request, r)
@@ -247,7 +247,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -270,7 +270,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -293,7 +293,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -315,7 +315,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -596,7 +596,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -628,7 +628,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -704,7 +704,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -734,7 +734,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -769,7 +769,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -809,7 +809,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -855,7 +855,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       groupManager.app(appDef.id) returns Some(appDef)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -912,7 +912,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       """.stripMargin.getBytes
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -956,7 +956,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -985,7 +985,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1006,7 +1006,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1038,7 +1038,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1063,7 +1063,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1124,7 +1124,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val body = Json.stringify(appJson).getBytes("UTF-8")
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1951,7 +1951,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1966,7 +1966,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
 
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
@@ -1977,7 +1977,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
 
       When("Env is updated with a PUT request")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
 
       val update =
         """
@@ -2006,7 +2006,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val result = Try {
         val response = asyncRequest { r =>
           appsResource.create(body, force = false, auth.request, r)
@@ -2041,7 +2041,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2061,7 +2061,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2083,7 +2083,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       //      val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2106,7 +2106,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2129,7 +2129,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val body = Json.stringify(Json.toJson(normalize(appWithDifferentCustomRole))).getBytes("UTF-8")
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2149,7 +2149,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2167,7 +2167,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2189,7 +2189,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       //      val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2209,7 +2209,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock advanceBy 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -204,7 +204,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val result = Try {
         val response = asyncRequest { r =>
           appsResource.create(body, force = false, auth.request, r)
@@ -247,7 +247,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -270,7 +270,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -293,7 +293,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -315,7 +315,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -596,7 +596,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -628,7 +628,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -704,7 +704,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -734,7 +734,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -769,7 +769,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -809,7 +809,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -855,7 +855,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       groupManager.app(appDef.id) returns Some(appDef)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -912,7 +912,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       """.stripMargin.getBytes
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -956,7 +956,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -985,7 +985,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1006,7 +1006,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1038,7 +1038,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1063,7 +1063,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1124,7 +1124,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val body = Json.stringify(appJson).getBytes("UTF-8")
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1951,7 +1951,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -1966,7 +1966,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, enabledFeatures = Set("secrets"))
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
 
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
@@ -1977,7 +1977,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
 
       When("Env is updated with a PUT request")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
 
       val update =
         """
@@ -2006,7 +2006,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, plan) = prepareApp(app, groupManager)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val result = Try {
         val response = asyncRequest { r =>
           appsResource.create(body, force = false, auth.request, r)
@@ -2041,7 +2041,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2061,7 +2061,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2083,7 +2083,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       //      val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2106,7 +2106,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2129,7 +2129,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val body = Json.stringify(Json.toJson(normalize(appWithDifferentCustomRole))).getBytes("UTF-8")
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2149,7 +2149,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2167,7 +2167,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2189,7 +2189,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       //      val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }
@@ -2209,7 +2209,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareAppInGroup(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock += 5.seconds
+      clock advanceBy 5.seconds
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
@@ -66,7 +66,7 @@ class LeaderResourceTest extends UnitTest with JerseyTest {
       Then("we receive a authorized response")
       delete.getStatus should be(200)
       verify(f.electionService, times(0)).abdicateLeadership()
-      f.clock += 500.millis
+      f.clock advanceBy 500.millis
       verify(f.electionService, times(1)).abdicateLeadership()
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/LeaderResourceTest.scala
@@ -66,7 +66,7 @@ class LeaderResourceTest extends UnitTest with JerseyTest {
       Then("we receive a authorized response")
       delete.getStatus should be(200)
       verify(f.electionService, times(0)).abdicateLeadership()
-      f.clock advanceBy 500.millis
+      f.clock.advanceBy(500.millis)
       verify(f.electionService, times(1)).abdicateLeadership()
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -429,13 +429,13 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       val v1 = VersionInfo.OnlyVersion(f.clock.now())
       val podspec1 = pod.copy(versionInfo = v1)
 
-      f.clock += 1.minute
+      f.clock advanceBy 1.minute
 
       // the same as podspec1 but with a new version and a renamed container
       val v2 = VersionInfo.OnlyVersion(f.clock.now())
       val podspec2 = pod.copy(versionInfo = v2, containers = pod.containers.map(_.copy(name = "ct2")))
 
-      f.clock += 1.minute
+      f.clock advanceBy 1.minute
 
       When("requesting pod instance status")
       val instanceV1 = f.fakeInstance(podspec1)

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -429,13 +429,13 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       val v1 = VersionInfo.OnlyVersion(f.clock.now())
       val podspec1 = pod.copy(versionInfo = v1)
 
-      f.clock advanceBy 1.minute
+      f.clock.advanceBy(1.minute)
 
       // the same as podspec1 but with a new version and a renamed container
       val v2 = VersionInfo.OnlyVersion(f.clock.now())
       val podspec2 = pod.copy(versionInfo = v2, containers = pod.containers.map(_.copy(name = "ct2")))
 
-      f.clock advanceBy 1.minute
+      f.clock.advanceBy(1.minute)
 
       When("requesting pod instance status")
       val instanceV1 = f.fakeInstance(podspec1)

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -73,7 +73,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
       val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
 
       // Forward time to expire unreachable status
-      f.clock advanceBy unreachableInactiveAfter + 1.minute
+      f.clock.advanceBy(unreachableInactiveAfter + 1.minute)
       val operation = InstanceUpdateOperation.MesosUpdate(f.instance, newMesosStatus, f.clock.now())
       val result = InstanceUpdater.mesosUpdate(f.instance, operation)
 
@@ -206,7 +206,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
         runSpec = updatedRunSpec)
 
       // Move time forward
-      f.clock advanceBy 5.minutes
+      f.clock.advanceBy(5.minutes)
       // Update unreachableInstance with unreachable Mesos status.
       val operation = InstanceUpdateOperation.MesosUpdate(unreachableInstance, mesosTaskStatus, f.clock.now())
       val result = InstanceUpdater.mesosUpdate(unreachableInstance, operation)
@@ -233,7 +233,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
         runSpec = updatedRunSpec)
 
       // Move time forward
-      f.clock advanceBy 5.minutes
+      f.clock.advanceBy(5.minutes)
 
       // Update unreachableInstance with unreachable Mesos status.
       val operation = InstanceUpdateOperation.MesosUpdate(unreachableInactiveInstance, mesosTaskStatus, f.clock.now())

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -73,7 +73,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
       val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
 
       // Forward time to expire unreachable status
-      f.clock += unreachableInactiveAfter + 1.minute
+      f.clock advanceBy unreachableInactiveAfter + 1.minute
       val operation = InstanceUpdateOperation.MesosUpdate(f.instance, newMesosStatus, f.clock.now())
       val result = InstanceUpdater.mesosUpdate(f.instance, operation)
 
@@ -206,7 +206,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
         runSpec = updatedRunSpec)
 
       // Move time forward
-      f.clock += 5.minutes
+      f.clock advanceBy 5.minutes
       // Update unreachableInstance with unreachable Mesos status.
       val operation = InstanceUpdateOperation.MesosUpdate(unreachableInstance, mesosTaskStatus, f.clock.now())
       val result = InstanceUpdater.mesosUpdate(unreachableInstance, operation)
@@ -233,7 +233,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
         runSpec = updatedRunSpec)
 
       // Move time forward
-      f.clock += 5.minutes
+      f.clock advanceBy 5.minutes
 
       // Update unreachableInstance with unreachable Mesos status.
       val operation = InstanceUpdateOperation.MesosUpdate(unreachableInactiveInstance, mesosTaskStatus, f.clock.now())

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterTest.scala
@@ -51,7 +51,7 @@ class RateLimiterTest extends UnitTest {
 
       // after advancing the clock by (threshold + 1), the existing delays
       // with maxLaunchDelay < (threshold + 1) should be gone
-      clock += threshold + 1.seconds
+      clock advanceBy threshold + 1.seconds
       limiter.cleanUpOverdueDelays()
       limiter.getDelay(appWithOverdueDelay.configRef) shouldBe empty
       limiter.getDelay(appWithValidDelay.configRef).value.deadline should be(time_origin + 20.seconds)

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/RateLimiterTest.scala
@@ -51,7 +51,7 @@ class RateLimiterTest extends UnitTest {
 
       // after advancing the clock by (threshold + 1), the existing delays
       // with maxLaunchDelay < (threshold + 1) should be gone
-      clock advanceBy threshold + 1.seconds
+      clock.advanceBy(threshold + 1.seconds)
       limiter.cleanUpOverdueDelays()
       limiter.getDelay(appWithOverdueDelay.configRef) shouldBe empty
       limiter.getDelay(appWithValidDelay.configRef).value.deadline should be(time_origin + 20.seconds)

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
@@ -166,7 +166,7 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
       When("1 offer is send, which is passed to the matcher, 2 offers are send and queued with a 10 millis gap")
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer1, offerMatch1)
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer2, offerMatch2)
-      clock += 10.millis
+      clock advanceBy 10.millis
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer3, offerMatch3)
 
       Then("offer-2 is declined, due to timeout but not offer-3")
@@ -175,7 +175,7 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
       offerMatch1.isCompleted should be(false)
 
       And("After 10 millis also offer-2 is declined")
-      clock += 10.millis
+      clock advanceBy 10.millis
       offerMatch3.future.futureValue.opsWithSource should be('empty)
       offerMatch1.isCompleted should be(false)
     }
@@ -189,7 +189,7 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
 
       When("1 offer is send, which is passed to the matcher, but the matcher does not respond")
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer1, offerMatch1)
-      clock += 30.millis
+      clock advanceBy 30.millis
 
       Then("offer-1 is declined, since the actor did not respond in time")
       offerMatch1.future.futureValue.opsWithSource should be('empty)

--- a/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActorTest.scala
@@ -166,7 +166,7 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
       When("1 offer is send, which is passed to the matcher, 2 offers are send and queued with a 10 millis gap")
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer1, offerMatch1)
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer2, offerMatch2)
-      clock advanceBy 10.millis
+      clock.advanceBy(10.millis)
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer3, offerMatch3)
 
       Then("offer-2 is declined, due to timeout but not offer-3")
@@ -175,7 +175,7 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
       offerMatch1.isCompleted should be(false)
 
       And("After 10 millis also offer-2 is declined")
-      clock advanceBy 10.millis
+      clock.advanceBy(10.millis)
       offerMatch3.future.futureValue.opsWithSource should be('empty)
       offerMatch1.isCompleted should be(false)
     }
@@ -189,7 +189,7 @@ class OfferMatcherManagerActorTest extends AkkaUnitTest with Eventually {
 
       When("1 offer is send, which is passed to the matcher, but the matcher does not respond")
       offerMatcherManager ! ActorOfferMatcher.MatchOffer(offer1, offerMatch1)
-      clock advanceBy 30.millis
+      clock.advanceBy(30.millis)
 
       Then("offer-1 is declined, since the actor did not respond in time")
       offerMatch1.future.futureValue.opsWithSource should be('empty)

--- a/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/PersistenceStoreTest.scala
@@ -84,7 +84,7 @@ private[storage] trait PersistenceStoreTest { this: AkkaUnitTest =>
         implicit val clock = new SettableClock()
         val store = newStore
         val original = TestClass1("abc", 1)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         val updated = TestClass1("def", 2)
         store.store("task-1", original).futureValue should be(Done)
         store.store("task-1", updated).futureValue should be(Done)
@@ -104,14 +104,14 @@ private[storage] trait PersistenceStoreTest { this: AkkaUnitTest =>
       "store the multiple versions of the old values" in {
         val clock = new SettableClock()
         val versions = 0.until(10).map { i =>
-          clock.plus(1.minute)
+          clock.advanceBy(1.minute)
           TestClass1("abc", i, OffsetDateTime.now(clock))
         }
         val store = newStore
         versions.foreach { v =>
           store.store("task", v).futureValue should be(Done)
         }
-        clock.plus(1.hour)
+        clock.advanceBy(1.hour)
         val newestVersion = TestClass1("def", 3, OffsetDateTime.now(clock))
         store.store("task", newestVersion).futureValue should be(Done)
         // it should have dropped one element.

--- a/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/storage/store/impl/cache/LazyCachingPersistenceStoreTest.scala
@@ -69,7 +69,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
         val store = newStore
         1.to(100).foreach { i =>
           val obj = TestClass1("abc", i)
-          clock.plus(1.second)
+          clock.advanceBy(1.second)
           store.store("task-1", obj).futureValue should be(Done)
         }
         store.versionedValueCache.size should be(100) // sanity
@@ -81,7 +81,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
         implicit val clock = new SettableClock()
         val store = newStore
         val original = TestClass1("abc", 1)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         val updated = TestClass1("def", 2)
         store.store("task-1", original).futureValue should be(Done)
         store.store("task-1", updated).futureValue should be(Done)
@@ -98,7 +98,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
         implicit val clock = new SettableClock()
         val store = newStore
         val original = TestClass1("abc", 1)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         val updated = TestClass1("def", 2)
         store.store("task-1", original).futureValue should be(Done)
         store.store("task-1", updated).futureValue should be(Done)
@@ -114,7 +114,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
         implicit val clock = new SettableClock()
         val store = newStore
         val original = TestClass1("abc", 1)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         val updated = TestClass1("def", 2)
         store.store("task-1", original).futureValue should be(Done)
         store.store("task-1", updated).futureValue should be(Done)
@@ -132,7 +132,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
         implicit val clock = new SettableClock()
         val store = newStore
         val original = TestClass1("abc", 1)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         val updated = TestClass1("def", 2)
         store.store("task-1", original).futureValue should be(Done)
         store.store("task-1", updated).futureValue should be(Done)
@@ -154,7 +154,7 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
         implicit val clock = new SettableClock()
         val store = newStore
         val original = TestClass1("abc", 1)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         val updated = TestClass1("def", 2)
         store.store("task-1", original).futureValue should be(Done)
         store.store("task-1", updated).futureValue should be(Done)
@@ -177,9 +177,9 @@ class LazyCachingPersistenceStoreTest extends AkkaUnitTest
 
         // 1 version available in the cache and 2 in the underlying store
         store.store("test", TestClass1("abc", 1)).futureValue should be(Done)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         underlying.store("test", TestClass1("abc", 2)).futureValue should be(Done)
-        clock.plus(1.minute)
+        clock.advanceBy(1.minute)
         underlying.store("test", TestClass1("abc", 3)).futureValue should be(Done)
 
         store.versionCache.size should be(0)

--- a/src/test/scala/mesosphere/marathon/core/task/TaskStatusUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskStatusUpdateTest.scala
@@ -41,7 +41,7 @@ class TaskStatusUpdateTest extends UnitTest {
       val instance = mock[Instance]
       instance.hasReservation returns false
 
-      f.clock += 5.seconds
+      f.clock advanceBy 5.seconds
 
       val status = MesosTaskStatusTestHelper.unreachable(task.taskId, f.clock.now())
 
@@ -58,7 +58,7 @@ class TaskStatusUpdateTest extends UnitTest {
       val instance = mock[Instance]
       instance.hasReservation returns true
 
-      f.clock += 5.seconds
+      f.clock advanceBy 5.seconds
 
       val status = MesosTaskStatusTestHelper.unreachable(task.taskId, f.clock.now())
 

--- a/src/test/scala/mesosphere/marathon/core/task/TaskStatusUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/TaskStatusUpdateTest.scala
@@ -41,7 +41,7 @@ class TaskStatusUpdateTest extends UnitTest {
       val instance = mock[Instance]
       instance.hasReservation returns false
 
-      f.clock advanceBy 5.seconds
+      f.clock.advanceBy(5.seconds)
 
       val status = MesosTaskStatusTestHelper.unreachable(task.taskId, f.clock.now())
 
@@ -58,7 +58,7 @@ class TaskStatusUpdateTest extends UnitTest {
       val instance = mock[Instance]
       instance.hasReservation returns true
 
-      f.clock advanceBy 5.seconds
+      f.clock.advanceBy(5.seconds)
 
       val status = MesosTaskStatusTestHelper.unreachable(task.taskId, f.clock.now())
 

--- a/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/termination/impl/KillServiceActorTest.scala
@@ -221,7 +221,7 @@ class KillServiceActorTest extends AkkaUnitTest with StrictLogging with Eventual
         val (taskId, _) = instance.tasksMap.head
         verify(f.driver, timeout(f.killConfig.killRetryTimeout.toMillis.toInt * 2)).killTask(taskId.mesosTaskId)
 
-        f.clock.+=(10.seconds)
+        f.clock.advanceBy(10.seconds)
 
         verify(f.driver, timeout(f.killConfig.killRetryTimeout.toMillis.toInt * 2)).killTask(taskId.mesosTaskId)
       }
@@ -250,7 +250,7 @@ class KillServiceActorTest extends AkkaUnitTest with StrictLogging with Eventual
         captor.getAllValues should contain(f.taskIdFor(instance, stagingContainer))
         captor.getAllValues should contain(f.taskIdFor(instance, runningContainer))
 
-        f.clock.+=(10.seconds)
+        f.clock.advanceBy(10.seconds)
 
         val (taskId, _) = instance.tasksMap.head
         verify(f.driver, timeout(f.killConfig.killRetryTimeout.toMillis.toInt * 2)).killTask(taskId.mesosTaskId)
@@ -280,7 +280,7 @@ class KillServiceActorTest extends AkkaUnitTest with StrictLogging with Eventual
         captor.getAllValues should contain(f.taskIdFor(instance, stagingContainer))
         captor.getAllValues should contain(f.taskIdFor(instance, runningContainer))
 
-        f.clock.+=(10.seconds)
+        f.clock.advanceBy(10.seconds)
 
         val (taskId, _) = instance.tasksMap.head
         verify(f.driver, timeout(f.killConfig.killRetryTimeout.toMillis.toInt * 2)).killTask(taskId.mesosTaskId)

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -99,7 +99,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = provisionedInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -129,7 +129,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = stagingInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -160,7 +160,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = startingInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -194,7 +194,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = runningInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -232,7 +232,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(false)) // task status will say unhealthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -270,7 +270,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(true)) // task status will say healthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -309,7 +309,7 @@ class PodStatusConversionTest extends UnitTest {
 
       val pod = withCommandLineHealthChecks(basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now())))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = runningInstance(pod = pod) // mesos task status health is missing
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -348,7 +348,7 @@ class PodStatusConversionTest extends UnitTest {
 
       val pod = withCommandLineHealthChecks(basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now())))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(false)) // task status will say unhealthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -387,7 +387,7 @@ class PodStatusConversionTest extends UnitTest {
 
       val pod = withCommandLineHealthChecks(basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now())))
 
-      clock advanceBy 1.seconds
+      clock.advanceBy(1.seconds)
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(true)) // task status will say healthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -99,7 +99,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = provisionedInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -129,7 +129,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = stagingInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -160,7 +160,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = startingInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -194,7 +194,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = runningInstance(pod)
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -232,7 +232,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(false)) // task status will say unhealthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -270,7 +270,7 @@ class PodStatusConversionTest extends UnitTest {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(true)) // task status will say healthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -309,7 +309,7 @@ class PodStatusConversionTest extends UnitTest {
 
       val pod = withCommandLineHealthChecks(basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now())))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = runningInstance(pod = pod) // mesos task status health is missing
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -348,7 +348,7 @@ class PodStatusConversionTest extends UnitTest {
 
       val pod = withCommandLineHealthChecks(basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now())))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(false)) // task status will say unhealthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))
@@ -387,7 +387,7 @@ class PodStatusConversionTest extends UnitTest {
 
       val pod = withCommandLineHealthChecks(basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now())))
 
-      clock += 1.seconds
+      clock advanceBy 1.seconds
       val fixture = runningInstance(pod = pod, maybeHealthy = Some(true)) // task status will say healthy
 
       val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, fixture.instance))

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTest.scala
@@ -214,7 +214,7 @@ class MigrationTest extends AkkaUnitTest with Mockito with GivenWhenThen with Ev
 
       started.future.futureValue shouldBe Done
       (1 to 3) foreach { _ =>
-        f.clock += Migration.statusLoggingInterval
+        f.clock advanceBy Migration.statusLoggingInterval
       }
       eventually {
         f.notificationCounter.get shouldBe 3

--- a/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
+++ b/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
@@ -50,7 +50,7 @@ class RateLimiterFlowTest extends AkkaUnitTest {
     JavaDuration.between(start, e2Time).toMillis should be >= 100L
 
     When("the clock is advanced by 200 ms")
-    clock.+=(200.millis)
+    clock.advanceBy(200.millis)
     And("element 3 is published")
     input.offer(3)
 
@@ -69,6 +69,5 @@ class RateLimiterFlowTest extends AkkaUnitTest {
 
     output shouldBe input
   }
-
 
 }

--- a/src/test/scala/mesosphere/marathon/test/SettableClock.scala
+++ b/src/test/scala/mesosphere/marathon/test/SettableClock.scala
@@ -1,8 +1,9 @@
 package mesosphere.marathon
 package test
 
-import java.time._
+import java.time.{Duration => JavaDuration, _}
 
+import scala.compat.java8.DurationConverters
 import scala.concurrent.duration.FiniteDuration
 
 object SettableClock {
@@ -24,18 +25,16 @@ class SettableClock(private[this] var clock: Clock = SettableClock.defaultJavaCl
 
   override def withZone(zoneId: ZoneId): Clock = new SettableClock(clock.withZone(zoneId))
 
-  def +=(duration: FiniteDuration): Unit = plus(duration)
+  def advanceBy(duration: FiniteDuration): this.type =
+    advanceBy(DurationConverters.toJava(duration))
 
-  def plus(duration: FiniteDuration): this.type =
-    plus(Duration.ofMillis(duration.toMillis))
-
-  def plus(duration: Duration): this.type = {
+  def advanceBy(duration: JavaDuration): this.type = {
     clock = Clock.offset(clock, duration)
     subscribers.foreach(_())
     this
   }
 
-  def at(instant: Instant): this.type = {
+  def advanceTo(instant: Instant): this.type = {
     clock = Clock.fixed(instant, clock.getZone)
     subscribers.foreach(_())
     this


### PR DESCRIPTION
Hijacking `+=` makes it unclear if the clock is being mutated.

Specifying methods "at" and "plus" don't express that the clock is
being mutated as well as `advanceBy` and `advanceTo`.
