### PR TITLE
Make the help wider for description

### DIFF
--- a/src/main/scala/mesosphere/marathon/AllConf.scala
+++ b/src/main/scala/mesosphere/marathon/AllConf.scala
@@ -13,6 +13,7 @@ class AllConf(args: Seq[String] = Nil) extends ScallopConf(args)
   with DebugConf
   with PluginManagerConfiguration
   with FeaturesConf {
+  helpWidth(160)
   verify()
 }
 


### PR DESCRIPTION
Summary:
Running `./marathon --help` falls back to scallop printing out help https://github.com/scallop/scallop/blob/b05ab7d88ffc498384e18663d24389e134843477/src/main/scala/org.rogach.scallop/ScallopHelpFormatter.scala#L5

By default, the width is 80, which is not very much for our descriptions. With this change the output changed from

```
--access_control_allow_origin  <arg>                             The
                                                                       origin(s)
                                                                       to allow
                                                                       in
                                                                       Marathon.
                                                                       Not set
                                                                       by
                                                                       default.
                                                                       Example
                                                                       values
                                                                       are "*",
                                                                       or
                                                                       "http://localhost:8888,
                                                                       http://domain.com"
```

to

```
--access_control_allow_origin  <arg>                             The origin(s) to allow in Marathon. Not set by default. Example values are "*", or
                                                                       "http://localhost:8888, http://domain.com"
```

JIRA issues: MARATHON-8678
