### PR TITLE
Move package upload logic to packages makefile

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -207,7 +207,7 @@ def buildDockerAndLinuxPackages(): String = {
 
     val toolPath = pwd/'tools/'packager
     %('make, "clean")(toolPath)
-    %('make, s"all", "-j")(toolPath)
+    %('make, "all", "-j")(toolPath)
 
     %%("./version", "docker").out.string.trim
   }

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -9,6 +9,8 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.util.Try
+import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
 
 import $file.awsClient
 import $file.dataDogClient
@@ -28,6 +30,7 @@ import utils.BranchType._
 
 val PACKAGE_DIR: Path = pwd / 'target / 'universal
 val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
+
 
 /**
  * Compile Marathon and run unit, integration tests.
@@ -204,7 +207,7 @@ def buildDockerAndLinuxPackages(): String = {
 
     val toolPath = pwd/'tools/'packager
     %('make, "clean")(toolPath)
-    %('make, "all", "-j")(toolPath)
+    %('make, s"all", "-j")(toolPath)
 
     %%("./version", "docker").out.string.trim
   }

--- a/ci/releases.sc
+++ b/ci/releases.sc
@@ -89,49 +89,9 @@ def copyTarballBuildsToReleases(version: SemVer): Unit = {
 }
 
 /**
- * Publish ative Linx packages to package server.
+ * Publish native Linx packages to package server.
  */
-def uploadLinuxPackagesToRepos(tagName: String): Unit = {
-  val pkgserverUser = sys.env.getOrElse("PKG_SSH_USER", {
-    throw new IllegalStateException("PKG_SSH_USER environment variable must be set")
-  })
-  val pkgserverHost = sys.env.getOrElse("PKG_SSH_HOST", {
-    throw new IllegalStateException("PKG_SSH_HOST environment variable must be set")
-  })
-
-  // Note - the key is expected to be provided via an SSH agent
-  utils.printStageTitle(s"Uploading native packages")
-  %("rsync", "-avz",
-    (pwd / 'tools / 'packager) + "/",
-    s"${pkgserverUser}@${pkgserverHost}:repo/incoming/marathon-${tagName}/",
-    "--include", "*.deb",
-    "--include", "*.rpm",
-    "--exclude", "*")
-
-  val pkgType = if (tagName.toLowerCase contains "rc")
-    "-testing"
-  else
-    ""
-
-  val mappings = Seq(
-    "debian9" -> s"debian/stretch${pkgType}",
-    "ubuntu1604" -> s"ubuntu/xenial${pkgType}",
-    "ubuntu1404" -> s"ubuntu/trusty${pkgType}",
-    "ubuntu1804" -> s"ubuntu/bionic${pkgType}",
-    "el6" -> s"el${pkgType}/6",
-    "el7" -> s"el${pkgType}/7")
-
-  val copyCommands = mappings.map { case (packageType, path) =>
-    s"cp $$HOME/repo/incoming/marathon-${tagName}/marathon*.${packageType}* " +
-    s"$$HOME/repo/incoming/${path}/"
-  }.mkString(";")
-
-  utils.printStageTitle("Distributing packages to distros")
-  %("ssh", s"${pkgserverUser}@${pkgserverHost}", "bash",
-    "-e", "-x", "-c",
-    utils.escapeCmdArg(List(
-      copyCommands,
-      s"rm -rf $$HOME/repo/incoming/marathon-${tagName}").mkString("\n")))
-
-  utils.printStageTitle("All done")
+def uploadLinuxPackagesToRepos(packageVersion: String): Unit = {
+  val toolPath = pwd/'tools/'packager
+  %('make, "upload")(toolPath)
 }

--- a/tools/packager/Makefile
+++ b/tools/packager/Makefile
@@ -4,11 +4,14 @@ PREFIX := usr
 FPM_VERSION := 1.10.2
 FPM := FPM_VERSION=$(FPM_VERSION) bin/fpm-docker
 
-PKG_VER ?= $(shell cd ../../ && ./version)
+REF ?= HEAD
+
 PKG_REL ?= 0.1.$(shell date -u +'%Y%m%d%H%M%S')
-PKG_COMMIT ?= $(shell cd ../../ && ./version commit)
+PKG_COMMIT = $(shell cd ../../ && ./version commit --ref $(REF))
+PKG_VER = $(shell cd ../../ && ./version --ref $(PKG_COMMIT))
 
 FPM_OPTS := -s dir -n marathon -v $(PKG_VER) \
+	-p target/ \
 	--architecture all \
 	--url "https://github.com/mesosphere/marathon" \
 	--license Apache-2.0 \
@@ -64,11 +67,9 @@ ubuntu: ubuntu-trusty-1404 ubuntu-xenial-1604 ubuntu-bionic-1804
 debian: debian-stretch-9
 
 .PHONY: el6
-el6: toor/el6/etc/init.d/marathon
-el6: toor/el6/$(PREFIX)/share/marathon
-el6: toor/el6/etc/default/marathon
-el6: fpm-docker/.provisioned
-	$(FPM) -C toor/el6 \
+el6: target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm
+target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm: target/toor/el6/etc/init.d/marathon target/toor/el6/$(PREFIX)/share/marathon target/toor/el6/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C target/toor/el6 \
 	        --config-files etc/default/marathon \
 		--iteration $(PKG_REL).el6 \
 	        --before-install scripts/adduser \
@@ -77,11 +78,9 @@ el6: fpm-docker/.provisioned
 		$(FPM_OPTS_RPM) $(FPM_OPTS) .
 
 .PHONY: el7
-el7: toor/el7/usr/lib/systemd/system/marathon.service
-el7: toor/el7/$(PREFIX)/share/marathon
-el7: toor/el7/etc/default/marathon
-el7: fpm-docker/.provisioned
-	$(FPM) -C toor/el7 \
+el7: target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm
+target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm: target/toor/el7/usr/lib/systemd/system/marathon.service target/toor/el7/$(PREFIX)/share/marathon target/toor/el7/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C target/toor/el7 \
 		--iteration $(PKG_REL).el7 \
 		--config-files usr/lib/systemd/system/marathon.service \
                 --config-files etc/default/marathon \
@@ -92,11 +91,9 @@ el7: fpm-docker/.provisioned
 		$(FPM_OPTS_RPM) $(FPM_OPTS) .
 
 .PHONY: ubuntu-trusty-1404
-ubuntu-trusty-1404: toor/ubuntu-trusty/etc/init.d/marathon
-ubuntu-trusty-1404: toor/ubuntu-trusty/$(PREFIX)/share/marathon
-ubuntu-trusty-1404: toor/ubuntu-trusty/etc/default/marathon
-ubuntu-trusty-1404: fpm-docker/.provisioned
-	$(FPM) -C toor/ubuntu-trusty \
+ubuntu-trusty-1404: target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1404_all.deb
+target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1404_all.deb: target/toor/ubuntu-trusty/etc/init.d/marathon target/toor/ubuntu-trusty/$(PREFIX)/share/marathon target/toor/ubuntu-trusty/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C target/toor/ubuntu-trusty \
 	        --config-files etc/default/marathon \
 		--iteration $(PKG_REL).ubuntu1404 \
 	        --before-install scripts/adduser \
@@ -105,70 +102,75 @@ ubuntu-trusty-1404: fpm-docker/.provisioned
 		$(FPM_OPTS_DEB) $(FPM_OPTS) .
 
 .PHONY: ubuntu-xenial-1604
-ubuntu-xenial-1604: toor/ubuntu-xenial/lib/systemd/system/marathon.service
-ubuntu-xenial-1604: toor/ubuntu-xenial/$(PREFIX)/share/marathon
-ubuntu-xenial-1604: toor/ubuntu-xenial/etc/default/marathon
-ubuntu-xenial-1604: fpm-docker/.provisioned
-	$(FPM) -C toor/ubuntu-xenial \
+ubuntu-xenial-1604: target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb
+target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb: target/toor/ubuntu-xenial/lib/systemd/system/marathon.service target/toor/ubuntu-xenial/$(PREFIX)/share/marathon target/toor/ubuntu-xenial/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C target/toor/ubuntu-xenial \
 		--iteration $(PKG_REL).ubuntu1604 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
 .PHONY: ubuntu-bionic-1804
-ubuntu-bionic-1804: toor/ubuntu-bionic/lib/systemd/system/marathon.service
-ubuntu-bionic-1804: toor/ubuntu-bionic/$(PREFIX)/share/marathon
-ubuntu-bionic-1804: toor/ubuntu-bionic/etc/default/marathon
-ubuntu-bionic-1804: fpm-docker/.provisioned
-	$(FPM) -C toor/ubuntu-xenial \
+ubuntu-bionic-1804: target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb
+target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb: target/toor/ubuntu-bionic/lib/systemd/system/marathon.service target/toor/ubuntu-bionic/$(PREFIX)/share/marathon target/toor/ubuntu-bionic/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C target/toor/ubuntu-xenial \
 		--iteration $(PKG_REL).ubuntu1804 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
 .PHONY: debian-stretch-9
-debian-stretch-9: toor/debian-stretch-9/lib/systemd/system/marathon.service
-debian-stretch-9: toor/debian-stretch-9/$(PREFIX)/share/marathon
-debian-stretch-9: toor/debian-stretch-9/etc/default/marathon
-debian-stretch-9: fpm-docker/.provisioned
-	$(FPM) -C toor/debian-stretch-9 \
+debian-stretch-9: marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb
+target/marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb: target/toor/debian-stretch-9/lib/systemd/system/marathon.service target/toor/debian-stretch-9/$(PREFIX)/share/marathon target/toor/debian-stretch-9/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C target/toor/debian-stretch-9 \
 		--iteration $(PKG_REL).debian9 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
-toor/%/etc/default/marathon:
+target/toor/%/etc/default/marathon:
 	mkdir -p "$(dir $@)"
 	cp marathon.defaults $@
 
-toor/el6/etc/init.d/marathon: scripts/el6.init
+target/toor/el6/etc/init.d/marathon: scripts/el6.init
 	mkdir -p "$(dir $@)"
 	cp scripts/el6.init "$@"
 	chmod 0755 "$@"
 
-toor/ubuntu-trusty/etc/init.d/marathon: scripts/ubuntu1404.init
+target/toor/ubuntu-trusty/etc/init.d/marathon: scripts/ubuntu1404.init
 	mkdir -p "$(dir $@)"
 	cp scripts/ubuntu1404.init "$@"
 	chmod 0755 "$@"
 
-toor/%/usr/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
+target/toor/%/usr/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
 	mkdir -p "$(dir $@)"
 	cp scripts/marathon.systemd.service "$@"
 
-toor/%/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
+target/toor/%/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
 	mkdir -p "$(dir $@)"
 	cp scripts/marathon.systemd.service "$@"
 
-toor/%/share/marathon: ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+target/toor/%/share/marathon: target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 	rm -rf "$(dir $@)"
 	mkdir -p "$(dir $@)"
-	tar xzf ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz -C "$(dir $@)"
+	tar xzf target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz -C "$(dir $@)"
 	mv $@-$(PKG_VER)-$(PKG_COMMIT) $@
 	touch $@
 
-../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
+ifeq ($(REF), HEAD)
+target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
+	mkdir -p target/toor
 	cd ../../ && sbt universal:packageZipTarball
+	cp ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz $@
+else
+target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
+	mkdir -p target/toor
+	curl -f -o $@ https://downloads.mesosphere.io/marathon/builds/$(PKG_VER)-$(PKG_COMMIT)/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+endif
 
-fpm-docker/.provisioned:
+download: | target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+
+target/fpm-docker/.provisioned:
 	cd fpm-docker && docker build . --build-arg FPM_VERSION=$(FPM_VERSION) -t fpm:$(FPM_VERSION)
+	mkdir -p target/fpm-docker
 	touch $@
 
 clean:
-	rm -rf marathon*.deb marathon*.rpm marathon*.pkg toor fpm-docker/.provisioned
+	rm -rf marathon*.deb marathon*.rpm marathon*.pkg target
 
 purge: | clean
 	# We could also use 'sbt clean' but it takes forever and is not as thorough.

--- a/tools/packager/Makefile
+++ b/tools/packager/Makefile
@@ -41,12 +41,11 @@ FPM_OPTS_RPM := -t rpm \
 
 EL6_PKG_PATH=target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm
 EL7_PKG_PATH=target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm
-UBUNTU_1404_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1404_all.deb
 UBUNTU_1604_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb
 UBUNTU_1804_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb
 DEBIAN_9_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb
 
-ALL_PKGS=$(EL6_PKG_PATH) $(EL7_PKG_PATH) $(DEBIAN_9_PKG_PATH) $(UBUNTU_1804_PKG_PATH) $(UBUNTU_1604_PKG_PATH) $(UBUNTU_1404_PKG_PATH)
+ALL_PKGS=$(EL6_PKG_PATH) $(EL7_PKG_PATH) $(DEBIAN_9_PKG_PATH) $(UBUNTU_1804_PKG_PATH) $(UBUNTU_1604_PKG_PATH)
 
 .PHONY: help
 help:
@@ -71,7 +70,7 @@ rpm: el
 el: el6 el7
 
 .PHONY: ubuntu
-ubuntu: ubuntu-trusty-1404 ubuntu-xenial-1604 ubuntu-bionic-1804
+ubuntu: ubuntu-xenial-1604 ubuntu-bionic-1804
 
 .PHONY: debian
 debian: debian-stretch-9
@@ -99,17 +98,6 @@ $(EL7_PKG_PATH): target/toor/el7/usr/lib/systemd/system/marathon.service target/
 		--after-remove scripts/rmuser \
 		--before-remove scripts/systemd.disable \
 		$(FPM_OPTS_RPM) $(FPM_OPTS) .
-
-.PHONY: ubuntu-trusty-1404
-ubuntu-trusty-1404: $(UBUNTU_1404_PKG_PATH)
-$(UBUNTU_1404_PKG_PATH): target/toor/ubuntu-trusty/etc/init.d/marathon target/toor/ubuntu-trusty/$(PREFIX)/share/marathon target/toor/ubuntu-trusty/etc/default/marathon target/fpm-docker/.provisioned
-	$(FPM) -C target/toor/ubuntu-trusty \
-	        --config-files etc/default/marathon \
-		--iteration $(PKG_REL).ubuntu1404 \
-	        --before-install scripts/adduser \
-	        --after-install scripts/ubuntu1404.enable \
-	        --deb-init scripts/ubuntu1404.init \
-		$(FPM_OPTS_DEB) $(FPM_OPTS) .
 
 .PHONY: ubuntu-xenial-1604
 ubuntu-xenial-1604: $(UBUNTU_1604_PKG_PATH)
@@ -139,11 +127,6 @@ target/toor/%/etc/default/marathon:
 target/toor/el6/etc/init.d/marathon: scripts/el6.init
 	mkdir -p "$(dir $@)"
 	cp scripts/el6.init "$@"
-	chmod 0755 "$@"
-
-target/toor/ubuntu-trusty/etc/init.d/marathon: scripts/ubuntu1404.init
-	mkdir -p "$(dir $@)"
-	cp scripts/ubuntu1404.init "$@"
 	chmod 0755 "$@"
 
 target/toor/%/usr/lib/systemd/system/marathon.service: scripts/marathon.systemd.service

--- a/tools/packager/Makefile
+++ b/tools/packager/Makefile
@@ -6,9 +6,9 @@ FPM := FPM_VERSION=$(FPM_VERSION) bin/fpm-docker
 
 REF ?= HEAD
 
-PKG_REL ?= 0.1.$(shell date -u +'%Y%m%d%H%M%S')
-PKG_COMMIT = $(shell cd ../../ && ./version commit --ref $(REF))
-PKG_VER = $(shell cd ../../ && ./version --ref $(PKG_COMMIT))
+PKG_REL ?= 1
+PKG_COMMIT := $(shell cd ../../ && ./version commit --ref $(REF))
+PKG_VER := $(shell cd ../../ && ./version --ref $(PKG_COMMIT))
 
 FPM_OPTS := -s dir -n marathon -v $(PKG_VER) \
 	-p target/ \
@@ -38,6 +38,16 @@ FPM_OPTS_RPM := -t rpm \
 	-d 'java >= 1:1.8.0' \
 	-d redhat-lsb-core
 
+
+EL6_PKG_PATH=target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm
+EL7_PKG_PATH=target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm
+UBUNTU_1404_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1404_all.deb
+UBUNTU_1604_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb
+UBUNTU_1804_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb
+DEBIAN_9_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb
+
+ALL_PKGS=$(EL6_PKG_PATH) $(EL7_PKG_PATH) $(DEBIAN_9_PKG_PATH) $(UBUNTU_1804_PKG_PATH) $(UBUNTU_1604_PKG_PATH) $(UBUNTU_1404_PKG_PATH)
+
 .PHONY: help
 help:
 	@echo "Please choose one of the following targets:"
@@ -49,7 +59,7 @@ help:
 	@exit 0
 
 .PHONY: all
-all: deb rpm
+all: $(foreach pkg,$(ALL_PKGS),$(pkg))
 
 .PHONY: deb
 deb: ubuntu debian
@@ -67,8 +77,8 @@ ubuntu: ubuntu-trusty-1404 ubuntu-xenial-1604 ubuntu-bionic-1804
 debian: debian-stretch-9
 
 .PHONY: el6
-el6: target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm
-target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm: target/toor/el6/etc/init.d/marathon target/toor/el6/$(PREFIX)/share/marathon target/toor/el6/etc/default/marathon target/fpm-docker/.provisioned
+el6: $(EL6_PKG_PATH)
+$(EL6_PKG_PATH): target/toor/el6/etc/init.d/marathon target/toor/el6/$(PREFIX)/share/marathon target/toor/el6/etc/default/marathon target/fpm-docker/.provisioned
 	$(FPM) -C target/toor/el6 \
 	        --config-files etc/default/marathon \
 		--iteration $(PKG_REL).el6 \
@@ -78,8 +88,8 @@ target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm: target/toor/el6/etc/init.d
 		$(FPM_OPTS_RPM) $(FPM_OPTS) .
 
 .PHONY: el7
-el7: target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm
-target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm: target/toor/el7/usr/lib/systemd/system/marathon.service target/toor/el7/$(PREFIX)/share/marathon target/toor/el7/etc/default/marathon target/fpm-docker/.provisioned
+el7: $(EL7_PKG_PATH)
+$(EL7_PKG_PATH): target/toor/el7/usr/lib/systemd/system/marathon.service target/toor/el7/$(PREFIX)/share/marathon target/toor/el7/etc/default/marathon target/fpm-docker/.provisioned
 	$(FPM) -C target/toor/el7 \
 		--iteration $(PKG_REL).el7 \
 		--config-files usr/lib/systemd/system/marathon.service \
@@ -91,8 +101,8 @@ target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm: target/toor/el7/usr/lib/sy
 		$(FPM_OPTS_RPM) $(FPM_OPTS) .
 
 .PHONY: ubuntu-trusty-1404
-ubuntu-trusty-1404: target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1404_all.deb
-target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1404_all.deb: target/toor/ubuntu-trusty/etc/init.d/marathon target/toor/ubuntu-trusty/$(PREFIX)/share/marathon target/toor/ubuntu-trusty/etc/default/marathon target/fpm-docker/.provisioned
+ubuntu-trusty-1404: $(UBUNTU_1404_PKG_PATH)
+$(UBUNTU_1404_PKG_PATH): target/toor/ubuntu-trusty/etc/init.d/marathon target/toor/ubuntu-trusty/$(PREFIX)/share/marathon target/toor/ubuntu-trusty/etc/default/marathon target/fpm-docker/.provisioned
 	$(FPM) -C target/toor/ubuntu-trusty \
 	        --config-files etc/default/marathon \
 		--iteration $(PKG_REL).ubuntu1404 \
@@ -102,22 +112,22 @@ target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1404_all.deb: target/toor/ubuntu-tru
 		$(FPM_OPTS_DEB) $(FPM_OPTS) .
 
 .PHONY: ubuntu-xenial-1604
-ubuntu-xenial-1604: target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb
-target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb: target/toor/ubuntu-xenial/lib/systemd/system/marathon.service target/toor/ubuntu-xenial/$(PREFIX)/share/marathon target/toor/ubuntu-xenial/etc/default/marathon target/fpm-docker/.provisioned
+ubuntu-xenial-1604: $(UBUNTU_1604_PKG_PATH)
+$(UBUNTU_1604_PKG_PATH): target/toor/ubuntu-xenial/lib/systemd/system/marathon.service target/toor/ubuntu-xenial/$(PREFIX)/share/marathon target/toor/ubuntu-xenial/etc/default/marathon target/fpm-docker/.provisioned
 	$(FPM) -C target/toor/ubuntu-xenial \
 		--iteration $(PKG_REL).ubuntu1604 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
 .PHONY: ubuntu-bionic-1804
-ubuntu-bionic-1804: target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb
-target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb: target/toor/ubuntu-bionic/lib/systemd/system/marathon.service target/toor/ubuntu-bionic/$(PREFIX)/share/marathon target/toor/ubuntu-bionic/etc/default/marathon target/fpm-docker/.provisioned
+ubuntu-bionic-1804: $(UBUNTU_1804_PKG_PATH)
+$(UBUNTU_1804_PKG_PATH): target/toor/ubuntu-bionic/lib/systemd/system/marathon.service target/toor/ubuntu-bionic/$(PREFIX)/share/marathon target/toor/ubuntu-bionic/etc/default/marathon target/fpm-docker/.provisioned
 	$(FPM) -C target/toor/ubuntu-xenial \
 		--iteration $(PKG_REL).ubuntu1804 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
 .PHONY: debian-stretch-9
-debian-stretch-9: marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb
-target/marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb: target/toor/debian-stretch-9/lib/systemd/system/marathon.service target/toor/debian-stretch-9/$(PREFIX)/share/marathon target/toor/debian-stretch-9/etc/default/marathon target/fpm-docker/.provisioned
+debian-stretch-9: $(DEBIAN_9_PKG_PATH)
+$(DEBIAN_9_PKG_PATH): target/toor/debian-stretch-9/lib/systemd/system/marathon.service target/toor/debian-stretch-9/$(PREFIX)/share/marathon target/toor/debian-stretch-9/etc/default/marathon target/fpm-docker/.provisioned
 	$(FPM) -C target/toor/debian-stretch-9 \
 		--iteration $(PKG_REL).debian9 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
@@ -152,15 +162,28 @@ target/toor/%/share/marathon: target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 	touch $@
 
 ifeq ($(REF), HEAD)
-target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
-	mkdir -p target/toor
+../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
 	cd ../../ && sbt universal:packageZipTarball
+
+target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz: ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+	mkdir -p target/toor
 	cp ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz $@
 else
 target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
 	mkdir -p target/toor
 	curl -f -o $@ https://downloads.mesosphere.io/marathon/builds/$(PKG_VER)-$(PKG_COMMIT)/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 endif
+
+
+define upload_target
+$(1).uploaded: $(1)
+	./bin/upload-package $(1) 2>&1 | tee $(1).uploaded.tmp
+	mv $(1).uploaded.tmp $(1).uploaded
+endef
+
+$(foreach target,$(ALL_PKGS),$(eval $(call upload_target,$(target))))
+
+upload: $(foreach target,$(ALL_PKGS),$(target).uploaded)
 
 download: | target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 

--- a/tools/packager/Makefile
+++ b/tools/packager/Makefile
@@ -121,7 +121,7 @@ $(UBUNTU_1604_PKG_PATH): target/toor/ubuntu-xenial/lib/systemd/system/marathon.s
 .PHONY: ubuntu-bionic-1804
 ubuntu-bionic-1804: $(UBUNTU_1804_PKG_PATH)
 $(UBUNTU_1804_PKG_PATH): target/toor/ubuntu-bionic/lib/systemd/system/marathon.service target/toor/ubuntu-bionic/$(PREFIX)/share/marathon target/toor/ubuntu-bionic/etc/default/marathon target/fpm-docker/.provisioned
-	$(FPM) -C target/toor/ubuntu-xenial \
+	$(FPM) -C target/toor/ubuntu-bionic \
 		--iteration $(PKG_REL).ubuntu1804 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
@@ -177,7 +177,7 @@ endif
 
 define upload_target
 $(1).uploaded: $(1)
-	./bin/upload-package $(1) 2>&1 | tee $(1).uploaded.tmp
+	set -o pipefail && ./bin/upload-package $(1) 2>&1 | tee $(1).uploaded.tmp
 	mv $(1).uploaded.tmp $(1).uploaded
 endef
 

--- a/tools/packager/README.md
+++ b/tools/packager/README.md
@@ -4,14 +4,12 @@ packager
 Packaging utilities for Marathon.
 
 
-Set Up
-------
+## Set Up
 * Install Docker
 
 * Install [SBT](http://www.scala-sbt.org/release/tutorial/Installing-sbt-on-Linux.html) and an appropriate JDK to build Marathon.
 
-Building Packages
------------------
+## Building Packages
 
 ```bash
 make clean
@@ -25,8 +23,21 @@ make all                                ## Build all packages
 make deb                                ## For all Debian/Ubuntu DEB packages
 make rpm                                ## For all EL/Fedora RPM packages
 make el                                 ## For all Enterprise Linux (EL) packages
-make fedora                             ## For all Fedora (FC) packages
 make debian                             ## For all Debian packages
 make ubuntu                             ## For all Ubuntu packages
-make osx                                ## For Apple Macintosh
+make upload                             ## Upload all debian packages
+```
+
+## Uploading Packages
+
+The Makefile is used to upload packages to the pkgmaintainer repository. The following pre-requisites are required:
+
+* You must have an ssh-agent running
+* The ssh-agent must have the pkgmaintainer key
+
+For example, to build and upload the packages for v1.9.71, the following command can be invoked
+
+```
+ssh-add ~/.ssh/pkgmaintainer.pem
+PKG_SSH_USER=... PKG_SSH_HOST=... make REF=v1.9.71 upload
 ```

--- a/tools/packager/bin/upload-package
+++ b/tools/packager/bin/upload-package
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$PKG_SSH_USER" ]; then
+  echo "PKG_SSH_USER environment variable must be set"
+  exit 1
+fi
+
+if [ -z "$PKG_SSH_HOST" ]; then
+  echo "PKG_SSH_HOST environment variable must be set"
+  exit 1
+fi
+
+
+: ${PKG_TYPE=} # maybe testing?
+
+# identify package type and map to appropriate folder
+
+FILE=$1
+
+case $FILE in
+  *.el6.noarch.rpm)
+    DISTPATH=el${PKG_TYPE}/6
+    ;;
+  *.el7.noarch.rpm)
+    DISTPATH=el${PKG_TYPE}/7
+    ;;
+  *.ubuntu1404_all.deb)
+    DISTPATH=ubuntu/trusty${PKG_TYPE}
+    ;;
+  *.ubuntu1604_all.deb)
+    DISTPATH=ubuntu/xenial${PKG_TYPE}
+    ;;
+  *.ubuntu1804_all.deb)
+    DISTPATH=ubuntu/bionic${PKG_TYPE}
+    ;;
+  *.debian9_all.deb)
+    DISTPATH=debian/stretch${PKG_TYPE}
+    ;;
+  *)
+    echo "I don't know what kind of package $FILE is"
+    exit 1
+    ;;
+esac
+
+BASENAME=$(basename "$FILE")
+
+scp $FILE ${PKG_SSH_USER}@${PKG_SSH_HOST}:repo/incoming/$BASENAME
+ssh ${PKG_SSH_USER}@${PKG_SSH_HOST} "mv repo/incoming/$BASENAME repo/incoming/$DISTPATH/"

--- a/version
+++ b/version
@@ -7,6 +7,7 @@
 MAJOR=1
 MINOR=9
 BRANCH_POINT=8228cea
+PREVIOUS_BRANCH=origin/releases/1.$(($MINOR - 1))
 REF=HEAD
 
 declare -a OTHERARGS
@@ -46,8 +47,16 @@ done
 
 # Infer version
 # Number of commits since branch point
+IS_DIRECT_CHILD=$( git log origin/master..8228cea)
 COMMIT_NUMBER="$(git rev-list --count --first-parent $BRANCH_POINT..$REF)"
 COMMIT_HASH=$(git rev-parse --short $REF)
+
+# Detect if the commit in question belongs to another minor version
+if !(git merge-base --is-ancestor $BRANCH_POINT $REF) || (git merge-base --is-ancestor $REF $PREVIOUS_BRANCH) &&
+      [ $(git rev-parse --verify $REF) != $(git rev-parse --verify $BRANCH_POINT) ]; then
+  echo "$REF is not a ${MAJOR}.${MINOR}.x version"
+  exit 1
+fi
 
 case ${OTHERARGS[0]} in
   commit)

--- a/version
+++ b/version
@@ -47,7 +47,7 @@ done
 
 # Infer version
 # Number of commits since branch point
-IS_DIRECT_CHILD=$( git log origin/master..8228cea)
+IS_DIRECT_CHILD=$( git log origin/master..$BRANCH_POINT)
 COMMIT_NUMBER="$(git rev-list --count --first-parent $BRANCH_POINT..$REF)"
 COMMIT_HASH=$(git rev-parse --short $REF)
 


### PR DESCRIPTION
* Building and uploading packages for previous tags of the same minor release now possible; artifacts will be downloaded and used without needing to checkout old code
* version script fails with an error when attempting to build and upload a package a different minor release