### PR TITLE
Removed the SECOND validation for external volume names

### DIFF
--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -231,7 +231,7 @@ trait AppValidation {
         option.keys.each should matchRegex(OptionKeyRegex)
       }
       val validExternalInfo: Validator[ExternalVolumeInfo] = validator[ExternalVolumeInfo] { info =>
-        info.name is definedAnd(matchRegex(LabelRegex))
+        info.name is notEmpty
         info.provider is definedAnd(matchRegex(LabelRegex))
         info.options is validOptions
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -1120,7 +1120,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       response.getEntity.toString should include("is unknown provider")
     }
 
-    "Creating an app with an external volume with no name orprovider name specified should FAIL provider validation" in new Fixture {
+    "Creating an app with an external volume with no name or provider name specified should FAIL provider validation" in new Fixture {
       Given("An app with an unnamed volume provider")
       val response =
         createAppWithVolumes(
@@ -1840,6 +1840,85 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       updateResponse.getStatus should be(200)
       updateResponse.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
 
+    }
+
+
+    "ExternalVolume names with options are considered valid" in new Fixture() {
+      Given("an app with external volume whose name serializes options")
+      val volumeName = "name=teamvolumename,repl=1,secure=true,secret_key=volume-secret-key-team"
+      val appWithExtVol: String =
+        s"""
+          |{
+          |  "id": "nginx-ucr",
+          |  "container": {
+          |    "type": "MESOS",
+          |    "volumes": [
+          |      {
+          |        "external": {
+          |          "size": 5,
+          |          "name": "$volumeName",
+          |          "provider": "dvdi",
+          |          "options": {
+          |            "dvdi/driver": "pxd",
+          |            "dvdi/secure": "true",
+          |            "dvdi/secret_key": "volume-secret-key-team",
+          |            "dvdi/repl": "1",
+          |            "dvdi/shared": "true"
+          |          }
+          |        },
+          |        "mode": "RW",
+          |        "containerPath": "/mnt/nginx"
+          |      }
+          |    ],
+          |    "docker": {
+          |      "image": "nginx",
+          |      "forcePullImage": false,
+          |      "parameters": []
+          |    },
+          |    "portMappings": [
+          |      {
+          |        "containerPort": 80,
+          |        "hostPort": 0,
+          |        "protocol": "tcp",
+          |        "name": "web"
+          |      }
+          |    ]
+          |  },
+          |  "cpus": 0.1,
+          |  "disk": 0,
+          |  "instances": 1,
+          |  "mem": 128,
+          |  "gpus": 0,
+          |  "networks": [
+          |    {
+          |      "mode": "container/bridge"
+          |    }
+          |  ],
+          |  "requirePorts": false,
+          |  "healthChecks": [],
+          |  "fetch": [],
+          |  "constraints": []
+          |}
+        """.stripMargin
+      val appJs = Json.parse(appWithExtVol)
+      val app = appJs.as[raml.App]
+
+      val (body, _) = prepareApp(app, groupManager, validate = false)
+
+      When("The create request is made")
+      clock.advanceBy(5.seconds)
+      val response = asyncRequest { r =>
+        appsResource.create(body, force = false, auth.request, r)
+      }
+
+      withClue(response.getEntity.toString) {
+        Then("The return code indicates success")
+        response.getStatus should be(201)
+      }
+
+      And("the resulting app has the given volume name")
+      val appJson = Json.parse(response.getEntity.asInstanceOf[String])
+      (appJson \ "container" \ "volumes" \ 0 \ "external" \ "name") should be (JsDefined(JsString(volumeName)))
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -1906,7 +1906,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val (body, _) = prepareApp(app, groupManager, validate = false)
 
       When("The create request is made")
-      clock.advanceBy(5.seconds)
+      clock += (5.seconds)
       val response = asyncRequest { r =>
         appsResource.create(body, force = false, auth.request, r)
       }

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -14,7 +14,7 @@ class AppValidationTest extends UnitTest with ValidationTestLike with TableDrive
   val basicValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName)
   val withSecretsValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set("secrets"), () => config.defaultNetworkName)
   val withDefaultNetworkNameValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => configWithDefaultNetworkName.defaultNetworkName)
-  val withExternalVolValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(enabledFeatures = Set(Features.EXTERNAL_VOLUMES), defaultNetworkName = () => config.defaultNetworkName, validRoles = Set.empty[String])
+  val withExternalVolValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(enabledFeatures = Set(Features.EXTERNAL_VOLUMES), defaultNetworkName = () => config.defaultNetworkName)
 
   "File based secrets validation" when {
     "file based secret is used when secret feature is not enabled" should {

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/AppValidationTest.scala
@@ -14,6 +14,7 @@ class AppValidationTest extends UnitTest with ValidationTestLike with TableDrive
   val basicValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => config.defaultNetworkName)
   val withSecretsValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set("secrets"), () => config.defaultNetworkName)
   val withDefaultNetworkNameValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(Set.empty, () => configWithDefaultNetworkName.defaultNetworkName)
+  val withExternalVolValidator: Validator[App] = AppValidation.validateCanonicalAppAPI(enabledFeatures = Set(Features.EXTERNAL_VOLUMES), defaultNetworkName = () => config.defaultNetworkName, validRoles = Set.empty[String])
 
   "File based secrets validation" when {
     "file based secret is used when secret feature is not enabled" should {
@@ -163,6 +164,32 @@ class AppValidationTest extends UnitTest with ValidationTestLike with TableDrive
             hostPort = Option(0),
             networkNames = List("1"))), networkCount = 2)
         basicValidator(app) should be(aSuccess)
+      }
+    }
+
+    "external volume" should {
+
+      "consider an external volume with a complex name as valid" in {
+        val app = App(
+          id = "/foo",
+          cmd = Some("bar"),
+          container = Some(Container(
+            `type` = EngineType.Mesos,
+            docker = Some(DockerContainer(
+              image = "xyz")),
+            volumes = Seq(AppExternalVolume(
+              containerPath = "/some/path",
+              external = ExternalVolumeInfo(
+                provider = Some("dvdi"),
+                size = Some(1024),
+                name = Some("name=teamvolumename,secret_key=volume-secret-key-team,secure=true,size=5,repl=1,shared=true"),
+                options = Map("dvdi/driver" -> "pxd")
+              ),
+              mode = ReadMode.Rw
+            )))
+          ))
+
+        withExternalVolValidator(app) should be(aSuccess)
       }
     }
 

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
@@ -129,6 +129,29 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
       )
     }
 
+    "a volume with parameters in the name and result in no error" in {
+      val f = new Fixture
+      Given("a root group with two apps and conflicting volumes")
+      val app1 = f.appWithDVDIVolume(appId = AbsolutePathId("/nested/app1"), volumeName = "name=teamvolumename,secret_key=volume-secret-key-team,secure=true,size=5,repl=1,shared=true")
+      val rootGroup = createRootGroup(
+        groups = Set(
+          createGroup(
+            id = AbsolutePathId("/nested"),
+            apps = Map(
+              app1.id -> app1
+            ),
+            validate = false
+          )
+        ),
+        validate = false
+      )
+
+      f.checkResult(
+        rootGroup,
+        expectedViolations = Set.empty
+      )
+    }
+
     class Fixture {
       def appWithDVDIVolume(appId: PathId, volumeName: String, provider: String = DVDIProvider.name, shared: Boolean = false): AppDefinition = {
         AppDefinition(

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderRootGroupValidationTest.scala
@@ -132,11 +132,11 @@ class DVDIProviderRootGroupValidationTest extends UnitTest with GroupCreation {
     "a volume with parameters in the name and result in no error" in {
       val f = new Fixture
       Given("a root group with two apps and conflicting volumes")
-      val app1 = f.appWithDVDIVolume(appId = AbsolutePathId("/nested/app1"), volumeName = "name=teamvolumename,secret_key=volume-secret-key-team,secure=true,size=5,repl=1,shared=true")
+      val app1 = f.appWithDVDIVolume(appId = PathId("/nested/app1"), volumeName = "name=teamvolumename,secret_key=volume-secret-key-team,secure=true,size=5,repl=1,shared=true")
       val rootGroup = createRootGroup(
         groups = Set(
           createGroup(
-            id = AbsolutePathId("/nested"),
+            id = PathId("/nested"),
             apps = Map(
               app1.id -> app1
             ),

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderVolumeValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/DVDIProviderVolumeValidationTest.scala
@@ -177,6 +177,14 @@ class DVDIProviderVolumeValidationTest extends UnitTest {
             options = Map("dvdi/driver" -> "bar"
             )
           )
+        ),
+        ExternalVolume(
+          name = Some("name=teamvolumename,secret_key=volume-secret-key-team,secure=true,size=5,repl=1,shared=true"),
+          external = ExternalVolumeInfo(
+            size = None, name = "f", provider = "dvdi",
+            options = Map("dvdi/driver" -> "bar"
+            )
+          )
         )
       ),
       wantsValid = true


### PR DESCRIPTION
Backport of f9840b5bf (#7059)

86475dd (MARATHON-8681) was about to relax the external volume name validation in order to allow passing options via the volume name, which is required for some drivers to function as expected. However, an additional validation was missed, which is still in place. This issue is about removing that extra validation in order to fully support e.g. Encrypted Volumes with Portworx and UCR.

JIRA issues: MARATHON-8697
