### PR TITLE
Verify Docker is running.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -168,7 +168,8 @@ def provisionHost(): Unit = utils.stage("Provision") {
   // Set port range for random port 0 allocation.
   %('sudo, "ci/set_port_range.sh")
 
-  // Make sure Docker daemon is running.
+  // First call to `docker --version` can take up to 30s. This sometimes leads to Mesos agent
+  // failing to start when checking for the docker version. So we do it here (successive calls will be faster).
   %('sudo, "docker", "--version")
 
   provision.killStaleTestProcesses()

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -168,6 +168,9 @@ def provisionHost(): Unit = utils.stage("Provision") {
   // Set port range for random port 0 allocation.
   %('sudo, "ci/set_port_range.sh")
 
+  // Make sure Docker daemon is running.
+  %('sudo, "docker", "--version")
+
   provision.killStaleTestProcesses()
   provision.installMesos()
   provision.installDcosCli()

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
@@ -10,6 +10,7 @@ import akka.actor.{ActorSystem, Scheduler}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.stream.Materializer
+import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.integration.facades.MesosFacade
 import mesosphere.marathon.state.FaultDomain
 import mesosphere.marathon.util.{Retry, ZookeeperServerTest}
@@ -58,7 +59,7 @@ case class MesosCluster(
     system: ActorSystem,
     mat: Materializer,
     ctx: ExecutionContext,
-    scheduler: Scheduler) extends AutoCloseable with Eventually {
+    scheduler: Scheduler) extends AutoCloseable with Eventually with StrictLogging {
 
   lazy val masters = 0.until(config.numMasters).map { i =>
     val faultDomainJson = if (config.mastersFaultDomains.nonEmpty && config.mastersFaultDomains(i).nonEmpty) {
@@ -145,6 +146,7 @@ case class MesosCluster(
 
   def waitForLeader(): Future[String] = async {
     val firstMaster = s"http://${masters.head.ip}:${masters.head.port}"
+    logger.info(s"Waiting for Mesos leader at $firstMaster")
     val result = Retry("wait for leader", maxAttempts = Int.MaxValue, maxDuration = waitForMesosTimeout) {
       Http().singleRequest(Get(firstMaster + "/redirect")).map { result =>
         result.discardEntityBytes() // forget about the body
@@ -169,6 +171,7 @@ case class MesosCluster(
   }
 
   def waitForAgents(masterUri: String): Future[Done] = {
+    logger.info(s"Waiting for all ${agents.size} Mesos agents to come online for $masterUri")
     val mesosFacade = new MesosFacade(masterUri)
     Retry.blocking("wait for agents", maxAttempts = Int.MaxValue, maxDuration = waitForMesosTimeout) {
       val numAgents = mesosFacade.state.value.agents.size
@@ -372,7 +375,7 @@ trait MesosClusterTest extends Suite with ZookeeperServerTest with MesosTest wit
     mesosMasterUrl,
     autoStart = false,
     config = mesosConfig,
-    waitForMesosTimeout = patienceConfig.timeout.toMillis.milliseconds
+    waitForMesosTimeout = patienceConfig.timeout.toMillis.milliseconds - 10.seconds
   )
   lazy val mesos = new MesosFacade(localMesosUrl.getOrElse(mesosCluster.waitForLeader().futureValue))
 


### PR DESCRIPTION
Summary:
The `SharedMemoryIntegrationTest` fails to start the Mesos cluster from time to time. The Mesos
agent fails with

```
EXIT with status 1: Failed to create a containerizer: Could not create DockerContainerizer: Failed to create docker: Timed out getting docker version
```

We call `docker --version` to make sure the Docker daemon is running.