### PR TITLE
Clean up Reservation state types

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Reservation.scala
@@ -45,7 +45,7 @@ object Reservation {
     *
     * @param instanceId The identifier for the instance this reservation belongs to.
     */
-  case class SimplifiedId(val instanceId: Instance.Id) extends Id {
+  case class SimplifiedId(instanceId: Instance.Id) extends Id {
     val label: String = instanceId.idString
   }
 
@@ -120,11 +120,9 @@ object Reservation {
       override def timeout: Option[Timeout] = None
     }
     /** A resident instance that has been running before but terminated and can be relaunched */
-    case class Suspended(timeout: Option[Timeout]) extends State
-    /** A resident instance whose reservation and persistent volumes are being destroyed */
-    case class Garbage(timeout: Option[Timeout]) extends State
-    /** An unknown resident instance created because of unknown reservations/persistent volumes */
-    case class Unknown(timeout: Option[Timeout]) extends State
+    case object Suspended extends State {
+      override def timeout: Option[Timeout] = None
+    }
 
     implicit object StateFormat extends Format[State] {
       override def reads(json: JsValue): JsResult[State] = {
@@ -133,9 +131,7 @@ object Reservation {
           (json \ "name").validate[String].map {
             case "new" => New(timeout)
             case "launched" => Launched
-            case "suspended" => Suspended(timeout)
-            case "garbage" => Garbage(timeout)
-            case _ => Unknown(timeout)
+            case "suspended" => Suspended
           }
         }
       }
@@ -145,9 +141,7 @@ object Reservation {
         o match {
           case _: New => JsObject(Seq("name" -> JsString("new"), "timeout" -> timeout))
           case Launched => JsObject(Seq("name" -> JsString("launched"), "timeout" -> timeout))
-          case _: Suspended => JsObject(Seq("name" -> JsString("suspended"), "timeout" -> timeout))
-          case _: Garbage => JsObject(Seq("name" -> JsString("garbage"), "timeout" -> timeout))
-          case _: Unknown => JsObject(Seq("name" -> JsString("unknown"), "timeout" -> timeout))
+          case Suspended => JsObject(Seq("name" -> JsString("suspended"), "timeout" -> timeout))
         }
       }
     }

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -29,8 +29,8 @@ object InstanceUpdater extends StrictLogging {
 
     // We need to suspend reservation on already launched reserved instances
     // to prevent reservations being destroyed/unreserved.
-    val updatedReservation = if (updatedTask.status.condition.isTerminal && instance.hasReservation && !instance.reservation.exists(r => r.state.isInstanceOf[Reservation.State.Suspended])) {
-      val suspendedState = Reservation.State.Suspended(timeout = None)
+    val updatedReservation = if (updatedTask.status.condition.isTerminal && instance.hasReservation && !instance.reservation.exists(r => r.state.isInstanceOf[Reservation.State.Suspended.type])) {
+      val suspendedState = Reservation.State.Suspended
       instance.reservation.map(_.copy(state = suspendedState))
     } else {
       instance.reservation

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -335,7 +335,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
     val killedOperation = InstanceUpdateOperation.MesosUpdate(provisionedInstance, Condition.Killed, MesosTaskStatusTestHelper.killed(f.taskId), Timestamp(f.clock.instant()))
     val updated = InstanceUpdater.mesosUpdate(provisionedInstance, killedOperation).asInstanceOf[Update]
 
-    updated.instance.reservation.get.state should be(Suspended(None))
+    updated.instance.reservation.get.state should be(Suspended)
   }
 
   "when a TASK_GONE_BY_OPERATOR status update is sent" should {


### PR DESCRIPTION
Summary:
When reviewing #7044, I realized there's some legacy, unused `Reservation.State` types. This patch removed those.

`Garbage` and `Unknown` were never used; `Suspended` never had a timeout set, so all these are removed.