### PR TITLE
Allow PUT /v2/groups to modify enforceRole so long as services are unaffected

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -153,7 +153,7 @@ class GroupsResource @Inject() (
       val raw = Json.parse(body).as[raml.GroupUpdate]
       val effectivePath = raw.id.map(id => validateOrThrow(PathId(id)).canonicalPath(rootPath)).getOrElse(rootPath)
 
-      val groupValidator = Group.validNestedGroupUpdateWithBase(rootPath, originalRootGroup)
+      val groupValidator = Group.validNestedGroupUpdateWithBase(rootPath, originalRootGroup, Group.updateModifiesServices(raw))
       val groupUpdate = validateOrThrow(
         GroupNormalization(config, originalRootGroup).updateNormalization(effectivePath).normalized(raw)
       )(groupValidator)
@@ -243,7 +243,7 @@ class GroupsResource @Inject() (
       val raw = Json.parse(body).as[raml.GroupUpdate]
       val effectivePath = raw.id.map(id => validateOrThrow(PathId(id)).canonicalPath(rootPath)).getOrElse(rootPath)
 
-      val groupValidator = Group.validNestedGroupUpdateWithBase(effectivePath, originalRootGroup)
+      val groupValidator = Group.validNestedGroupUpdateWithBase(effectivePath, originalRootGroup, Group.updateModifiesServices(raw))
       val groupUpdate = validateOrThrow(
         GroupNormalization(config, originalRootGroup).updateNormalization(effectivePath).normalized(raw)
       )(groupValidator)

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -342,7 +342,7 @@ object Group extends StrictLogging {
     import disallowEnforceRoleChangeIfServicesChanged.EnforceRoleCantBeChangedMessage
 
     override def apply(group: raml.GroupUpdate): Result = {
-      if (servicesGloballyModified == false) {
+      if (!servicesGloballyModified) {
         Success
       } else {
         val updatedGroupId = group.id.map { id => id.toPath.canonicalPath(base) }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -353,7 +353,7 @@ object Group extends StrictLogging {
           Failure(Set(RuleViolation(maybeNewEnforceRole, s"enforce role cannot be removed from $updatedGroupId.")))
         case (Some(newEnforceRole), Some(oldEnforceRole)) =>
           if (newEnforceRole == oldEnforceRole) Success
-          else Failure(Set(RuleViolation(maybeNewEnforceRole, s"enforce role cannot be updated from $oldEnforceRole to $newEnforceRole for $updatedGroupId. Use a pratial update instead.")))
+          else Failure(Set(RuleViolation(maybeNewEnforceRole, s"enforce role cannot be updated from $oldEnforceRole to $newEnforceRole for $updatedGroupId. Use a PATCH request, instead.")))
         case _ => Success
       }
     }

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -361,7 +361,7 @@ object Group extends StrictLogging {
   }
 
   def updateModifiesServices(update: raml.GroupUpdate): Boolean = {
-    update.version.nonEmpty || update.scaleBy.nonEmpty || update.apps.exists(_.nonEmpty) || update.groups.getOrElse(Set.empty).exists { group =>
+    update.version.nonEmpty || update.scaleBy.nonEmpty || update.apps.nonEmpty || update.groups.getOrElse(Set.empty).exists { group =>
       updateModifiesServices(group)
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/ModelValidationTest.scala
@@ -41,8 +41,8 @@ class ModelValidationTest extends UnitTest with GroupCreation with ValidationTes
   import ModelValidationTest._
 
   "ModelValidation" should {
-    "A group update should pass validation" in {
-      implicit val groupUpdateValidator: Validator[GroupUpdate] = Group.validNestedGroupUpdateWithBase(PathId.root, RootGroup.empty)
+    "An empty group update should pass validation" in {
+      implicit val groupUpdateValidator: Validator[GroupUpdate] = Group.validNestedGroupUpdateWithBase(PathId.root, RootGroup.empty, false)
       val update = GroupUpdate(id = Some("/a/b/c"))
 
       validate(update).isSuccess should be(true)

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/GroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/GroupValidationTest.scala
@@ -8,7 +8,7 @@ class GroupValidationTest extends UnitTest with ValidationTestLike {
 
   "Group validation" should {
     "reject defined `enforceRole` outside of a top-level group" in {
-      val groupValidator = Group.validNestedGroupUpdateWithBase(AbsolutePathId("/"), RootGroup.empty)
+      val groupValidator = Group.validNestedGroupUpdateWithBase(AbsolutePathId("/"), RootGroup.empty, false)
       val update = raml.GroupUpdate(
         id = Some("/prod"),
         enforceRole = Some(true),
@@ -20,6 +20,30 @@ class GroupValidationTest extends UnitTest with ValidationTestLike {
       groupValidator(update) should haveViolations(
         "/groups(0)/enforceRole" -> """enforceRole can only be set for top-level groups, and /prod/second is not top-level"""
       )
+    }
+
+    "disallows changes to enforceRole if other services are modified with the request" in {
+      val originalGroup = RootGroup.empty.putGroup(Group(AbsolutePathId("/dev"), enforceRole = false))
+      val groupValidator = Group.validNestedGroupUpdateWithBase(AbsolutePathId("/"), originalGroup, servicesGloballyModified = true)
+
+      val update = raml.GroupUpdate(
+        id = Some("/dev"),
+        enforceRole = Some(true))
+
+      groupValidator(update) should haveViolations(
+        "/enforceRole" -> Group.disallowEnforceRoleChangeIfServicesChanged.EnforceRoleCantBeChangedMessage
+      )
+    }
+
+    "allows changes to enforceRole if other services are modified with the request" in {
+      val originalGroup = RootGroup.empty.putGroup(Group(AbsolutePathId("/dev"), enforceRole = false))
+      val groupValidator = Group.validNestedGroupUpdateWithBase(AbsolutePathId("/"), originalGroup, servicesGloballyModified = false)
+
+      val update = raml.GroupUpdate(
+        id = Some("/dev"),
+        enforceRole = Some(true))
+
+      groupValidator(update) shouldBe aSuccess
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/GroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/GroupValidationTest.scala
@@ -35,7 +35,7 @@ class GroupValidationTest extends UnitTest with ValidationTestLike {
       )
     }
 
-    "allows changes to enforceRole if other services are modified with the request" in {
+    "allows changes to enforceRole if other services are not modified with the request" in {
       val originalGroup = RootGroup.empty.putGroup(Group(AbsolutePathId("/dev"), enforceRole = false))
       val groupValidator = Group.validNestedGroupUpdateWithBase(AbsolutePathId("/"), originalGroup, servicesGloballyModified = false)
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/GroupDeployIntegrationTest.scala
@@ -377,7 +377,7 @@ class GroupDeployIntegrationTest extends AkkaIntegrationTest with EmbeddedMarath
 
       Then("The update fails")
       result should be(UnprocessableEntity)
-      result.entityString should include("enforce role cannot be updated from false to true")
+      result.entityString should include(Group.disallowEnforceRoleChangeIfServicesChanged.EnforceRoleCantBeChangedMessage)
     }
 
     "Patching second level group fails" in {


### PR DESCRIPTION
Requiring PATCH for this one case has tripped up many users and turned out to be bad UX. Further, it would have forced existing tooling (such as dcos-cli), which allows for modification of group properties, to have special corner-case handling for updating this one property.

Instead, we'll allow PUT to modify the enforceRole property so long as deployment-inducing properties are globally avoided in the request