### PR TITLE
[1.8] Trigger overdue reservations event not only for scheduled instances

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueInstancesActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/OverdueInstancesActor.scala
@@ -6,7 +6,7 @@ import java.time.Clock
 import akka.actor._
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.condition.Condition
-import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.{Goal, Instance}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
 import mesosphere.marathon.core.task.tracker.InstanceTracker
@@ -98,8 +98,13 @@ private[jobs] object OverdueInstancesActor {
     }
 
     private[this] def overdueReservations(now: Timestamp, instances: Seq[Instance]): Seq[Instance] = {
+      // We're mainly checking if the reservation timeout is expired, i.e. we have send a reservation to mesos
+      // but didn't receive an offer with the requested reservation back in time.
+      //
+      // Usually, the instance is scheduled, but in rare cases it can get decommissioned before the reservation
+      // times out, so we need to check that as well
       instances.filter { instance =>
-        instance.isScheduled && instance.reservation.exists(_.state.timeout.exists(_.deadline <= now))
+        (instance.isScheduled || instance.state.goal == Goal.Decommissioned) && instance.reservation.exists(_.state.timeout.exists(_.deadline <= now))
       }
     }
   }


### PR DESCRIPTION
…but also for Decommissioned ones (#7044)

This fixes a rare bug which happens if Mesos fails to create a reservation as requested by Marathon; the associated service will be stuck indefinitely and is not able to be removed via the API.

JIRA Issues: MARATHON-8693

(cherry picked from commit 967c3d3e629713007ddf532b8c309c265a78f651)
