### PR TITLE
Update --default_accepted_resource_roles to be multi-role compliant

### DIFF
--- a/src/main/scala/mesosphere/marathon/AcceptedResourceRolesDefaultBehavior.scala
+++ b/src/main/scala/mesosphere/marathon/AcceptedResourceRolesDefaultBehavior.scala
@@ -1,0 +1,39 @@
+package mesosphere.marathon
+
+/**
+  * The accepted resource roles default behavior defines whether which values are selected for the accepted resource roles by default
+  *
+  *  - [[AcceptedResourceRolesDefaultBehavior.Any]] indicates that either reserved or unreserved resources will be accepted. (default)
+  *  - [[AcceptedResourceRolesDefaultBehavior.Unreserved]] Only unreserved ( offers with role '*' ) will be accepted.
+  *  - [[AcceptedResourceRolesDefaultBehavior.Reserved]] Only reserved (offers with the role of the starting task) will be accepted.
+  *
+  */
+sealed trait AcceptedResourceRolesDefaultBehavior {
+  val name: String
+  override def toString: String = name
+}
+
+object AcceptedResourceRolesDefaultBehavior {
+  case object Any extends AcceptedResourceRolesDefaultBehavior {
+    override val name: String = "Any"
+  }
+
+  case object Unreserved extends AcceptedResourceRolesDefaultBehavior {
+    override val name: String = "Unreserved"
+  }
+
+  case object Reserved extends AcceptedResourceRolesDefaultBehavior {
+    override val name: String = "Reserved"
+  }
+
+  val all = Seq(Any, Unreserved, Reserved)
+
+  def fromString(s: String): Option[AcceptedResourceRolesDefaultBehavior] = {
+    s.toLowerCase match {
+      case "any" => Some(AcceptedResourceRolesDefaultBehavior.Any)
+      case "unreserved" => Some(AcceptedResourceRolesDefaultBehavior.Unreserved)
+      case "reserved" => Some(AcceptedResourceRolesDefaultBehavior.Reserved)
+      case _ => None
+    }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -189,7 +189,7 @@ trait MarathonConf
   lazy val acceptedResourceRolesDefaultBehavior = opt[AcceptedResourceRolesDefaultBehavior](
     name = "accepted_resource_roles_default_behavior",
     descr = "Default behavior for acceptedResourceRoles if not explicitly set on a service." +
-      "This defaults to 'any', which allows the either unreserved and reserved resources",
+      "This defaults to 'any', which allows either unreserved or reserved resources",
     default = deriveDefaultAcceptedResourceRolesDefaultBehavior)(acceptedResourceRolesDefaultBehaviorConverter)
 
   lazy val gracefulShutdownTimeout = opt[Long] (

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -133,25 +133,19 @@ trait MarathonConf
       "resources with the role designation '*'.",
     default = Some(ResourceRole.Unreserved))
 
-  def expectedResourceRoles: Set[String] = mesosRole.toOption match {
-    case Some(role) => Set(role, ResourceRole.Unreserved)
-    case None => Set(ResourceRole.Unreserved)
-  }
-
   lazy val groupRoleBehavior = opt[GroupRoleBehavior](
     name = "group_role_behavior",
     descr = "Defines the behavior for group roles. 'Top' means that all new child apps and pods are launched" +
       "with a role that matches the top-level group's name.",
     default = Some(GroupRoleBehavior.Off))(groupRoleBehaviorConverter)
 
-  lazy val defaultAcceptedResourceRolesSet = defaultAcceptedResourceRoles.getOrElse(expectedResourceRoles)
-
-  lazy val defaultAcceptedResourceRoles = opt[String](
+  @deprecated("Accepted resource roles can not be set directly anymore. Use accepted_resource_roles_default_behavior.", since = "1.9")
+  private[this] lazy val defaultAcceptedResourceRoles = opt[String](
     "default_accepted_resource_roles",
     descr =
-      "Default for the defaultAcceptedResourceRoles attribute of all app definitions" +
+      "(Deprecated) Default for the defaultAcceptedResourceRoles attribute of all app definitions" +
         " as a comma-separated list of strings. " +
-        "This defaults to all roles for which this Marathon instance is configured to receive offers.",
+        "This parameter is deprecated, please use --accepted_resource_roles_default_behavior",
     default = None,
     validate = validateDefaultAcceptedResourceRoles).map(parseDefaultAcceptedResourceRoles)
 
@@ -159,6 +153,11 @@ trait MarathonConf
     str.split(',').map(_.trim).toSet
 
   private[this] def validateDefaultAcceptedResourceRoles(str: String): Boolean = {
+    def expectedResourceRoles: Set[String] = mesosRole.toOption match {
+      case Some(role) => Set(role, ResourceRole.Unreserved)
+      case None => Set(ResourceRole.Unreserved)
+    }
+
     val parsed = parseDefaultAcceptedResourceRoles(str)
 
     // throw exceptions for better error messages
@@ -170,6 +169,28 @@ trait MarathonConf
 
     true
   }
+
+  private[this] def deriveDefaultAcceptedResourceRolesDefaultBehavior: Option[AcceptedResourceRolesDefaultBehavior] = {
+    defaultAcceptedResourceRoles.toOption match {
+      case Some(set) if set == Set(ResourceRole.Unreserved) => Some(AcceptedResourceRolesDefaultBehavior.Unreserved)
+      case Some(set) if set == Set(mesosRole()) => Some(AcceptedResourceRolesDefaultBehavior.Reserved)
+      case _ => Some(AcceptedResourceRolesDefaultBehavior.Any)
+    }
+  }
+
+  def defaultAcceptedResourceRolesSet(serviceRole: Role): Set[String] = {
+    acceptedResourceRolesDefaultBehavior() match {
+      case AcceptedResourceRolesDefaultBehavior.Any => Set(serviceRole, ResourceRole.Unreserved)
+      case AcceptedResourceRolesDefaultBehavior.Unreserved => Set(ResourceRole.Unreserved)
+      case AcceptedResourceRolesDefaultBehavior.Reserved => Set(serviceRole)
+    }
+  }
+
+  lazy val acceptedResourceRolesDefaultBehavior = opt[AcceptedResourceRolesDefaultBehavior](
+    name = "accepted_resource_roles_default_behavior",
+    descr = "Default behavior for acceptedResourceRoles if not explicitly set on a service." +
+      "This defaults to 'any', which allows the either unreserved and reserved resources",
+    default = deriveDefaultAcceptedResourceRolesDefaultBehavior)(acceptedResourceRolesDefaultBehaviorConverter)
 
   lazy val gracefulShutdownTimeout = opt[Long] (
     "graceful_shutdown_timeout",
@@ -387,6 +408,22 @@ object MarathonConf extends StrictLogging {
         Right(None)
       case other =>
         Left("Expected exactly one default enforce group role")
+    }
+  }
+
+  val acceptedResourceRolesDefaultBehaviorConverter = new ValueConverter[AcceptedResourceRolesDefaultBehavior] {
+    val argType = org.rogach.scallop.ArgType.SINGLE
+
+    override def parse(s: List[(String, List[String])]): Either[String, Option[AcceptedResourceRolesDefaultBehavior]] = s match {
+      case (_, acceptedResourceRolesDefaultBehavior :: Nil) :: Nil =>
+        AcceptedResourceRolesDefaultBehavior.fromString(acceptedResourceRolesDefaultBehavior) match {
+          case o @ Some(_) => Right(o)
+          case None => Left(s"Setting $acceptedResourceRolesDefaultBehavior is invalid. Valid settings are ${AcceptedResourceRolesDefaultBehavior.all.map(_.name).mkString(", ")}")
+        }
+      case Nil =>
+        Right(None)
+      case other =>
+        Left("Expected exactly one acceptedResourceRoles default behavior")
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -82,7 +82,7 @@ class InstanceOpFactoryImpl(
     logger.debug(s"Infer for ephemeral pod ${scheduledInstance.instanceId}")
 
     val builderConfig = TaskGroupBuilder.BuilderConfig(
-      config.defaultAcceptedResourceRolesSet,
+      config.defaultAcceptedResourceRolesSet(pod.role),
       config.envVarsPrefix.toOption,
       config.mesosBridgeName())
 
@@ -130,8 +130,14 @@ class InstanceOpFactoryImpl(
     scheduledInstance: Instance): OfferMatchResult = {
 
     val matchResponse =
-      RunSpecOfferMatcher.matchOffer(app, offer, runningInstances,
-        config.defaultAcceptedResourceRolesSet, config, schedulerPlugins, localRegion)
+      RunSpecOfferMatcher.matchOffer(
+        app,
+        offer,
+        runningInstances,
+        config.defaultAcceptedResourceRolesSet(app.role),
+        config,
+        schedulerPlugins,
+        localRegion)
     matchResponse match {
       case matches: ResourceMatchResponse.Match =>
         val taskId = scheduledInstance.tasksMap.headOption match {
@@ -214,7 +220,7 @@ class InstanceOpFactoryImpl(
 
       logger.debug(s"Need to reserve for ${runSpec.id}, version ${runSpec.version}")
       val configuredRoles = if (runSpec.acceptedResourceRoles.isEmpty) {
-        config.defaultAcceptedResourceRolesSet
+        config.defaultAcceptedResourceRolesSet(runSpec.role)
       } else {
         runSpec.acceptedResourceRoles
       }
@@ -290,7 +296,7 @@ class InstanceOpFactoryImpl(
       case pod: PodDefinition =>
         logger.debug(s"Launching resident pod ${reservedInstance.instanceId} on reservation ${reservedInstance.reservation}")
         val builderConfig = TaskGroupBuilder.BuilderConfig(
-          config.defaultAcceptedResourceRolesSet,
+          config.defaultAcceptedResourceRolesSet(pod.role),
           config.envVarsPrefix.toOption,
           config.mesosBridgeName())
 

--- a/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
@@ -135,8 +135,7 @@ class MarathonConfTest extends UnitTest {
         "--mesos_role", "marathon",
         "--default_accepted_resource_roles", "*,marathon"
       )
-
-      assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved, "marathon"))
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Any)
     }
 
     "--default_accepted_resource_roles *" in {
@@ -144,14 +143,14 @@ class MarathonConfTest extends UnitTest {
         "--master", "127.0.0.1:5050",
         "--default_accepted_resource_roles", "*"
       )
-      assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved))
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Unreserved)
     }
 
     "--default_accepted_resource_roles default without --mesos_role" in {
       val conf = MarathonTestHelper.makeConfig(
         "--master", "127.0.0.1:5050"
       )
-      assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved))
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Any)
     }
 
     "--default_accepted_resource_roles default with --mesos_role" in {
@@ -159,7 +158,68 @@ class MarathonConfTest extends UnitTest {
         "--master", "127.0.0.1:5050",
         "--mesos_role", "marathon"
       )
-      assert(conf.defaultAcceptedResourceRolesSet == Set(ResourceRole.Unreserved, "marathon"))
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Any)
     }
+
+    "--accepted_resource_roles_default_behavior any without --default_accepted_resource_roles" in {
+      val conf = MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+        "--accepted_resource_roles_default_behavior", "any"
+      )
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Any)
+    }
+
+    "--accepted_resource_roles_default_behavior reserved without --default_accepted_resource_roles" in {
+      val conf = MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+        "--accepted_resource_roles_default_behavior", "reserved"
+      )
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Reserved)
+    }
+
+    "--accepted_resource_roles_default_behavior unreserved without --default_accepted_resource_roles" in {
+      val conf = MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+        "--accepted_resource_roles_default_behavior", "unreserved"
+      )
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Unreserved)
+    }
+
+    "--accepted_resource_roles_default_behavior overrides --default_accepted_resource_roles *" in {
+      val conf = MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+        "--default_accepted_resource_roles", "*",
+        "--accepted_resource_roles_default_behavior", "any"
+      )
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Any)
+    }
+
+    "--accepted_resource_roles_default_behavior overrides --default_accepted_resource_roles * and mesos_role" in {
+      val conf = MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+        "--mesos_role", "marathon",
+        "--default_accepted_resource_roles", "*,marathon",
+        "--accepted_resource_roles_default_behavior", "reserved"
+      )
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Reserved)
+    }
+
+    "--accepted_resource_roles_default_behavior overrides --default_accepted_resource_roles mesos_role" in {
+      val conf = MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+        "--mesos_role", "marathon",
+        "--default_accepted_resource_roles", "marathon",
+        "--accepted_resource_roles_default_behavior", "unreserved"
+      )
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Unreserved)
+    }
+
+    "--accepted_resource_roles_default_behavior not set nor --default_accepted_resource_roles set" in {
+      val conf = MarathonTestHelper.makeConfig(
+        "--master", "127.0.0.1:5050",
+      )
+      assert(conf.acceptedResourceRolesDefaultBehavior() == AcceptedResourceRolesDefaultBehavior.Any)
+    }
+
   }
 }

--- a/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
+++ b/src/test/scala/mesosphere/marathon/MarathonConfTest.scala
@@ -1,9 +1,8 @@
 package mesosphere.marathon
 
 import mesosphere.UnitTest
-import mesosphere.marathon.state.ResourceRole
-import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.marathon.ZookeeperConf.ZkUrl
+import mesosphere.marathon.test.MarathonTestHelper
 
 import scala.util.{Failure, Try}
 

--- a/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/MesosHealthCheckTest.scala
@@ -880,7 +880,7 @@ class MesosHealthCheckTest extends UnitTest {
     val taskId = Task.Id(instanceId)
     val builder = new TaskBuilder(app, taskId, config)
     val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty,
-      config.defaultAcceptedResourceRolesSet, config, Seq.empty)
+      config.defaultAcceptedResourceRolesSet(app.role), config, Seq.empty)
     resourceMatch match {
       case matches: ResourceMatchResponse.Match => Some(builder.build(offer, matches.resourceMatch, None, enforceRole = true))
       case _ => None

--- a/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskBuilderTest.scala
@@ -1264,7 +1264,7 @@ class TaskBuilderTest extends UnitTest {
       val s = Seq(t1, t2)
 
       val config = MarathonTestHelper.defaultConfig()
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, s, config.defaultAcceptedResourceRolesSet,
+      val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, s, config.defaultAcceptedResourceRolesSet(app.role),
         config, Seq.empty)
       assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
       // TODO test for resources etc.
@@ -1290,7 +1290,7 @@ class TaskBuilderTest extends UnitTest {
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(message: String, offer: Offer): Unit = {
         val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq,
-          config.defaultAcceptedResourceRolesSet, config, Seq.empty)
+          config.defaultAcceptedResourceRolesSet(app.role), config, Seq.empty)
         withClue(message) {
           assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
         }
@@ -1312,7 +1312,7 @@ class TaskBuilderTest extends UnitTest {
 
       def shouldNotBuildTask(message: String, offer: Offer): Unit = {
         val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq,
-          config.defaultAcceptedResourceRolesSet, config, Seq.empty)
+          config.defaultAcceptedResourceRolesSet(app.role), config, Seq.empty)
         assert(resourceMatch.isInstanceOf[ResourceMatchResponse.NoMatch], message)
       }
 
@@ -1359,7 +1359,7 @@ class TaskBuilderTest extends UnitTest {
       val builder = new TaskBuilder(app, taskId, config)
       def shouldBuildTask(offer: Offer): Unit = {
         val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq,
-          config.defaultAcceptedResourceRolesSet, config, Seq.empty)
+          config.defaultAcceptedResourceRolesSet(app.role), config, Seq.empty)
         assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
         val matches = resourceMatch.asInstanceOf[ResourceMatchResponse.Match]
         val (taskInfo, networkInfo) = builder.build(offer, matches.resourceMatch, None, enforceRole = true)
@@ -1380,7 +1380,7 @@ class TaskBuilderTest extends UnitTest {
 
       def shouldNotBuildTask(message: String, offer: Offer): Unit = {
         val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq,
-          config.defaultAcceptedResourceRolesSet, config, Seq.empty)
+          config.defaultAcceptedResourceRolesSet(app.role), config, Seq.empty)
         assert(resourceMatch.isInstanceOf[ResourceMatchResponse.NoMatch], message)
       }
 
@@ -1902,7 +1902,7 @@ class TaskBuilderTest extends UnitTest {
       val runningInstances = Set.empty[Instance]
 
       val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, runningInstances.toIndexedSeq,
-        config.defaultAcceptedResourceRolesSet, config, Seq.empty)
+        config.defaultAcceptedResourceRolesSet(app.role), config, Seq.empty)
       assert(resourceMatch.isInstanceOf[ResourceMatchResponse.Match])
       val matches = resourceMatch.asInstanceOf[ResourceMatchResponse.Match]
       val (taskInfo, _) = builder.build(offer, matches.resourceMatch, None, enforceRole = true)
@@ -1997,7 +1997,7 @@ class TaskBuilderTest extends UnitTest {
 
     val config = MarathonTestHelper.defaultConfig()
     val resourceMatch = RunSpecOfferMatcher.matchOffer(app, offer, Seq.empty,
-      acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet), config, Seq.empty)
+      acceptedResourceRoles.getOrElse(config.defaultAcceptedResourceRolesSet(app.role)), config, Seq.empty)
 
     resourceMatch match {
       case matches: ResourceMatchResponse.Match => Some(builder.build(offer, matches.resourceMatch, None, enforceRole = true))


### PR DESCRIPTION
Added `--accepted_resource_roles_default_behavior` and deprecated `--default_accepted_resource_roles`.  The accepted resource roles default behavior defines whether which values are selected for the accepted resource roles by default:
- `AcceptedResourceRolesDefaultBehavior.Any` indicates that either reserved or unreserved resources will be accepted (default)
- `AcceptedResourceRolesDefaultBehavior.Unreserved` Only unreserved ( offers with role '*' ) will be accepted
- `AcceptedResourceRolesDefaultBehavior.Reserved` Only reserved (offers with the role of the starting task) will be accepted

JIRA issues: MARATHON-8655
