### PR TITLE
Multi-role offer match debugging

### DIFF
--- a/docs/docs/rest-api/public/api/v2/examples/queue.json
+++ b/docs/docs/rest-api/public/api/v2/examples/queue.json
@@ -40,6 +40,7 @@
         }
       },
       "count": 1,
+      "role": "*",
       "delay": {
         "timeLeftSeconds": 0,
         "overdue": true
@@ -98,6 +99,7 @@
         }
       },
       "count": 2,
+      "role": "*",
       "delay": {
         "timeLeftSeconds": 0,
         "overdue": true

--- a/docs/docs/rest-api/public/api/v2/types/queue.raml
+++ b/docs/docs/rest-api/public/api/v2/types/queue.raml
@@ -74,6 +74,11 @@ types:
         type: number
         format: int32
         description: The number of instances left to launch.
+      role:
+        type: string
+        description: |
+          The role of the instances attempting to be launched; this can differ from the RunSpec for resident services
+          that have had their role changed.
       delay:
         type: QueueDelay
         description: If a runspec has failed too often the launch will be delayed. See backoff to tune this behavior.

--- a/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/matcher/manager/impl/OfferMatcherManagerActor.scala
@@ -291,7 +291,7 @@ private[impl] class OfferMatcherManagerActor private (
     offer: Offer,
     deadline: Timestamp,
     promise: Promise[OfferMatcher.MatchedInstanceOps]): Unit = {
-    logger.info(s"Start processing offer ${offer.getId.getValue}. Current offer matcher count: ${offerQueues.size}")
+    logger.info(s"Start processing offer ${offer.getId.getValue} with role ${offer.getAllocationInfo.getRole}. Current offer matcher count: ${offerQueues.size}")
 
     // setup initial offer data
     val randomizedMatchers = offerMatchers(offer)

--- a/src/main/scala/mesosphere/marathon/raml/QueueInfoConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/QueueInfoConversion.scala
@@ -2,7 +2,6 @@ package mesosphere.marathon
 package raml
 
 import java.time.Clock
-import java.time.OffsetDateTime
 
 import mesosphere.marathon.core.launcher.OfferMatchResult
 import mesosphere.marathon.core.launchqueue.LaunchStats.QueuedInstanceInfoWithStatistics
@@ -51,20 +50,27 @@ trait QueueInfoConversion extends DefaultConversions with OfferConversion {
         )
       }
 
-      def queueItem[A](create: (Int, String, QueueDelay, OffsetDateTime, ProcessedOffersSummary, Option[Seq[UnusedOffer]]) => A): A = {
-        create(
-          info.instancesLeftToLaunch,
-          info.role,
-          delay,
-          info.startedAt.toOffsetDateTime,
-          processedOffersSummary,
-          if (withLastUnused) Some(Raml.toRaml(info.lastNoMatches)) else None
-        )
-      }
+      val lastUnusedOffers = if (withLastUnused) Some(Raml.toRaml(info.lastNoMatches)) else None
 
       info.runSpec match {
-        case app: AppDefinition => queueItem(QueueApp(_, _, _, _, _, _, Raml.toRaml(app)))
-        case pod: PodDefinition => queueItem(QueuePod(_, _, _, _, _, _, Raml.toRaml(pod)))
+        case app: AppDefinition =>
+          QueueApp(
+            info.instancesLeftToLaunch,
+            info.role,
+            delay,
+            info.startedAt.toOffsetDateTime,
+            processedOffersSummary,
+            lastUnusedOffers,
+            Raml.toRaml(app))
+        case pod: PodDefinition =>
+          QueuePod(
+            info.instancesLeftToLaunch,
+            info.role,
+            delay,
+            info.startedAt.toOffsetDateTime,
+            processedOffersSummary,
+            lastUnusedOffers,
+            Raml.toRaml(pod))
       }
   }
 

--- a/src/main/scala/mesosphere/marathon/raml/QueueInfoConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/QueueInfoConversion.scala
@@ -51,9 +51,10 @@ trait QueueInfoConversion extends DefaultConversions with OfferConversion {
         )
       }
 
-      def queueItem[A](create: (Int, QueueDelay, OffsetDateTime, ProcessedOffersSummary, Option[Seq[UnusedOffer]]) => A): A = {
+      def queueItem[A](create: (Int, String, QueueDelay, OffsetDateTime, ProcessedOffersSummary, Option[Seq[UnusedOffer]]) => A): A = {
         create(
           info.instancesLeftToLaunch,
+          info.role,
           delay,
           info.startedAt.toOffsetDateTime,
           processedOffersSummary,
@@ -62,8 +63,8 @@ trait QueueInfoConversion extends DefaultConversions with OfferConversion {
       }
 
       info.runSpec match {
-        case app: AppDefinition => queueItem(QueueApp(_, _, _, _, _, Raml.toRaml(app)))
-        case pod: PodDefinition => queueItem(QueuePod(_, _, _, _, _, Raml.toRaml(pod)))
+        case app: AppDefinition => queueItem(QueueApp(_, _, _, _, _, _, Raml.toRaml(app)))
+        case pod: PodDefinition => queueItem(QueuePod(_, _, _, _, _, _, Raml.toRaml(pod)))
       }
   }
 

--- a/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
+++ b/src/main/scala/mesosphere/mesos/ResourceMatcher.scala
@@ -227,7 +227,7 @@ object ResourceMatcher extends StrictLogging {
         // Add constraints to noOfferMatchReasons
         noOfferMatchReasons += NoOfferMatchReason.UnfulfilledConstraint
         logger.info(
-          s"Offer [${offer.getId.getValue}]. Constraints for run spec [${runSpec.id}] not satisfied.\n" +
+          s"Offer [${offer.getId.getValue}] with role [${offer.getAllocationInfo.getRole}]. Constraints for run spec [${runSpec.id}] not satisfied.\n" +
             s"The conflicting constraints are: [${badConstraints.mkString(", ")}]"
         )
       }
@@ -566,7 +566,7 @@ object ResourceMatcher extends StrictLogging {
     if (scalarMatchResults.exists(!_.matches)) {
       val basicResourceString = scalarMatchResults.mkString(", ")
       logger.info(
-        s"Offer [${offer.getId.getValue}]. " +
+        s"Offer [${offer.getId.getValue}] with role ${offer.getAllocationInfo.getRole}. " +
           s"$selector. " +
           s"Not all basic resources satisfied: $basicResourceString")
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2280,7 +2280,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
 
       And("resulting app has acceptedResourceRoles sanitized (equals default one)")
       val appJson = Json.parse(response.getEntity.asInstanceOf[String])
-      (appJson \ "acceptedResourceRoles" \ 0 ) should be (JsDefined(JsString(ResourceRole.Unreserved)))
+      (appJson \ "acceptedResourceRoles" \ 0) should be (JsDefined(JsString(ResourceRole.Unreserved)))
     }
 
     "Create an app in root with acceptedResourceRoles = customMesosRole and sanitizeAcceptedResourceRoles = false" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -60,7 +60,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
         clock.now())
       stats.getStatistics() returns Future.successful(Seq(
         QueuedInstanceInfoWithStatistics(
-          app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
+          app, "*", inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
           backOffUntil = Some(clock.now() + 100.seconds), startedAt = clock.now(),
           rejectSummaryLastOffers = Map(NoOfferMatchReason.InsufficientCpus -> 1, NoOfferMatchReason.DeclinedScarceResources -> 2),
           rejectSummaryLaunchAttempt = Map(NoOfferMatchReason.InsufficientCpus -> 3, NoOfferMatchReason.DeclinedScarceResources -> 2),
@@ -104,7 +104,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
       val app = AppDefinition(id = "app".toAbsolutePath, role = "*")
       stats.getStatistics() returns Future.successful(Seq(
         QueuedInstanceInfoWithStatistics(
-          app, inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
+          app, "*", inProgress = true, instancesLeftToLaunch = 23, finalInstanceCount = 23,
           backOffUntil = Some(clock.now() - 100.seconds), startedAt = clock.now(), rejectSummaryLastOffers = Map.empty,
           rejectSummaryLaunchAttempt = Map.empty, processedOffersCount = 3, unusedOffersCount = 1, lastMatch = None,
           lastNoMatch = None, lastNoMatches = Seq.empty

--- a/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/QueueInfoConversionTest.scala
@@ -84,7 +84,7 @@ class QueueInfoConversionTest extends UnitTest {
         DeclinedOfferStep("DeclinedScarceResources", 0, 0)
       )
 
-      val info = QueuedInstanceInfoWithStatistics(app, inProgress = true,
+      val info = QueuedInstanceInfoWithStatistics(app, "*", inProgress = true,
         instancesLeftToLaunch = 23,
         finalInstanceCount = 23,
         backOffUntil = None,


### PR DESCRIPTION
This adds the role field to the /v2/queue output, to help clarify cases when
we're reviving for a role other than the runSpec role (resident app which had
its role changed)

Also, logging

JIRA Issues: MARATHON-8639
