### PR TITLE
Add requirement to use force flag to update role of resident services

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -157,13 +157,6 @@ class GroupsResource @Inject() (
       val groupUpdate = validateOrThrow(
         GroupNormalization(config, originalRootGroup).updateNormalization(effectivePath).normalized(raw)
       )(groupValidator)
-        normalizeApps(
-          originalRootGroup,
-          rootPath,
-          normalized,
-          config,
-          force // TODO: Do we want to reuse force parameter for force role update?
-        ))(groupValidator)
 
       def throwIfConflicting[A](conflict: Option[Any], msg: String) = {
         conflict.map(_ => throw ConflictingChangeException(msg))
@@ -254,13 +247,6 @@ class GroupsResource @Inject() (
       val groupUpdate = validateOrThrow(
         GroupNormalization(config, originalRootGroup).updateNormalization(effectivePath).normalized(raw)
       )(groupValidator)
-        normalizeApps(
-          originalRootGroup,
-          effectivePath,
-          normalized,
-          config,
-          force // TODO: Do we want to reuse force parameter for force role update?
-        ))(groupValidator)
 
       if (dryRun) {
         val newVersion = Timestamp.now()

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -127,7 +127,6 @@ class PodsResource @Inject() (
       val podId = id.toAbsolutePath
       val podRaml = unmarshal(body)
 
-      // TODO: Do we want to reuse force parameter for force role update?)
       val roleSettings = RoleSettings.forService(config, podId, groupManager.rootGroup(), force)
       implicit val normalizer: Normalization[Pod] = PodNormalization(PodNormalization.Configuration(config, roleSettings))
       implicit val podValidator: Validator[Pod] = PodsValidation.podValidator(config, scheduler.mesosMasterVersion(), roleSettings)

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -93,7 +93,7 @@ class PodsResource @Inject() (
       implicit val identity = await(authenticatedAsync(req))
       val podRaml = unmarshal(body)
 
-      val roleSettings = RoleSettings.forService(config, PathId(podRaml.id).canonicalPath(PathId.root), groupManager.rootGroup())
+      val roleSettings = RoleSettings.forService(config, PathId(podRaml.id).canonicalPath(PathId.root), groupManager.rootGroup(), false)
       implicit val normalizer: Normalization[Pod] = PodNormalization(PodNormalization.Configuration(config, roleSettings))
       implicit val podValidator: Validator[Pod] = PodsValidation.podValidator(config, scheduler.mesosMasterVersion(), roleSettings)
       implicit val podDefValidator: Validator[PodDefinition] = PodsValidation.podDefValidator(pluginManager, roleSettings)
@@ -127,7 +127,8 @@ class PodsResource @Inject() (
       val podId = id.toAbsolutePath
       val podRaml = unmarshal(body)
 
-      val roleSettings = RoleSettings.forService(config, podId, groupManager.rootGroup())
+      // TODO: Do we want to reuse force parameter for force role update?)
+      val roleSettings = RoleSettings.forService(config, podId, groupManager.rootGroup(), force)
       implicit val normalizer: Normalization[Pod] = PodNormalization(PodNormalization.Configuration(config, roleSettings))
       implicit val podValidator: Validator[Pod] = PodsValidation.podValidator(config, scheduler.mesosMasterVersion(), roleSettings)
       implicit val podDefValidator: Validator[PodDefinition] = PodsValidation.podDefValidator(pluginManager, roleSettings)

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.plugin.validation.RunSpecValidator
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{PathId, ResourceRole, Role, RootGroup}
+import mesosphere.marathon.state.{AppDefinition, PathId, ResourceRole, Role, RootGroup}
 import mesosphere.marathon.util.{RoleSettings, SemanticVersion}
 // scalastyle:on
 
@@ -256,7 +256,7 @@ trait PodsValidation extends GeneralPurposeCombinators {
       }
     }
     if (pod.isResident) {
-      pod.role is isTrue((role: Role) => s"It is not possible to change the role for existing reservations. If you proceed with this change, all existing instances will continue to run under the previous role, ${roleEnforcement.previousRole.get}. Only new instances will be allocated with the new role, ${role}. In order to continue, retry your request with force=true") { role: Role =>
+      pod.role is isTrue((role: Role) => RoleSettings.residentRoleChangeWarningMessage(roleEnforcement.previousRole.get, role)) { role: Role =>
         roleEnforcement.previousRole.map(_.equals(role) || roleEnforcement.forceRoleUpdate).getOrElse(true)
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.core.pod.PodDefinition
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.plugin.validation.RunSpecValidator
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{AppDefinition, PathId, ResourceRole, Role, RootGroup}
+import mesosphere.marathon.state.{PathId, ResourceRole, Role, RootGroup}
 import mesosphere.marathon.util.{RoleSettings, SemanticVersion}
 // scalastyle:on
 

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -256,7 +256,7 @@ trait PodsValidation extends GeneralPurposeCombinators {
       }
     }
     if (pod.isResident) {
-      pod.role is isTrue((role: Role) => s"It is not possible to change the role for existing reservations. If you proceed with this change, all existing instances will continue to under the previous role, ${roleEnforcement.previousRole.get}. Only new instances will be allocated with the new role, ${role}. In order to continue, retry your request with force=true") { role: Role =>
+      pod.role is isTrue((role: Role) => s"It is not possible to change the role for existing reservations. If you proceed with this change, all existing instances will continue to run under the previous role, ${roleEnforcement.previousRole.get}. Only new instances will be allocated with the new role, ${role}. In order to continue, retry your request with force=true") { role: Role =>
         roleEnforcement.previousRole.map(_.equals(role) || roleEnforcement.forceRoleUpdate).getOrElse(true)
       }
     }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -506,7 +506,7 @@ object AppDefinition extends GeneralPurposeCombinators {
 
   def validWithRoleEnforcement(roleEnforcement: RoleSettings): Validator[AppDefinition] = validator[AppDefinition] { app =>
     app.role is in(roleEnforcement.validRoles)
-    // DO NOT MERGE THESE TWO similar if blocks! Wix Accord macros do weird stuff otherwise.
+    // DO NOT MERGE THESE TWO similar if blocks! Wix Accord macros does weird stuff otherwise.
     if (app.isResident) {
       app.role is isTrue(s"Resident apps cannot have the role ${ResourceRole.Unreserved}") { role: String =>
         !role.equals(ResourceRole.Unreserved)

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -513,7 +513,7 @@ object AppDefinition extends GeneralPurposeCombinators {
       }
     }
     if (app.isResident) {
-      app.role is isTrue((role: Role) => s"It is not possible to change the role for existing reservations. If you proceed with this change, all existing instances will continue to run under the previous role, ${roleEnforcement.previousRole.get}. Only new instances will be allocated with the new role, ${role}. In order to continue, retry your request with force=true") { role: String =>
+      app.role is isTrue((role: Role) => RoleSettings.residentRoleChangeWarningMessage(roleEnforcement.previousRole.get, role)) { role: String =>
         roleEnforcement.previousRole.map(_.equals(role) || roleEnforcement.forceRoleUpdate).getOrElse(true)
       }
     }

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -513,7 +513,7 @@ object AppDefinition extends GeneralPurposeCombinators {
       }
     }
     if (app.isResident) {
-      app.role is isTrue((role: Role) => s"It is not possible to change the role for existing reservations. If you proceed with this change, all existing instances will continue to under the previous role, ${roleEnforcement.previousRole.get}. Only new instances will be allocated with the new role, ${role}. In order to continue, retry your request with force=true") { role: String =>
+      app.role is isTrue((role: Role) => s"It is not possible to change the role for existing reservations. If you proceed with this change, all existing instances will continue to run under the previous role, ${roleEnforcement.previousRole.get}. Only new instances will be allocated with the new role, ${role}. In order to continue, retry your request with force=true") { role: String =>
         roleEnforcement.previousRole.map(_.equals(role) || roleEnforcement.forceRoleUpdate).getOrElse(true)
       }
     }

--- a/src/main/scala/mesosphere/marathon/state/RootGroup.scala
+++ b/src/main/scala/mesosphere/marathon/state/RootGroup.scala
@@ -452,11 +452,11 @@ object RootGroup {
     isTrue("Dependency graph has cyclic dependencies.") { _.hasNonCyclicDependencies }
 
   private def validAppRole(config: MarathonConf, rootGroup: RootGroup): Validator[AppDefinition] = (app: AppDefinition) => {
-    AppDefinition.validWithRoleEnforcement(RoleSettings.forService(config, app.id.asAbsolutePath, rootGroup)).apply(app)
+    AppDefinition.validWithRoleEnforcement(RoleSettings.forService(config, app.id.asAbsolutePath, rootGroup, false)).apply(app)
   }
 
   private def validPodRole(config: MarathonConf, rootGroup: RootGroup): Validator[PodDefinition] = (pod: PodDefinition) => {
-    PodsValidation.validPodDefinitionWithRoleEnforcement(RoleSettings.forService(config, pod.id.asAbsolutePath, rootGroup)).apply(pod)
+    PodsValidation.validPodDefinitionWithRoleEnforcement(RoleSettings.forService(config, pod.id.asAbsolutePath, rootGroup, false)).apply(pod)
   }
 
 }

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -72,4 +72,8 @@ object RoleSettings extends StrictLogging {
     }
   }
 
+  def residentRoleChangeWarningMessage(previousRole: String, newRole: String): String =
+    "It is not possible to change the role for existing reservations. If you proceed with this change, all existing " +
+      "instances will continue to run under the previous role, " + previousRole + ". Only new instances will be " +
+      "allocated with the new role, " + newRole + ". In order to continue, retry your request with ?force=true"
 }

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -13,21 +13,23 @@ import mesosphere.marathon.state.{RootGroup, AbsolutePathId}
   * @param validRoles List of valid roles
   * @param defaultRole The default role to use if no role is specified on the service. Defaults to '*'
   */
-case class RoleSettings(validRoles: Set[Role], defaultRole: Role) {
+case class RoleSettings(validRoles: Set[Role], defaultRole: Role, previousRole: Option[String] = None, forceRoleUpdate: Boolean = false) {
   require(validRoles(defaultRole))
 }
 
 object RoleSettings extends StrictLogging {
+
   /**
     * Returns the role settings for the service with the specified ID, based on the top-level group and the global config
     *
     * @param config Global config to provide defaultMesos role
     * @param servicePathId The absolute pathId of the affected runSpec, used to determine a possible top-level group role
     * @param rootGroup The root group, used to access possible top-level groups and their settings
+    * @param forceRoleUpdate For resident services, an update to the role may leave instances with their old roles and therefore requires an explicit force update
     *
     * @return A data set with valid roles, default role and a flag if the role should be enforced
     */
-  def forService(config: MarathonConf, servicePathId: AbsolutePathId, rootGroup: RootGroup): RoleSettings = {
+  def forService(config: MarathonConf, servicePathId: AbsolutePathId, rootGroup: RootGroup, forceRoleUpdate: Boolean): RoleSettings = {
     val defaultRole = config.mesosRole()
 
     if (servicePathId.parent.isRoot) {
@@ -37,6 +39,8 @@ object RoleSettings extends StrictLogging {
       val topLevelGroupPath = servicePathId.rootPath
       val topLevelGroupRole = topLevelGroupPath.root
       val topLevelGroup = rootGroup.group(topLevelGroupPath)
+
+      val oldServiceRole = rootGroup.runSpec(servicePathId).map(_.role)
 
       val defaultForEnforceFromConfig: Boolean = false // TODO: Use value from config instead
       val enforceRole = topLevelGroup.fold(defaultForEnforceFromConfig)(_.enforceRole)
@@ -54,12 +58,12 @@ object RoleSettings extends StrictLogging {
 
       if (enforceRole) {
         // With enforceRole, we only allow the service to use the group-role or an existing role
-        RoleSettings(validRoles = Set(topLevelGroupRole) ++ maybeExistingRole, defaultRole = topLevelGroupRole)
+        RoleSettings(validRoles = Set(topLevelGroupRole) ++ maybeExistingRole, defaultRole = topLevelGroupRole, previousRole = oldServiceRole, forceRoleUpdate = forceRoleUpdate)
       } else {
         // Without enforce role, we allow default role, group role and already existing role
         // The default role depends on the config parameter
         val defaultRoleToUse = if (defaultForEnforceFromConfig) topLevelGroupRole else defaultRole
-        RoleSettings(validRoles = Set(defaultRole, topLevelGroupRole) ++ maybeExistingRole, defaultRole = defaultRoleToUse)
+        RoleSettings(validRoles = Set(defaultRole, topLevelGroupRole) ++ maybeExistingRole, defaultRole = defaultRoleToUse, previousRole = oldServiceRole, forceRoleUpdate = forceRoleUpdate)
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2334,7 +2334,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val body = Json.stringify(Json.toJson(normalize(app))).getBytes("UTF-8")
 
       When("The create request is made")
-      clock += 5.seconds
+      clock.advanceBy(5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -25,7 +25,7 @@ import mesosphere.marathon.raml.{EnvVarSecret, ExecutorResources, FixedPodScalin
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.{GroupCreation, JerseyTest, Mockito, SettableClock}
-import mesosphere.marathon.util.SemanticVersion
+import mesosphere.marathon.util.{RoleSettings, SemanticVersion}
 import play.api.libs.json._
 
 import scala.collection.immutable.Seq
@@ -498,7 +498,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       }
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(422)
-        response.getEntity.toString should include("It is not possible to change the role for existing reservations. If you proceed with this change, all existing instances will continue to under the previous role")
+        response.getEntity.toString should include(RoleSettings.residentRoleChangeWarningMessage("*", "foo"))
       }
     }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
@@ -75,7 +75,7 @@ class MultiRoleIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       val updatedApp = AppUpdate(id = Some(appId.toString), role = Some("dev"), acceptedResourceRoles = Some(Set("*")))
 
       When("The Update is deployed")
-      val resultOfUpdate = marathon.updateApp(appId, updatedApp)
+      val resultOfUpdate = marathon.updateApp(appId, updatedApp, force = true)
 
       Then("The update is ready")
       resultOfUpdate should be(OK)
@@ -93,7 +93,7 @@ class MultiRoleIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       taskList.head.role.value should be(BaseMarathon.defaultRole)
 
       Given("The app is scaled to 2")
-      val resultOfScale = marathon.updateApp(appId, updatedApp.copy(instances = Some(2)))
+      val resultOfScale = marathon.updateApp(appId, updatedApp.copy(instances = Some(2)), force = true)
 
       resultOfScale should be(OK)
       waitForDeployment(resultOfScale)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
@@ -93,7 +93,7 @@ class MultiRoleIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       taskList.head.role.value should be(BaseMarathon.defaultRole)
 
       Given("The app is scaled to 2")
-      val resultOfScale = marathon.updateApp(appId, updatedApp.copy(instances = Some(2)), force = true)
+      val resultOfScale = marathon.updateApp(appId, updatedApp.copy(instances = Some(2)))
 
       resultOfScale should be(OK)
       waitForDeployment(resultOfScale)


### PR DESCRIPTION
When updating roles for resident tasks, it needs to be make clear that this is not straightforward like it is with updating the roles for ephemeral tasks, since existing instances will not change. Updating the role for a resident task will lead to an inconsistent state, in which existing instances continue to use the same role.

With this change, we gain an opportunity to make this clear to the user.

JIRA issues: MARATHON-8672