### PR TITLE
Prohibit mutual specification of accepted-resource-role configuration flags

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,14 +22,21 @@ The role field can now be optionally specified for a service. However, the value
    "acceptedResourceRoles": ["foo"]
 }
 ``` 
-but wouldn't be able to start the task since it is not subscribed for the role `foo`. 
+
+... but wouldn't be able to start the task since it is not subscribed for the role `foo`.
 
 This behavior has been changed with the addition of multi-role support. In Marathon 1.9, Marathon will sanitize the `acceptedResourceRoles` value, removing all invalid roles and leaving `*` (unreserved) by default. Using the example above, the service definition will be still accepted, however, `foo` will be removed and `"acceptedResourceRoles": ["*"]` will be used instead so that the task *will start*.
 
 Starting with Marathon 1.10, Marathon will reject the above service definition as invalid. However, the `sanitize_accepted_resource_roles` feature can be enabled with `--deprecated_features sanitize_accepted_resource_roles`, causing Marathon to continue to auto-sanitize this field value for one more version.
 
 In Marathon 1.11, the `sanitize_accepted_resource_roles` deprecated feature will be removed.
- 
+
+#### Command-line flag `--default_accepted_resource_roles` has been replaced with `--accepted_resource_roles_default_behavior`
+
+The command-line flag `--default_accepted_resource_roles` does not work in a multi-role context. A new command-line parameter, `--accepted_resource_roles_default_behavior`, has been introduced, to replace it. See the [command-line-flags](https://mesosphere.github.io/marathon/docs/command-line-flags.html) docs.
+
+The command-line flag `--default_accepted_resource_roles` is deprecated and will be removed in Marathon 1.10.0.
+
 ### Introduce SharedMemory/IPC configuration to Marathon Apps and Pods
 
 When running Marathon Apps or Pods it is now possible to configure the IPC separation level and shared memory size.

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -160,6 +160,7 @@ trait MarathonConf
     }
 
     val parsed = parseDefaultAcceptedResourceRoles(str)
+    require(BuildInfo.version.minor < 10, "This flag has been removed in Marathon 1.10.0; use --accepted_resource_roles_default_behavior, instead.")
 
     // throw exceptions for better error messages
     require(parsed.nonEmpty, "--default_accepted_resource_roles must not be empty")
@@ -187,10 +188,14 @@ trait MarathonConf
     }
   }
 
-  lazy val acceptedResourceRolesDefaultBehavior = opt[AcceptedResourceRolesDefaultBehavior](
+  lazy val acceptedResourceRolesDefaultBehavior: ScallopOption[AcceptedResourceRolesDefaultBehavior] = opt[AcceptedResourceRolesDefaultBehavior](
     name = "accepted_resource_roles_default_behavior",
     descr = "Default behavior for acceptedResourceRoles if not explicitly set on a service." +
       "This defaults to 'any', which allows either unreserved or reserved resources",
+    validate = { _ =>
+      require(!(defaultAcceptedResourceRoles.isSupplied && acceptedResourceRolesDefaultBehavior.isSupplied), "You may not specify both --default_accepted_resource_roles and --accepted_resource_roles_default_behavior")
+      true
+    },
     default = deriveDefaultAcceptedResourceRolesDefaultBehavior)(acceptedResourceRolesDefaultBehaviorConverter)
 
   lazy val gracefulShutdownTimeout = opt[Long] (


### PR DESCRIPTION
To avoid ambiguity, we prohibit the specification of conflicting flags
`--default_accepted_resource_roles` and `--accepted_resource_roles_default_behavior`.
