### PR TITLE
Migration to cull out invalid resource roles

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
@@ -20,7 +20,6 @@ import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistence
 import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkPersistenceStore, ZkSerialized}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{AppDefinition, Instance, PathId, Timestamp}
-import mesosphere.marathon.storage.migration.MigrationTo19300.{appMigratingFlow, logger, maybeStore}
 import mesosphere.marathon.storage.repository.InstanceRepository
 import mesosphere.marathon.storage.store.ZkStoreSerialization
 import play.api.libs.json._
@@ -183,7 +182,7 @@ object InstanceMigration extends MaybeStore with StrictLogging {
   def appTask(tasksMap: Map[Task.Id, Task]): Option[Task] = tasksMap.headOption.map(_._2)
 }
 
-object ServiceMigration extends StrictLogging {
+object ServiceMigration extends StrictLogging with MaybeStore {
   /**
     * Helper method to migrate all versions for all apps by loading them, threading them through the provided flow, and
     * then storing them. Filtered entities are simply unaffected in persistence.

--- a/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
@@ -6,25 +6,25 @@ import java.time.OffsetDateTime
 
 import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import akka.{Done, NotUsed}
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.util.ByteString
+import akka.{Done, NotUsed}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.instance.Reservation.{LegacyId, SimplifiedId}
 import mesosphere.marathon.core.instance.{LocalVolumeId, Reservation}
-import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkPersistenceStore, ZkSerialized}
+import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.{AppDefinition, Instance, PathId, Timestamp}
 import mesosphere.marathon.storage.repository.InstanceRepository
 import mesosphere.marathon.storage.store.ZkStoreSerialization
-import play.api.libs.json._
-import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Helper.scala
@@ -1,13 +1,17 @@
 package mesosphere.marathon
 package storage.migration
 
+import java.nio.charset.StandardCharsets
 import java.time.OffsetDateTime
 
+import akka.http.scaladsl.marshalling.Marshaller
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.{Done, NotUsed}
-import akka.stream.Materializer
-import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.util.ByteString
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.Protos.StorageVersion
 import mesosphere.marathon.core.instance.Instance.Id
 import mesosphere.marathon.core.instance.Reservation.{LegacyId, SimplifiedId}
 import mesosphere.marathon.core.instance.{LocalVolumeId, Reservation}
@@ -15,8 +19,10 @@ import mesosphere.marathon.core.storage.store.{IdResolver, PersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.cache.{LazyCachingPersistenceStore, LazyVersionCachingPersistentStore, LoadTimeCachingPersistenceStore}
 import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkPersistenceStore, ZkSerialized}
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.state.Instance
+import mesosphere.marathon.state.{AppDefinition, Instance, PathId, Timestamp}
+import mesosphere.marathon.storage.migration.MigrationTo19300.{appMigratingFlow, logger, maybeStore}
 import mesosphere.marathon.storage.repository.InstanceRepository
+import mesosphere.marathon.storage.store.ZkStoreSerialization
 import play.api.libs.json._
 import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
@@ -175,4 +181,106 @@ object InstanceMigration extends MaybeStore with StrictLogging {
   }
 
   def appTask(tasksMap: Map[Task.Id, Task]): Option[Task] = tasksMap.headOption.map(_._2)
+}
+
+object ServiceMigration extends StrictLogging {
+  /**
+    * Helper method to migrate all versions for all apps by loading them, threading them through the provided flow, and
+    * then storing them. Filtered entities are simply unaffected in persistence.
+    *
+    * @param storageVersion The storage version of the migration being run
+    * @param persistenceStore Used to load and store the entities
+    * @param migratingFlow The flow which actually performs the migrations.
+    * @return
+    */
+  def migrateAppVersions(storageVersion: StorageVersion, persistenceStore: PersistenceStore[ZkId, String, ZkSerialized],
+    migratingFlow: Flow[(Protos.ServiceDefinition, Option[OffsetDateTime]), (Protos.ServiceDefinition, Option[OffsetDateTime]), NotUsed])(implicit ec: ExecutionContext, mat: Materializer): Future[Done] = {
+    implicit val appProtosUnmarshaller: Unmarshaller[ZkSerialized, Protos.ServiceDefinition] =
+      Unmarshaller.strict {
+        case ZkSerialized(byteString) => Protos.ServiceDefinition.parseFrom(byteString.toArray)
+      }
+
+    implicit val appProtosMarshaller: Marshaller[Protos.ServiceDefinition, ZkSerialized] =
+      Marshaller.opaque(appProtos => ZkSerialized(ByteString(appProtos.toByteArray)))
+
+    implicit val appIdResolver: IdResolver[PathId, Protos.ServiceDefinition, String, ZkId] =
+      new ZkStoreSerialization.ZkPathIdResolver[Protos.ServiceDefinition]("apps", true, AppDefinition.versionInfoFrom(_).version.toOffsetDateTime)
+
+    val countingSink: Sink[Done, NotUsed] = Sink.fold[Int, Done](0) { case (count, Done) => count + 1 }
+      .mapMaterializedValue { f =>
+        f.map(i => logger.info(s"$i apps modified when migrating to ${storageVersion}"))
+        NotUsed
+      }
+
+    maybeStore(persistenceStore).map{ zkStore =>
+      zkStore
+        .ids()
+        .flatMapConcat(appId => zkStore.versions(appId).map(v => (appId, Some(v))) ++ Source.single((appId, Option.empty[OffsetDateTime])))
+        .mapAsync(Migration.maxConcurrency) {
+          case (appId, Some(version)) => zkStore.get(appId, version).map(app => (app, Some(version)))
+          case (appId, None) => zkStore.get(appId).map(app => (app, Option.empty[OffsetDateTime]))
+        }
+        .collect{ case (Some(appProtos), optVersion) if !appProtos.hasRole => (appProtos, optVersion) }
+        .via(migratingFlow)
+        .mapAsync(Migration.maxConcurrency) {
+          case (appProtos, Some(version)) => zkStore.store(PathId(appProtos.getId), appProtos, version)
+          case (appProtos, None) => zkStore.store(PathId(appProtos.getId), appProtos)
+        }
+        .alsoTo(countingSink)
+        .runWith(Sink.ignore)
+    }.getOrElse {
+      Future.successful(Done)
+    }
+  }
+
+  /**
+    * Helper method to migrate pod versions for all pods by loading them, threading them through the provided flow, and
+    * then storing them. Filtered entities are simply unaffected in persistence.
+    *
+    * @param storageVersion The storage version of the migration being run
+    * @param persistenceStore Used to load and store the entities
+    * @param migratingFlow The flow which actually performs the migrations.
+    * @return
+    */
+  def migratePodVersions(storageVersion: StorageVersion, persistenceStore: PersistenceStore[ZkId, String, ZkSerialized],
+    migratingFlow: Flow[(raml.Pod, Option[OffsetDateTime]), (raml.Pod, Option[OffsetDateTime]), NotUsed])(implicit ec: ExecutionContext, mat: Materializer): Future[Done] = {
+    implicit val podIdResolver =
+      new ZkStoreSerialization.ZkPathIdResolver[raml.Pod]("pods", true, _.version.getOrElse(Timestamp.now().toOffsetDateTime))
+
+    implicit val podJsonUnmarshaller: Unmarshaller[ZkSerialized, raml.Pod] =
+      Unmarshaller.strict {
+        case ZkSerialized(byteString) => Json.parse(byteString.utf8String).as[raml.Pod]
+      }
+
+    implicit val podRamlMarshaller: Marshaller[raml.Pod, ZkSerialized] =
+      Marshaller.opaque { podRaml =>
+        ZkSerialized(ByteString(Json.stringify(Json.toJson(podRaml)), StandardCharsets.UTF_8.name()))
+      }
+
+    val countingSink: Sink[Done, NotUsed] = Sink.fold[Int, Done](0) { case (count, Done) => count + 1 }
+      .mapMaterializedValue { f =>
+        f.map(i => logger.info(s"$i pods modified when migrating to ${storageVersion}"))
+        NotUsed
+      }
+
+    maybeStore(persistenceStore).map{ zkStore =>
+      zkStore
+        .ids()
+        .flatMapConcat(podId => zkStore.versions(podId).map(v => (podId, Some(v))) ++ Source.single((podId, Option.empty[OffsetDateTime])))
+        .mapAsync(Migration.maxConcurrency) {
+          case (podId, Some(version)) => zkStore.get(podId, version).map(pod => (pod, Some(version)))
+          case (podId, None) => zkStore.get(podId).map(pod => (pod, Option.empty[OffsetDateTime]))
+        }
+        .collect{ case (Some(podRaml), optVersion) if podRaml.role.isEmpty => (podRaml, optVersion) }
+        .via(migratingFlow)
+        .mapAsync(Migration.maxConcurrency) {
+          case (podRaml, Some(version)) => zkStore.store(PathId(podRaml.id), podRaml, version)
+          case (podRaml, None) => zkStore.store(PathId(podRaml.id), podRaml)
+        }
+        .alsoTo(countingSink)
+        .runWith(Sink.ignore)
+    }.getOrElse {
+      Future.successful(Done)
+    }
+  }
 }

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -216,7 +216,8 @@ object Migration {
       StorageVersions(18, 100) -> { (migration) => new MigrationTo18100(migration.instanceRepo, migration.persistenceStore) },
       StorageVersions(18, 200) -> { (migration) => new MigrationTo18200(migration.instanceRepo, migration.persistenceStore) },
       StorageVersions(19, 100) -> { (migration) => new MigrationTo19100(migration.defaultMesosRole, migration.persistenceStore) },
-      StorageVersions(19, 200) -> { (migration) => new MigrationTo19200(migration.defaultMesosRole, migration.instanceRepo, migration.persistenceStore) }
+      StorageVersions(19, 200) -> { (migration) => new MigrationTo19200(migration.defaultMesosRole, migration.instanceRepo, migration.persistenceStore) },
+      StorageVersions(19, 300) -> { (migration) => new MigrationTo19300(migration.persistenceStore) }
     )
 }
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo19300.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo19300.scala
@@ -1,0 +1,94 @@
+package mesosphere.marathon
+package storage.migration
+
+import java.time.OffsetDateTime
+
+import akka.Done
+import akka.stream.Materializer
+import akka.stream.scaladsl.Flow
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.storage.store.PersistenceStore
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkSerialized}
+import mesosphere.marathon.state._
+
+import scala.async.Async.{async, await}
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+class MigrationTo19300(
+    persistenceStore: PersistenceStore[ZkId, String, ZkSerialized]) extends MigrationStep with StrictLogging {
+
+  override def migrate()(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = async {
+    logger.info("Starting migration to 1.9.300")
+    await(MigrationTo19300.migrateApps(persistenceStore))
+    await(MigrationTo19300.migratePods(persistenceStore))
+  }
+
+}
+
+object MigrationTo19300 extends MaybeStore with StrictLogging {
+  val migrationVersion = StorageVersions(19, 300)
+  def repairRoles(role: String, acceptedResourceRoles: Seq[String]): Seq[String] = {
+    val repaired = acceptedResourceRoles.filter { acceptedResourceRole =>
+      acceptedResourceRole == role || acceptedResourceRole == ResourceRole.Unreserved
+    }
+
+    if (acceptedResourceRoles.nonEmpty && repaired.isEmpty)
+      Seq("*")
+    else
+      repaired
+  }
+
+  private[migration] val appMigratingFlow = Flow[(Protos.ServiceDefinition, Option[OffsetDateTime])].mapConcat {
+    case (service, version) =>
+      val acceptedResourceRoles = if (service.hasAcceptedResourceRoles) service.getAcceptedResourceRoles.getRoleList.asScala.toList else Nil
+      val role = service.getRole
+      val repaired = repairRoles(role, acceptedResourceRoles)
+      if (repaired != acceptedResourceRoles) {
+        val repairedApp = service.toBuilder.setAcceptedResourceRoles(Protos.ResourceRoles.newBuilder().addAllRole(repaired.asJava)).build
+        logger.info(s"Culling invalid resource roles from ${service.getId}, version ${version}; old acceptedResourceRoles: ${acceptedResourceRoles.mkString(",")}, new acceptedResourceRoles: ${repaired.mkString(",")}")
+        List((repairedApp, version))
+      } else {
+        Nil
+      }
+  }
+
+  private[migration] val podMigratingFlow = Flow[(raml.Pod, Option[OffsetDateTime])].mapConcat {
+    case (podRaml, version) =>
+
+      val repaired = for {
+        scheduling <- podRaml.scheduling
+        placement <- scheduling.placement
+
+        acceptedResourceRoles: Seq[String] = placement.acceptedResourceRoles
+        role = podRaml.role.getOrElse { throw new RuntimeException("Bug! Migration 19100 should have set this value") }
+        repaired = repairRoles(role, acceptedResourceRoles)
+        if (repaired != acceptedResourceRoles)
+      } yield {
+        val repairedPod = podRaml.copy(scheduling = Some(scheduling.copy(placement = Some(placement.copy(acceptedResourceRoles = repaired)))))
+        logger.info(s"Culling invalid resource roles from pod ${podRaml.id}, version ${version}; old acceptedResourceRoles: ${acceptedResourceRoles.mkString(",")}, new acceptedResourceRoles: ${repaired.mkString(",")}")
+        (repairedPod, version)
+      }
+      repaired.toList
+  }
+
+  /**
+    * Loads all app definitions from store and sets the role to Marathon's default role.
+    *
+    * @param persistenceStore The ZooKeeper storage.
+    * @return Successful future when done.
+    */
+  def migrateApps(persistenceStore: PersistenceStore[ZkId, String, ZkSerialized])(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+    ServiceMigration.migrateAppVersions(migrationVersion, persistenceStore, appMigratingFlow)
+  }
+
+  /**
+    * Loads all pod definitions from store and sets the role to Marathon's default role.
+    *
+    * @param persistenceStore The ZooKeeper storage.
+    * @return Successful future when done.
+    */
+  def migratePods(persistenceStore: PersistenceStore[ZkId, String, ZkSerialized])(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+    ServiceMigration.migratePodVersions(migrationVersion, persistenceStore, podMigratingFlow)
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2280,7 +2280,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
 
       And("resulting app has acceptedResourceRoles sanitized (equals default one)")
       val appJson = Json.parse(response.getEntity.asInstanceOf[String])
-      (appJson \ "acceptedResourceRoles" \ 0 ) should be (JsDefined(JsString(ResourceRole.Unreserved)))
+      (appJson \ "acceptedResourceRoles" \ 0) should be (JsDefined(JsString(ResourceRole.Unreserved)))
     }
 
     "Create an app in root with acceptedResourceRoles = customMesosRole and sanitizeAcceptedResourceRoles = false" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo19300Test.scala
+++ b/src/test/scala/mesosphere/marathon/storage/migration/MigrationTo19300Test.scala
@@ -1,0 +1,108 @@
+package mesosphere.marathon
+package storage.migration
+
+import java.time.OffsetDateTime
+
+import akka.stream.scaladsl.{Sink, Source}
+import mesosphere.AkkaUnitTest
+import org.apache.mesos.{Protos => Mesos}
+
+import scala.collection.JavaConverters._
+
+class MigrationTo19300Test extends AkkaUnitTest {
+  "migrating apps" should {
+    def mockServiceDefinition(id: String = "/serious-business", role: String, acceptedResourceRoles: Seq[String]): Protos.ServiceDefinition = {
+      val resourceRoles = if (acceptedResourceRoles.isEmpty)
+        None
+      else
+        Some(Protos.ResourceRoles.newBuilder.addAllRole(acceptedResourceRoles.asJava))
+      val b = Protos.ServiceDefinition.newBuilder()
+        .setId(id)
+        .setRole(role)
+        .setCmd(Mesos.CommandInfo.newBuilder().setValue("sleep 3600").build)
+        .setInstances(1)
+        .setExecutor("//cmd")
+
+      resourceRoles.foreach(b.setAcceptedResourceRoles)
+      b.build
+    }
+
+    "it removes invalid roles from apps" in {
+      val service = mockServiceDefinition(role = "role", acceptedResourceRoles = Seq("a", "role", "*"))
+      val time = OffsetDateTime.now()
+
+      val Seq((migratedService, Some(migratedTime))) = Source.single((service, Some(time))).via(MigrationTo19300.appMigratingFlow).runWith(Sink.seq).futureValue
+
+      migratedService.getAcceptedResourceRoles.getRoleList.asScala shouldBe Seq("role", "*")
+      migratedTime shouldBe time
+    }
+
+    "it defaults to [*] if all roles were invalid" in {
+      val service = mockServiceDefinition(role = "test", acceptedResourceRoles = Seq("a", "b", "c"))
+      val time = OffsetDateTime.now()
+
+      val Seq((migratedService, Some(migratedTime))) = Source.single((service, Some(time))).via(MigrationTo19300.appMigratingFlow).runWith(Sink.seq).futureValue
+
+      migratedService.getAcceptedResourceRoles.getRoleList.asScala shouldBe Seq("*")
+      migratedTime shouldBe time
+    }
+
+    "it leaves apps alone if they are valid" in {
+      val service = mockServiceDefinition(role = "test", acceptedResourceRoles = Seq("*"))
+
+      Source.single((service, None))
+        .via(MigrationTo19300.appMigratingFlow)
+        .runWith(Sink.seq)
+        .futureValue
+        .shouldBe(empty)
+    }
+  }
+
+  "migrating pods" should {
+    def mockPod(id: String = "/serious-business", role: String, acceptedResourceRoles: Seq[String]): raml.Pod = {
+
+      val scheduling = if (acceptedResourceRoles.nonEmpty) {
+        val placement = raml.PodPlacementPolicy(acceptedResourceRoles = acceptedResourceRoles)
+        Some(raml.PodSchedulingPolicy(placement = Some(placement)))
+      } else {
+        None
+      }
+      raml.Pod(id, containers = Nil, role = Some(role), scheduling = scheduling)
+    }
+
+    def getAcceptedResourceRoles(pod: raml.Pod): Option[Seq[String]] = for {
+      scheduling <- pod.scheduling
+      placement <- scheduling.placement
+    } yield placement.acceptedResourceRoles
+
+    "it removes invalid roles" in {
+      val service = mockPod(role = "role", acceptedResourceRoles = Seq("a", "role", "*"))
+      val time = OffsetDateTime.now()
+
+      val Seq((migratedPod, Some(migratedTime))) = Source.single((service, Some(time))).via(MigrationTo19300.podMigratingFlow).runWith(Sink.seq).futureValue
+
+      getAcceptedResourceRoles(migratedPod) shouldBe Some(Seq("role", "*"))
+      migratedTime shouldBe time
+    }
+
+    "it defaults to [*] if all roles were invalid" in {
+      val service = mockPod(role = "test", acceptedResourceRoles = Seq("a", "b", "c"))
+      val time = OffsetDateTime.now()
+
+      val Seq((migratedService, Some(migratedTime))) = Source.single((service, Some(time))).via(MigrationTo19300.podMigratingFlow).runWith(Sink.seq).futureValue
+
+      getAcceptedResourceRoles(migratedService) shouldBe Some(Seq("*"))
+      migratedTime shouldBe time
+    }
+
+    "it does not modify valid entities" in {
+      val service = mockPod(role = "test", acceptedResourceRoles = Seq("*"))
+
+      Source.single((service, None))
+        .via(MigrationTo19300.podMigratingFlow)
+        .runWith(Sink.seq)
+        .futureValue
+        .shouldBe(empty)
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
+++ b/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
@@ -70,5 +70,4 @@ class RateLimiterFlowTest extends AkkaUnitTest {
     output shouldBe input
   }
 
-
 }


### PR DESCRIPTION
Previously, Marathon would allow acceptedResourceRoles to include role values other than "*" and the configured Mesos role. In these cases, Marathon would not launch the instances at all.

With the migration for storage-version 19.100, all services are assigned the role as configured by `--mesos_role`; With this migration (version 19.300), we remove all unrelated roles from `acceptedResourceRoles`. If this results in the removal of all values from `acceptedResourceRoles`, then the `acceptedResourceRoles` is defaulted to `["*"]`.

JIRA Issues: MARATHON-8654
