### PR TITLE
Extract two interfaces from groupManager

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/LauncherModule.scala
@@ -21,7 +21,7 @@ class LauncherModule(
     marathonSchedulerDriverHolder: MarathonSchedulerDriverHolder,
     offerMatcher: OfferMatcher,
     pluginManager: PluginManager,
-    rootGroupRetriever: GroupManager.CurrentRootGroupRetriever)(implicit clock: Clock) {
+    enforceRoleSettingProvider: GroupManager.EnforceRoleSettingProvider)(implicit clock: Clock) {
 
   lazy val offerProcessor: OfferProcessor =
     new OfferProcessorImpl(
@@ -33,5 +33,5 @@ class LauncherModule(
     metrics,
     marathonSchedulerDriverHolder)
 
-  lazy val taskOpFactory: InstanceOpFactory = new InstanceOpFactoryImpl(metrics, conf, pluginManager, rootGroupRetriever)
+  lazy val taskOpFactory: InstanceOpFactory = new InstanceOpFactoryImpl(metrics, conf, pluginManager, enforceRoleSettingProvider)
 }

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -31,7 +31,7 @@ class InstanceOpFactoryImpl(
     metrics: Metrics,
     config: MarathonConf,
     pluginManager: PluginManager = PluginManager.None,
-    rootGroupRetriever: GroupManager.CurrentRootGroupRetriever)(implicit clock: Clock)
+    enforceRoleProvider: GroupManager.EnforceRoleSettingProvider)(implicit clock: Clock)
   extends InstanceOpFactory with StrictLogging {
 
   private[this] val instanceOperationFactory = {
@@ -334,14 +334,10 @@ class InstanceOpFactoryImpl(
 
   private def getEnforceRole(pathId: AbsolutePathId): Boolean = {
     val topLevelPath = pathId.rootPath
-    val topLevelGroup = if (topLevelPath.isEmpty)
-      None
+    if (topLevelPath.isEmpty)
+      false
     else
-      rootGroupRetriever.rootGroup().group(topLevelPath)
-
-    topLevelGroup
-      .map { _.enforceRole }
-      .getOrElse(false)
+      enforceRoleProvider.enforceRoleSetting(topLevelPath)
   }
 
   private[this] def reserveAndCreateVolumes(

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -37,7 +37,7 @@ class LaunchQueueModule(
     subOfferMatcherManager: OfferMatcherManager,
     instanceTracker: InstanceTracker,
     taskOpFactory: InstanceOpFactory,
-    groupManager: GroupManager,
+    runSpecProvider: GroupManager.RunSpecProvider,
     localRegion: () => Option[Region],
     initialFrameworkInfo: Future[FrameworkInfo])(implicit materializer: Materializer, ec: ExecutionContext) {
 
@@ -74,14 +74,14 @@ class LaunchQueueModule(
         rateLimiterActor,
         offerMatchStatisticsInput,
         localRegion)(runSpec.id)
-    val props = LaunchQueueActor.props(config, instanceTracker, groupManager, runSpecActorProps, rateLimiterUpdates)
+    val props = LaunchQueueActor.props(config, instanceTracker, runSpecProvider, runSpecActorProps, rateLimiterUpdates)
     leadershipModule.startWhenLeader(props, "launchQueue")
   }
 
   val launchQueue: LaunchQueue = new LaunchQueueDelegate(config, launchQueueActor, rateLimiterActor)
 
   val launchStats = LaunchStats(
-    groupManager,
+    runSpecProvider,
     clock,
     instanceTracker.instanceUpdates,
     rateLimiterUpdates,

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchStats.scala
@@ -117,7 +117,7 @@ object LaunchStats extends StrictLogging {
     * Given a source of instance updates, delay updates, and offer match statistics updates, materialize the streams and
     * aggregate the resulting data to produce the data returned by /v2/queue
     *
-    * @param groupManager
+    * @param runSpecProvider
     * @param clock
     * @param instanceUpdates InstanceTracker state subscription stream.
     * @param delayUpdates RateLimiter state subscription stream.
@@ -126,7 +126,7 @@ object LaunchStats extends StrictLogging {
     * @return LaunchStats instance used to query the current aggregate match state
     */
   def apply(
-    groupManager: GroupManager,
+    runSpecProvider: GroupManager.RunSpecProvider,
     clock: Clock,
     instanceUpdates: Source[(InstancesSnapshot, Source[InstanceChange, NotUsed]), NotUsed],
     delayUpdates: Source[RateLimiter.DelayUpdate, NotUsed],
@@ -147,7 +147,7 @@ object LaunchStats extends StrictLogging {
         .alsoToMat(OfferMatchStatistics.runSpecStatisticsSink)(Keep.right)
         .toMat(OfferMatchStatistics.noMatchStatisticsSink)(Keep.both)
         .run
-    new LaunchStats(groupManager.runSpec, delays, launchingInstances, runSpecStatistics, noMatchStatistics)
+    new LaunchStats(runSpecProvider.runSpec, delays, launchingInstances, runSpecStatistics, noMatchStatistics)
   }
 
   /**

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -268,10 +268,11 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
     implicit val clock = new SettableClock()
     val metrics: Metrics = DummyMetrics
     var rootGroup = RootGroup.empty()
-    val rootGroupRetriever: GroupManager.CurrentRootGroupRetriever = new GroupManager.CurrentRootGroupRetriever {
-      override def rootGroup(): RootGroup = Fixture.this.rootGroup
+    val enforceRoleSettingProvider: GroupManager.EnforceRoleSettingProvider = new GroupManager.EnforceRoleSettingProvider {
+      override def enforceRoleSetting(id: AbsolutePathId): Boolean = rootGroup.group(id).exists(_.enforceRole)
     }
-    val instanceOpFactory: InstanceOpFactory = new InstanceOpFactoryImpl(metrics, config, rootGroupRetriever = rootGroupRetriever)
+
+    val instanceOpFactory: InstanceOpFactory = new InstanceOpFactoryImpl(metrics, config, enforceRoleProvider = enforceRoleSettingProvider)
     val defaultHostName = AgentTestDefaults.defaultHostName
     val defaultAgentId = AgentTestDefaults.defaultAgentId
 


### PR DESCRIPTION
Without this, we'd have to implement the full GroupManager in Metronome, although it is not really required for the imported modules