### PR TITLE
Enable Marathon logs in integration tests again.

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -14,8 +14,8 @@
     <logger name="native-zk-connector" level="WARN" />
     <logger name="org.eclipse" level="INFO"/>
     <logger name="org.apache.zookeeper" level="WARN" />
-
     <logger name="spray" level="ERROR"/>
+
     <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -115,7 +115,7 @@ trait BaseMarathon extends AutoCloseable with StrictLogging with ScalaFutures {
 
   def create(): Process = {
     marathonProcess.getOrElse {
-      val process = processBuilder.run(ProcessOutputToLogStream(s"$suiteName-LocalMarathon-$httpPort"))
+      val process = processBuilder.run(ProcessOutputToLogStream(s"mesosphere.marathon.integration.process.$suiteName-LocalMarathon-$httpPort"))
       marathonProcess = Some(process)
       process
     }


### PR DESCRIPTION
Summary:
The USI `ProcessOutputToLogStream` logs any output to the debug output
of the integration tests. However, the `logback-test` would not show
debug logs onless the logger is for package `mesosphere.marathon.integration.process`.