### PR TITLE
Supply Docker Hub credentials.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,9 +20,11 @@ ansiColor('xterm') {
             string(credentialsId: '3f0dbb48-de33-431f-b91c-2366d2f0e1cf',variable: 'AWS_ACCESS_KEY_ID'),
             string(credentialsId: 'f585ec9a-3c38-4f67-8bdb-79e5d4761937',variable: 'AWS_SECRET_ACCESS_KEY')
         ]) {
-            sh """sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"""
-            sh """sudo -E ci/pipeline jenkins"""
-        }
+	    withDockerRegistry([credentialsId: 'docker-hub-credentials']) {
+                sh """sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"""
+                sh """sudo -E ci/pipeline jenkins"""
+            }
+	}
       } finally {
         junit(allowEmptyResults: true, testResults: 'type-generator/target/test-reports/*.xml')
         junit(allowEmptyResults: true, testResults: 'target/test-reports/*.xml')


### PR DESCRIPTION
Summary:
This is a hot-fix. The last patch introduced the publishing of Marathon
as `unstable` to Docker hub but the credentials were missing.
