### PR TITLE
Fix exception thrown when posting to /v2/groups without specifying id in the entity

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/GroupNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupNormalization.scala
@@ -42,7 +42,7 @@ case class GroupNormalization(conf: MarathonConf, originalRootGroup: RootGroup) 
   def visitTopLevelGroup(conf: MarathonConf, groupUpdate: raml.GroupUpdate, groupPath: AbsolutePathId, groupRoleBehavior: GroupRoleBehavior, mesosRole: Role): raml.GroupUpdate = {
     // Infer enforce role field and default role for all apps.
     val enforceRole = effectiveEnforceRole(groupRoleBehavior, groupUpdate.enforceRole)
-    val defaultRole = if (enforceRole) PathId(groupUpdate.id.get).root else mesosRole
+    val defaultRole = if (enforceRole) groupUpdate.id.map(PathId(_)).getOrElse(PathId.relativeEmpty).canonicalPath(groupPath).root else mesosRole
 
     // Visit children.
     val children = groupUpdate.groups.map(_.map { childGroup =>

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -190,6 +190,8 @@ object PathId {
 
   def root: AbsolutePathId = AbsolutePathId(Nil)
 
+  def relativeEmpty: RelativePathId = RelativePathId(Nil)
+
   implicit class StringPathId(val stringPath: String) extends AnyVal {
     def toPath: PathId = PathId(stringPath)
     def toAbsolutePath: AbsolutePathId = PathId(stringPath).canonicalPath()


### PR DESCRIPTION
The Marathon API has traditionally allowed group entities to lack the "id" field, instead specifying the group id path via the URL. The normalization logic was assuming that the id field would always be specified (and, that it would be absolute!), rather than falling back on the the base path as specified via the request URI.

JIRA Issues: MARATHON-8695
