### PR TITLE
Serialize apps with Jackson.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,8 +242,8 @@ lazy val marathon = (project in file("."))
       Package.ManifestAttributes("Implementation-Version" -> version.value ),
       Package.ManifestAttributes("Scala-Version" -> scalaVersion.value ),
       Package.ManifestAttributes("Git-Commit" -> git.gitHeadCommit.value.getOrElse("unknown") )
-    )//,
-    //javaOptions ++= Seq("-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:StartFlightRecording=duration=60s,filename=myrecording.jfr")
+    ),
+    javaOptions ++= Seq("-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:StartFlightRecording=delay=30s,duration=300s,filename=jackson_buffered.jfr")
   )
 
 lazy val ammonite = (project in file("./tools/repl-server"))

--- a/build.sbt
+++ b/build.sbt
@@ -242,8 +242,7 @@ lazy val marathon = (project in file("."))
       Package.ManifestAttributes("Implementation-Version" -> version.value ),
       Package.ManifestAttributes("Scala-Version" -> scalaVersion.value ),
       Package.ManifestAttributes("Git-Commit" -> git.gitHeadCommit.value.getOrElse("unknown") )
-    )//,
-//    javaOptions ++= Seq("-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:StartFlightRecording=delay=30s,duration=300s,filename=jackson_buffered.jfr")
+    )
   )
 
 lazy val ammonite = (project in file("./tools/repl-server"))

--- a/build.sbt
+++ b/build.sbt
@@ -242,8 +242,8 @@ lazy val marathon = (project in file("."))
       Package.ManifestAttributes("Implementation-Version" -> version.value ),
       Package.ManifestAttributes("Scala-Version" -> scalaVersion.value ),
       Package.ManifestAttributes("Git-Commit" -> git.gitHeadCommit.value.getOrElse("unknown") )
-    ),
-    javaOptions ++= Seq("-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:StartFlightRecording=delay=30s,duration=300s,filename=jackson_buffered.jfr")
+    )//,
+//    javaOptions ++= Seq("-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:StartFlightRecording=delay=30s,duration=300s,filename=jackson_buffered.jfr")
   )
 
 lazy val ammonite = (project in file("./tools/repl-server"))

--- a/build.sbt
+++ b/build.sbt
@@ -242,7 +242,8 @@ lazy val marathon = (project in file("."))
       Package.ManifestAttributes("Implementation-Version" -> version.value ),
       Package.ManifestAttributes("Scala-Version" -> scalaVersion.value ),
       Package.ManifestAttributes("Git-Commit" -> git.gitHeadCommit.value.getOrElse("unknown") )
-    )
+    )//,
+    //javaOptions ++= Seq("-XX:+UnlockCommercialFeatures", "-XX:+FlightRecorder", "-XX:StartFlightRecording=duration=60s,filename=myrecording.jfr")
   )
 
 lazy val ammonite = (project in file("./tools/repl-server"))

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -333,10 +333,6 @@ types:
         description: |
           The role to use. If not specified, uses the role of the enclosing group, or the default role.
           At the moment, only the default role or the group role are allowed
-  AppList:
-    type: object
-    properties:
-      apps: App[]
 
   VersionList:
     type: object
@@ -371,3 +367,8 @@ types:
       lastTaskFailure?: task.TaskFailure
       tasksStats?: task.TaskStatsByVersion
 
+  AppList:
+    type: object
+    (pragma.serializeOnly): # Used only for serialization
+    properties:
+      apps: AppInfo[]

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -333,6 +333,11 @@ types:
         description: |
           The role to use. If not specified, uses the role of the enclosing group, or the default role.
           At the moment, only the default role or the group role are allowed
+  AppList:
+    type: object
+    (pragma.serializeOnly): # Used only for serialization
+    properties:
+      apps: AppInfo[]
 
   VersionList:
     type: object
@@ -367,8 +372,3 @@ types:
       lastTaskFailure?: task.TaskFailure
       tasksStats?: task.TaskStatsByVersion
 
-  AppList:
-    type: object
-    (pragma.serializeOnly): # Used only for serialization
-    properties:
-      apps: AppInfo[]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,6 +70,7 @@ object Dependencies {
     jerseyCore % "compile",
     jerseyServer % "compile",
     jerseyServlet % "compile",
+    jacksonAfterBurner % "compile",
     jacksonScala % "compile",
     jacksonJaxrs % "compile",
 
@@ -169,6 +170,7 @@ object Dependency {
   val guice = "com.google.inject" % "guice" % V.Guice
   val jGraphT = "org.javabits.jgrapht" % "jgrapht-core" % V.JGraphT
   val jacksonJaxrs = "com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider" % V.Jackson
+  val jacksonAfterBurner = "com.fasterxml.jackson.module" % "jackson-module-afterburner" % V.Jackson
   val jacksonScala = "com.fasterxml.jackson.module" %% "jackson-module-scala" % V.Jackson
   val java8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % V.Java8Compat
 

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -15,7 +15,6 @@ import mesosphere.marathon.raml.RamlSerializer
 import mesosphere.marathon.state.{PathId, Timestamp}
 import org.apache.commons.io.output.ByteArrayOutputStream
 import play.api.libs.json.JsonValidationError
-import play.api.libs.json.Json.JsValueWrapper
 import play.api.libs.json._
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -84,7 +84,6 @@ trait RestResource extends JaxResource {
 
   // TODO: Remove when all APi models are in RAML.
   protected def jsonString[T](obj: T)(implicit writes: Writes[T]): String = Json.stringify(Json.toJson(obj))
-  protected def jsonObjString(fields: (String, JsValueWrapper)*): String = Json.stringify(Json.obj(fields: _*))
 
   /**
     * Checks if the implicit validator yields a valid result.

--- a/src/main/scala/mesosphere/marathon/api/SystemResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/SystemResource.scala
@@ -95,7 +95,7 @@ class SystemResource @Inject() (val config: MarathonConf, val metricsModule: Met
     async {
       implicit val identity = await(authenticatedAsync(req))
       withAuthorization(ViewResource, SystemConfig) {
-        ok(jsonString(Raml.toRaml(metricsModule.snapshot())), MediaType.APPLICATION_JSON_TYPE)
+        ok(Raml.toRaml(metricsModule.snapshot()), MediaType.APPLICATION_JSON_TYPE)
       }
     }
   }
@@ -123,9 +123,9 @@ class SystemResource @Inject() (val config: MarathonConf, val metricsModule: Met
       withAuthorization(ViewResource, SystemConfig) {
         LoggerFactory.getILoggerFactory match {
           case lc: LoggerContext =>
-            ok(lc.getLoggerList.map { logger =>
+            ok(jsonString(lc.getLoggerList.map { logger =>
               logger.getName -> Option(logger.getLevel).map(_.levelStr).getOrElse(logger.getEffectiveLevel.levelStr + " (inherited)")
-            }.toMap)
+            }.toMap))
         }
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppVersionsResource.scala
@@ -5,7 +5,6 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType}
-import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.AuthResource
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, ViewRunSpec}
@@ -34,7 +33,8 @@ class AppVersionsResource(
       implicit val identity = await(authenticatedAsync(req))
       val id = appId.toAbsolutePath
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { _ =>
-        ok(jsonObjString("versions" -> service.listAppVersions(id)))
+        val versions = raml.VersionList(service.listAppVersions(id).map(_.toOffsetDateTime))
+        ok(versions)
       }
     }
   }
@@ -51,7 +51,7 @@ class AppVersionsResource(
       val id = appId.toAbsolutePath
       val timestamp = Timestamp(version)
       withAuthorization(ViewRunSpec, service.getApp(id, timestamp), unknownApp(id, Some(timestamp))) { app =>
-        ok(jsonString(Raml.toRaml(app)))
+        ok(Raml.toRaml(app))
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -72,9 +72,8 @@ class AppsResource @Inject() (
   case class AppInfos(apps: Seq[raml.AppInfo])
   class AppInfoStream(apps: Seq[raml.AppInfo]) extends StreamingOutput {
     override def write(output: OutputStream): Unit = {
-      val writer = new BufferedWriter(new OutputStreamWriter(output))
-      RamlSerializer.serializer.writeValue(writer, AppInfos(apps))
-      writer.flush()
+      RamlSerializer.serializer.writeValue(output, AppInfos(apps))
+      output.flush()
     }
   }
 
@@ -94,10 +93,8 @@ class AppsResource @Inject() (
         AppInfo.Embed.Counts + AppInfo.Embed.Deployments
       val mapped = await(appInfoService.selectAppsBy(selector, resolvedEmbed))
 
-      println("+++ Send apps")
       val stream = new AppInfoStream(mapped)
       Response.ok(stream).build()
-      //      Response.ok(RamlSerializer.serializer.writeValueAsString(AppInfos(mapped))).build()
 
       //      Response.ok(jsonObjString("apps" -> mapped)).build()
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.{Context, MediaType, Response}
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.{AuthResource, PATCH, RestResource}
 import mesosphere.marathon.core.appinfo._
@@ -154,7 +155,7 @@ class AppsResource @Inject() (
             case Some(group) =>
               checkAuthorization(ViewGroup, group)
               val appsWithTasks = await(appInfoService.selectAppsInGroup(groupId, authzSelector, resolvedEmbed))
-              ok(jsonObjString("*" -> appsWithTasks))
+              Response.ok(new RestStreamingBody(Map("*" -> appsWithTasks))).build()
             case None =>
               unknownGroup(groupId)
           }
@@ -167,7 +168,7 @@ class AppsResource @Inject() (
           (appInfo, appDef) match {
             case (Some(info), Some(app)) =>
               checkAuthorization(ViewRunSpec, app)
-              ok(jsonObjString("app" -> info))
+              Response.ok(new RestStreamingBody(Map("app" -> info))).build()
             case _ => unknownApp(appId)
           }
       }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppsResource.scala
@@ -1,7 +1,7 @@
 package mesosphere.marathon
 package api.v2
 
-import java.io.{BufferedWriter, OutputStream, OutputStreamWriter}
+import java.io.{BufferedOutputStream, OutputStream}
 import java.net.URI
 import java.time.Clock
 
@@ -72,8 +72,9 @@ class AppsResource @Inject() (
   case class AppInfos(apps: Seq[raml.AppInfo])
   class AppInfoStream(apps: Seq[raml.AppInfo]) extends StreamingOutput {
     override def write(output: OutputStream): Unit = {
-      RamlSerializer.serializer.writeValue(output, AppInfos(apps))
-      output.flush()
+      val writer = new BufferedOutputStream(output)
+      RamlSerializer.serializer.writeValue(writer, AppInfos(apps))
+      writer.flush()
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/DeploymentsResource.scala
@@ -36,7 +36,7 @@ class DeploymentsResource @Inject() (
       implicit val identity = await(authenticatedAsync(req))
       val infos = await(service.listRunningDeployments())
         .filter(_.plan.affectedRunSpecs.exists(isAuthorized(ViewRunSpec, _)))
-      ok(infos)
+      ok(jsonString(infos))
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/GroupsResource.scala
@@ -13,7 +13,7 @@ import akka.stream.Materializer
 import mesosphere.marathon.api.v2.InfoEmbedResolver._
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.json.Formats._
-import mesosphere.marathon.api.{AuthResource, GroupApiService}
+import mesosphere.marathon.api.{AuthResource, GroupApiService, RestResource}
 import mesosphere.marathon.core.appinfo.{GroupInfoService, Selector}
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
@@ -102,7 +102,7 @@ class GroupsResource @Inject() (
 
       def versionsResponse(groupId: AbsolutePathId) = {
         withAuthorization(ViewGroup, groupManager.group(groupId), Future.successful(unknownGroup(groupId))) { _ =>
-          groupManager.versions(groupId).runWith(Sink.seq).map(versions => ok(versions))
+          groupManager.versions(groupId).runWith(Sink.seq).map(versions => Response.ok(new RestResource.RestStreamingBody(versions.map(_.toOffsetDateTime))).build())
         }
       }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/InfoResource.scala
@@ -97,17 +97,16 @@ class InfoResource @Inject() (
       val frameworkId = await(frameworkIdRepository.get()).map(_.id)
       withAuthorization(ViewResource, AuthorizedResource.SystemConfig) {
         val mesosLeaderUiUrl = Json.obj("mesos_leader_ui_url" -> mesosLeaderInfo.currentLeaderUrl)
-        Response.ok(
-          jsonObjString(
-            "name" -> BuildInfo.name,
-            "version" -> BuildInfo.version.toString(),
-            "buildref" -> BuildInfo.buildref,
-            "elected" -> electionService.isLeader,
-            "leader" -> electionService.leaderHostPort,
-            "frameworkId" -> frameworkId,
-            "marathon_config" -> (marathonConfigValues ++ mesosLeaderUiUrl),
-            "zookeeper_config" -> zookeeperConfigValues,
-            "http_config" -> httpConfigValues)).build()
+        Response.ok(Json.stringify(Json.obj(
+          "name" -> BuildInfo.name,
+          "version" -> BuildInfo.version.toString(),
+          "buildref" -> BuildInfo.buildref,
+          "elected" -> electionService.isLeader,
+          "leader" -> electionService.leaderHostPort,
+          "frameworkId" -> frameworkId,
+          "marathon_config" -> (marathonConfigValues ++ mesosLeaderUiUrl),
+          "zookeeper_config" -> zookeeperConfigValues,
+          "http_config" -> httpConfigValues))).build()
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -68,7 +68,7 @@ class LeaderResource @Inject() (
           electionService.abdicateLeadership()
         }
 
-        ok(jsonObjString("message" -> "Leadership abdicated"))
+        ok(raml.Error(message = "Leadership abdicated"))
       } else {
         notFound("There is no leader")
       }

--- a/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/LeaderResource.scala
@@ -42,8 +42,7 @@ class LeaderResource @Inject() (
       withAuthorization(ViewResource, AuthorizedResource.Leader) {
         electionService.leaderHostPort match {
           case None => notFound("There is no leader")
-          case Some(leader) =>
-            ok(jsonObjString("leader" -> leader))
+          case Some(leader) => ok(raml.LeaderInfo(leader))
         }
       }
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -15,6 +15,7 @@ import javax.ws.rs.container.{AsyncResponse, Suspended}
 import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.{Context, MediaType, Response}
 import mesosphere.marathon.Normalization._
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.api.v2.Validation.validateOrThrow
 import mesosphere.marathon.api.v2.validation.PodsValidation
 import mesosphere.marathon.api.{AuthResource, RestResource, TaskKiller}
@@ -57,10 +58,6 @@ class PodsResource @Inject() (
   // If we can normalize using the internal model, do that instead.
   // The version of the pod is changed here to make sure, the user has not send a version.
   private def normalize(pod: PodDefinition): PodDefinition = pod.copy(versionInfo = VersionInfo.OnlyVersion(clock.now()))
-
-  private def marshal(pod: Pod): String = Json.stringify(Json.toJson(pod))
-
-  private def marshal(pod: PodDefinition): String = marshal(Raml.toRaml(pod))
 
   private def unmarshal(bytes: Array[Byte]): Pod = {
     // no normalization or validation here, that happens elsewhere and in a precise order
@@ -108,7 +105,7 @@ class PodsResource @Inject() (
 
       Response.created(new URI(podDef.id.toString))
         .header(RestResource.DeploymentHeader, deployment.id)
-        .entity(marshal(podDef))
+        .entity(new RestStreamingBody[raml.Pod](Raml.toRaml(podDef)))
         .build()
     }
   }
@@ -149,7 +146,7 @@ class PodsResource @Inject() (
 
         val builder = Response
           .ok(new URI(podDef.id.toString))
-          .entity(marshal(podDef))
+          .entity(new RestStreamingBody(Raml.toRaml(podDef)))
           .header(RestResource.DeploymentHeader, deployment.id)
         builder.build()
       }
@@ -161,7 +158,7 @@ class PodsResource @Inject() (
     async {
       implicit val identity = await(authenticatedAsync(req))
       val pods = podSystem.findAll(isAuthorized(ViewRunSpec, _))
-      ok(Json.stringify(Json.toJson(pods.map(Raml.toRaml(_)))))
+      ok(pods.map(Raml.toRaml(_)))
     }
   }
 
@@ -178,7 +175,7 @@ class PodsResource @Inject() (
       withValid(id.toAbsolutePath) { id =>
         podSystem.find(id).fold(notFound(s"""{"message": "pod with $id does not exist"}""")) { pod =>
           withAuthorization(ViewRunSpec, pod) {
-            ok(marshal(pod))
+            ok(Raml.toRaml(pod))
           }
         }
       }
@@ -270,7 +267,7 @@ class PodsResource @Inject() (
         async {
           await(podSystem.version(id, version)).fold(notFound(id)) { pod =>
             withAuthorization(ViewRunSpec, pod) {
-              ok(marshal(pod))
+              ok(Raml.toRaml(pod))
             }
           }
         }

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -349,7 +349,7 @@ class PodsResource @Inject() (
         instances.filter(instance => instancesDesired.contains(instance.instanceId))
       }
       val instances = await(taskKiller.kill(id, toKill, wipe)).map { instance => Raml.toRaml(instance) }
-      ok(Json.toJson(instances))
+      ok(instances)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -83,9 +83,7 @@ class TasksResource @Inject() (
       }
 
       val enrichedTasks: Iterable[EnrichedTask] = await(futureEnrichedTasks)
-      ok(jsonObjString(
-        "tasks" -> enrichedTasks.toIndexedSeq.toRaml
-      ))
+      ok(raml.TaskList(enrichedTasks.toIndexedSeq.toRaml))
     }
   }
 
@@ -145,7 +143,7 @@ class TasksResource @Inject() (
             case (appId, instances) => taskKiller.kill(appId, _ => instances, wipe)
           })).flatten
         val killedTasks = killedInstances.flatMap { i => EnrichedTask.fromInstance(i).map(_.toRaml) }
-        ok(jsonObjString("tasks" -> killedTasks))
+        ok(raml.TaskList(killedTasks.to[Seq]))
       }
 
       val maybeInstances: Iterable[Option[Instance]] = await(Future.sequence(tasksIdToAppId.view

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -20,7 +20,6 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer, UpdateRunSpec, ViewRunSpec}
 import mesosphere.marathon.raml.AnyToRaml
-import mesosphere.marathon.raml.Task._
 import mesosphere.marathon.raml.TaskConversion._
 import mesosphere.marathon.state.{AbsolutePathId, PathId}
 import mesosphere.marathon.stream.Implicits._

--- a/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/json/Formats.scala
@@ -61,6 +61,7 @@ object Formats extends Formats {
 
     RamlSerializer.serializer.registerModule(jtm)
     RamlSerializer.serializer.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    RamlSerializer.serializer.disable(SerializationFeature.FLUSH_AFTER_WRITE_VALUE)
   }
 
 }

--- a/src/test/scala/mesosphere/UnitTest.scala
+++ b/src/test/scala/mesosphere/UnitTest.scala
@@ -9,7 +9,6 @@ import akka.testkit.{TestActor, TestActorRef, TestKitBase}
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
-import mesosphere.marathon.api.v2.json.Formats
 import mesosphere.marathon.test.Mockito
 import org.scalactic.source.Position
 import org.scalatest._

--- a/src/test/scala/mesosphere/UnitTest.scala
+++ b/src/test/scala/mesosphere/UnitTest.scala
@@ -9,6 +9,7 @@ import akka.testkit.{TestActor, TestActorRef, TestKitBase}
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.api.v2.json.Formats
 import mesosphere.marathon.test.Mockito
 import org.scalactic.source.Position
 import org.scalatest._

--- a/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/SystemResourceTest.scala
@@ -5,6 +5,7 @@ import akka.actor.ActorSystem
 import ch.qos.logback.classic.{Level, Logger}
 import javax.ws.rs.core.{MediaType, Request, Variant}
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.test.JerseyTest
 import org.slf4j.LoggerFactory
 import org.mockito.Matchers
@@ -101,7 +102,7 @@ class SystemResourceTest extends AkkaUnitTest with JerseyTest {
       response.getStatus shouldBe 200
       Option(response.getMetadata.getFirst("Content-Type")).value.toString should be("application/json")
 
-      val metricsJson = Json.parse(response.getEntity.asInstanceOf[String])
+      val metricsJson = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
       metricsJson \ "version" shouldBe a[JsDefined]
       metricsJson \ "counters" shouldBe a[JsDefined]
       metricsJson \ "gauges" shouldBe a[JsDefined]

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -6,6 +6,7 @@ import java.util
 import javax.ws.rs.core.Response
 import akka.Done
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.api._
 import mesosphere.marathon.api.v2.validation.NetworkValidationMessages
 import mesosphere.marathon.core.appinfo.AppInfo.Embed
@@ -15,30 +16,7 @@ import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.plugin.PluginManager
 import mesosphere.marathon.core.pod.ContainerNetwork
 import mesosphere.marathon.plugin.auth.{Authenticator, Authorizer}
-import mesosphere.marathon.raml.{
-  App,
-  AppPersistentVolume,
-  AppSecretVolume,
-  AppUpdate,
-  ContainerPortMapping,
-  DockerContainer,
-  DockerNetwork,
-  DockerPullConfig,
-  EngineType,
-  EnvVarSecret,
-  EnvVarValueOrSecret,
-  IpAddress,
-  IpDiscovery,
-  IpDiscoveryPort,
-  LinuxInfo,
-  Network,
-  NetworkMode,
-  Raml,
-  ReadMode,
-  Seccomp,
-  SecretDef,
-  Container => RamlContainer
-}
+import mesosphere.marathon.raml.{App, AppPersistentVolume, AppSecretVolume, AppUpdate, ContainerPortMapping, DockerContainer, DockerNetwork, DockerPullConfig, EngineType, EnvVarSecret, EnvVarValueOrSecret, IpAddress, IpDiscovery, IpDiscoveryPort, LinuxInfo, Network, NetworkMode, Raml, ReadMode, Seccomp, SecretDef, Container => RamlContainer}
 import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.GroupRepository
@@ -234,7 +212,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
           tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
           deployments = Some(Seq(raml.Identifiable(plan.id)))
         )
-        JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+        JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
       }
       if (!result.isSuccess) {
         result.failed.foreach {
@@ -266,7 +244,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       Try(prepareApp(app, groupManager))
 
       Then("It is successful")
-      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[String]}")
+      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[RestStreamingBody[_]].toString}")
     }
 
     "Creating a new app with w/ Docker containerizer and a Docker config.json should fail" in new Fixture(configArgs = Seq("--enable_features", "secrets")) {
@@ -614,7 +592,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       Then("It is successful")
-      assert(response.getStatus == 201, s"body = ${new String(body)}, response = ${response.getEntity.asInstanceOf[String]}")
+      assert(response.getStatus == 201, s"body = ${new String(body)}, response = ${response.getEntity.asInstanceOf[RestStreamingBody[_]].toString}")
       response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
 
       And("the JSON is as expected, including a newly generated version")
@@ -624,7 +602,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app with IP/CT on virtual network foo w/ MESOS container spec" in new Fixture {
@@ -654,7 +632,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app with IP/CT on virtual network foo, then update it to bar" in new Fixture {
@@ -719,7 +697,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       Then("It is successful")
-      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[String]}")
+      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[RestStreamingBody[_]].toString}")
       response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
 
       And("the JSON is as expected, including a newly generated version")
@@ -729,7 +707,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app with IP/CT when default virtual network is bar, Alice did not specify network name" in new Fixture(configArgs = Seq("--default_network_name", "bar")) {
@@ -763,7 +741,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app with IP/CT when default virtual network is bar, but Alice specified foo" in new Fixture(configArgs = Seq("--default_network_name", "bar")) {
@@ -793,7 +771,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app with IP/CT with virtual network foo w/ Docker" in new Fixture {
@@ -832,7 +810,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app in BRIDGE mode w/ Docker" in new Fixture {
@@ -885,7 +863,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app in USER mode w/ ipAddress.discoveryInfo w/ Docker" in new Fixture {
@@ -977,7 +955,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app (that uses undefined secret ref) and fails" in new Fixture(configArgs = Seq("--enable_features", Features.SECRETS)) {
@@ -1026,7 +1004,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "The secrets feature is NOT enabled and create app (that uses secret refs) fails" in new Fixture(configArgs = Seq()) {
@@ -1133,7 +1111,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       Then("It is successful")
-      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[String]}")
+      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[RestStreamingBody[_]].toString}")
 
       And("the JSON is as expected, including a newly generated version")
       val expected = raml.AppInfo.fromParent(
@@ -1142,7 +1120,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
         tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
         deployments = Some(Seq(raml.Identifiable(plan.id)))
       )
-      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+      JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
     }
 
     "Create a new app fails with Validation errors" in new Fixture {
@@ -1390,7 +1368,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       )
 
       Then("The return code indicates create success")
-      assert(response.getStatus == 201, s"response=${response.getEntity.asInstanceOf[String]}")
+      assert(response.getStatus == 201, s"response=${response.getEntity.asInstanceOf[RestStreamingBody[_]].toString}")
       response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
     }
 
@@ -1665,7 +1643,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val response = asyncRequest { r => appsResource.index(null, null, null, new java.util.HashSet(), auth.request, r) }
 
       Then("The response holds counts and deployments")
-      val appJson = Json.parse(response.getEntity.asInstanceOf[String])
+      val appJson = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
       (appJson \ "apps" \\ "deployments" head) should be(Json.arr(Json.obj("id" -> "deployment-123")))
       (appJson \ "apps" \\ "tasksStaged" head) should be(JsNumber(1))
     }
@@ -1686,7 +1664,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       val response = asyncRequest { r => appsResource.index(null, null, null, embeds, auth.request, r) }
 
       Then("The response holds counts and task failure")
-      val appJson = Json.parse(response.getEntity.asInstanceOf[String])
+      val appJson = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
       ((appJson \ "apps" \\ "lastTaskFailure" head) \ "state") should be(JsDefined(JsString("TASK_STAGING")))
       (appJson \ "apps" \\ "tasksStaged" head) should be(JsNumber(1))
     }
@@ -1936,7 +1914,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
 
       Then("The response has no error and it is valid")
       response.getStatus should be(201)
-      val appJson = Json.parse(response.getEntity.asInstanceOf[String])
+      val appJson = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
       // TODO: are we violating appInfo here?
       (appJson \ "fetch" \ 0 \ "uri" get) should be (JsString("file:///bin/bash"))
       (appJson \ "fetch" \ 0 \ "extract" get) should be(JsBoolean(false))
@@ -1963,7 +1941,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       Then("It is successful")
-      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[String]}")
+      assert(response.getStatus == 201, s"body=${new String(body)}, response=${response.getEntity.asInstanceOf[RestStreamingBody[_]].toString}")
     }
 
     "Allow editing a env configuration without sending secrets" in new Fixture(configArgs = Seq("--enable_features", "secrets")) {
@@ -2028,7 +2006,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
           tasksStaged = Some(0), tasksRunning = Some(0), tasksUnhealthy = Some(0), tasksHealthy = Some(0),
           deployments = Some(Seq(raml.Identifiable(plan.id)))
         )
-        JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[String]).correspondsToJsonOf(expected)
+        JsonTestHelper.assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).correspondsToJsonOf(expected)
       }
       if (!result.isSuccess) {
         result.failed.foreach {
@@ -2289,7 +2267,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       And("resulting app has acceptedResourceRoles sanitized (equals default one)")
-      val appJson = Json.parse(response.getEntity.asInstanceOf[String])
+      val appJson = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[raml.AppInfo]].toString)
       (appJson \ "acceptedResourceRoles" \ 0) should be (JsDefined(JsString(ResourceRole.Unreserved)))
     }
 
@@ -2431,7 +2409,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
 
       And("the resulting app has the given volume name")
-      val appJson = Json.parse(response.getEntity.asInstanceOf[String])
+      val appJson = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
       (appJson \ "container" \ "volumes" \ 0 \ "external" \ "name") should be (JsDefined(JsString(volumeName)))
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -6,6 +6,7 @@ import java.util.Collections
 
 import akka.stream.scaladsl.Source
 import mesosphere.AkkaUnitTest
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.api.v2.json.Formats._
 import mesosphere.marathon.api.{GroupApiService, TestAuthFixture, TestGroupManagerFixture}
 import mesosphere.marathon.core.appinfo._
@@ -264,7 +265,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
 
       Then("The versions are send as simple json array")
       rootVersionsResponse.getStatus should be (200)
-      rootVersionsResponse.getEntity should be(Json.toJson(groupVersions).toString())
+      rootVersionsResponse.getEntity.toString should be(Json.toJson(groupVersions).toString())
     }
 
     "Group Versions for path are transferred as simple json string array (Fix #2329)" in new Fixture {
@@ -279,7 +280,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
 
       Then("The versions are send as simple json array")
       rootVersionsResponse.getStatus should be (200)
-      rootVersionsResponse.getEntity should be(Json.toJson(groupVersions).toString())
+      rootVersionsResponse.getEntity.asInstanceOf[RestStreamingBody[_]].toString should be(Json.toJson(groupVersions).toString())
     }
 
     "Creation of a group with same path as an existing app should be prohibited (fixes #3385)" in new FixtureWithRealGroupManager(

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -9,6 +9,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.api.RestResource.RestStreamingBody
+import mesosphere.marathon.api.v2.json.Formats
 import mesosphere.marathon.api.v2.json.Formats.TimestampFormat
 import mesosphere.marathon.api.v2.validation.NetworkValidationMessages
 import mesosphere.marathon.api.{JsonTestHelper, RestResource, TaskKiller, TestAuthFixture}
@@ -34,6 +35,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
+
+  Formats.configureJacksonSerializer()
 
   // TODO(jdef) incorporate checks for firing pod events on C, U, D operations
 
@@ -136,7 +139,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
 
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should be (defined)
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
@@ -163,7 +166,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
 
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should be (defined)
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
@@ -237,7 +240,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(201)
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should be (defined)
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
@@ -258,7 +261,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(201)
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should be (defined)
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
@@ -280,7 +283,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
 
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should be (defined)
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
@@ -320,7 +323,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
 
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should be (defined)
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
@@ -355,7 +358,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
 
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should not be None
         parsedResponse.map(_.as[Pod]) should not be None // validate that we DID get back a pod definition
 
@@ -383,7 +386,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
 
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString).map(Json.parse)
         parsedResponse should not be None
         val podOption = parsedResponse.map(_.as[Pod])
         podOption should not be None // validate that we DID get back a pod definition
@@ -424,7 +427,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
 
-        val jsonResponse = Json.parse(response.getEntity.asInstanceOf[String])
+        val jsonResponse = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
         val pod = jsonResponse.as[Pod]
         val volumeInfo = PersistentVolumeInfo(`type` = Some(PersistentVolumeType.Root), size = 10)
         val volume = PodPersistentVolume(name = "pst", persistent = volumeInfo)
@@ -683,7 +686,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_OK)
 
-        val jsonBody = Json.parse(response.getEntity.asInstanceOf[String])
+        val jsonBody = Json.parse(response.getEntity.toString)
         jsonBody.asInstanceOf[JsArray].value.size shouldEqual 2
       }
     }
@@ -766,7 +769,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       withClue(s"response body: ${response.getEntity}") {
         response.getStatus should be(HttpServletResponse.SC_CREATED)
 
-        val parsedResponse = Option(response.getEntity.asInstanceOf[String]).map(Json.parse)
+        val parsedResponse = Option(response.getEntity.toString).map(Json.parse)
         parsedResponse should be (defined)
         val maybePod = parsedResponse.map(_.as[Pod])
         maybePod should be (defined) // validate that we DID get back a pod definition
@@ -907,7 +910,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
         withClue(s"response body: ${response.getEntity}") {
           response.getStatus should be(201)
-          val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.asInstanceOf[String])).get)
+          val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.toString)).get)
           pod.role should be(ResourceRole.Unreserved)
         }
       }
@@ -943,7 +946,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
         withClue(s"response body: ${response.getEntity}") {
           response.getStatus should be(201)
-          val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.asInstanceOf[String])).get)
+          val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.toString)).get)
           pod.role should be("customMesosRole")
         }
       }
@@ -980,7 +983,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
         withClue(s"response body: ${response.getEntity}") {
           response.getStatus should be(201)
-          val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.asInstanceOf[String])).get)
+          val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.toString)).get)
           pod.role should be("customMesosRole")
         }
       }
@@ -1054,7 +1057,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
 
         withClue(s"response body: ${response.getEntity}") {
           response.getStatus should be(201)
-          val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.asInstanceOf[String])).get)
+          val pod = Raml.fromRaml(Json.fromJson[raml.Pod](Json.parse(response.getEntity.toString)).get)
           pod.role should be(ResourceRole.Unreserved)
         }
       }
@@ -1866,9 +1869,9 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
           val f = Fixture()
 
           val response = asyncRequest { r => f.podsResource.version("/id", pod1.version.toString, f.auth.request, r) }
-          withClue(s"reponse body: ${response.getEntity}") {
+          withClue(s"response body: ${response.getEntity}") {
             response.getStatus should be(HttpServletResponse.SC_OK)
-            val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.asInstanceOf[String])).get)
+            val pod = Raml.fromRaml(Json.fromJson[Pod](Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)).get)
             pod should equal(pod1)
           }
         }

--- a/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/QueueResourceTest.scala
@@ -2,6 +2,7 @@ package mesosphere.marathon
 package api.v2
 
 import mesosphere.UnitTest
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.api.TestAuthFixture
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.instance.Instance
@@ -17,6 +18,7 @@ import mesosphere.marathon.test.{JerseyTest, MarathonTestHelper, SettableClock}
 import mesosphere.mesos.NoOfferMatchReason
 import org.mockito.Matchers
 import play.api.libs.json._
+
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -77,7 +79,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
 
       //then
       response.getStatus should be(200)
-      val json = Json.parse(response.getEntity.asInstanceOf[String])
+      val json = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
       val queuedApps = (json \ "queue").as[Seq[JsObject]]
       val jsonApp1 = queuedApps.find { apps => (apps \ "app" \ "id").as[String] == "/app" }.get
 
@@ -115,7 +117,7 @@ class QueueResourceTest extends UnitTest with JerseyTest {
 
       //then
       response.getStatus should be(200)
-      val json = Json.parse(response.getEntity.asInstanceOf[String])
+      val json = Json.parse(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
       val queuedApps = (json \ "queue").as[Seq[JsObject]]
       val jsonApp1 = queuedApps.find { apps => (apps \ "app" \ "id").get == JsString("/app") }.get
 

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -4,6 +4,7 @@ package api.v2
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.api.{JsonTestHelper, TaskKiller, TestAuthFixture}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
@@ -125,7 +126,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
            |}
         """.stripMargin
       JsonTestHelper
-        .assertThatJsonString(response.getEntity.asInstanceOf[String])
+        .assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
         .correspondsToJsonString(expected)
     }
 
@@ -192,7 +193,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
           |  }
           |}""".stripMargin
       JsonTestHelper
-        .assertThatJsonString(response.getEntity.asInstanceOf[String])
+        .assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
         .correspondsToJsonString(expected)
       verify(taskKiller).kill(equalTo(appId), any, any)(any)
       verifyNoMoreInteractions(taskKiller)
@@ -251,7 +252,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
            |  }
            |}""".stripMargin
       JsonTestHelper
-        .assertThatJsonString(response.getEntity.asInstanceOf[String])
+        .assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
         .correspondsToJsonString(expected)
       verify(taskKiller).kill(equalTo(appId), any, org.mockito.Matchers.eq(true))(any)
       verifyNoMoreInteractions(taskKiller)
@@ -309,7 +310,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
         """.stripMargin
 
       JsonTestHelper
-        .assertThatJsonString(response.getEntity.asInstanceOf[String])
+        .assertThatJsonString(response.getEntity.asInstanceOf[RestStreamingBody[_]].toString)
         .correspondsToJsonString(expected)
     }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -6,6 +6,7 @@ import java.util.Collections
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
+import mesosphere.marathon.api.RestResource.RestStreamingBody
 import mesosphere.marathon.api.{RestResource, TaskKiller, TestAuthFixture}
 import mesosphere.marathon.test.JerseyTest
 
@@ -119,7 +120,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       response.getStatus shouldEqual 200
 
       And("The response is the list of killed tasks")
-      response.getEntity shouldEqual """{"tasks":[]}"""
+      response.getEntity.asInstanceOf[RestStreamingBody[_]].toString shouldEqual """{"tasks":[]}"""
 
       And("Both tasks should be requested to be killed")
       verify(taskKiller).kill(Matchers.eq(app1), any, any)(any)
@@ -187,7 +188,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       response.getMetadata.containsKey(RestResource.DeploymentHeader) should be(true)
 
       And("Should create a deployment")
-      response.getEntity shouldEqual """{"version":"1970-01-01T00:00:00.000Z","deploymentId":"plan"}"""
+      response.getEntity.asInstanceOf[RestStreamingBody[_]].toString shouldEqual """{"deploymentId":"plan","version":"1970-01-01T00:00:00.000Z"}"""
 
       And("app1 and app2 is killed with force")
       verify(taskKiller).killAndScale(Matchers.eq(Map(app1 -> Seq(instance1), app2 -> Seq(instance2))), Matchers.eq(true))(any)

--- a/tests/performance/apps.py
+++ b/tests/performance/apps.py
@@ -1,0 +1,16 @@
+import requests 
+import json
+
+def generate_apps():
+    apps = [{'id': '/app-{}'.format(i), 'cmd': 'sleep 3600', 'cpus': 0.1, 'mem': 32, 'instances': 0} for i in range(1000)]
+    groups = {'id': '/', 'groups': [], 'apps': apps}
+    return groups
+
+def main():
+    apps = generate_apps()
+    r = requests.put("http://localhost:8080/v2/groups?force=true", json=apps)
+    print(r.text)
+    r.raise_for_status()
+
+if __name__ == "__main__":
+    main()

--- a/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
@@ -374,6 +374,7 @@ object RamlTypeGenerator {
     BLOCK(
       IMPORT("com.fasterxml.jackson.databind.ObjectMapper"),
       IMPORT("com.fasterxml.jackson.databind.module.SimpleModule"),
+      IMPORT("com.fasterxml.jackson.module.afterburner.AfterburnerModule"),
       IMPORT("com.fasterxml.jackson.module.scala.DefaultScalaModule"),
       IMPORT("com.fasterxml.jackson.databind.ser.std.StdSerializer"),
 
@@ -402,7 +403,8 @@ object RamlTypeGenerator {
             } ++
 
             Seq(REF("mapper") DOT "registerModule" APPLY REF("module")) ++
-            Seq(REF("mapper") DOT "registerModule" APPLY REF("DefaultScalaModule"))
+            Seq(REF("mapper") DOT "registerModule" APPLY REF("DefaultScalaModule")) ++
+            Seq(REF("mapper") DOT "registerModule" APPLY NEW("AfterburnerModule"))
 
         ).withComment("ObjectMapper is thread safe, we have a single shared instance here")
       )

--- a/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/ObjectVisitor.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/ObjectVisitor.scala
@@ -281,6 +281,9 @@ object ObjectVisitor {
           } else {
             writerSimple
           }
+        } ++ discriminator.toSeq.map { discriminatorName =>
+          // If the object has a discriminator field such as "kind" it is added.
+          REF("gen") DOT "writeObjectField" APPLY( LIT(discriminatorName), LIT(discriminatorValue.getOrElse(discriminatorName)) )
         }
       ),
       DEF("serialize", UnitClass) withFlags Flags.OVERRIDE withParams(


### PR DESCRIPTION
Summary:
This patch introduces serialization via Jackson to improve throughput by
roughly 50% and reduce GC cycles by 50%.

You can create one thousand apps via `python tests/performance/apps.py`.
It will not deploy any instances.

Benchmark results on `master`:
```
❯ wrk -c 10 -t 10 -d 5m "http://localhost:8080/v2/apps"
Running 5m test @ http://localhost:8080/v2/apps
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   117.50ms   31.52ms   1.00s    88.04%
    Req/Sec     8.73      2.42    20.00     82.29%
  25705 requests in 5.00m, 17.49GB read
Requests/sec:     85.66
Transfer/sec:     59.67MB
```

Results for this patch
```
❯ wrk -c 10 -t 10 -d 5m "http://localhost:8080/v2/apps"
Running 5m test @ http://localhost:8080/v2/apps
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    81.86ms   16.89ms 631.05ms   88.96%
    Req/Sec    12.06      4.41    20.00     74.97%
  36801 requests in 5.00m, 25.31GB read
Requests/sec:    122.65
Transfer/sec:     86.38MB
```

JIRA issues: MARATHON-8567
