### PR TITLE
Add a changelog entry informing about instanceIds being stable.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -181,7 +181,7 @@ when Marathon fails to clean up reservation which requires offers being sent.
 
 ### Aligning Ephemeral with Stateful Task Handling
 
-Marathon 1.8 introduces handling ephemeral instances similar to how it handled stateful instances since version 1.0. Until now, Marathon expunged instances once all of their tasks ended up in a terminal state, and eventually launched replacements as a result of those instances being expunged. Instances will now only be expunged from the state when their goal is to be Decommissioned and all their tasks are in a terminal state. If their goal is still Running, they will be considered to be scheduled and used to launch replacement tasks. This change not only merges two previously different code paths; this also simplifies debugging since users will be able to follow the task incarnations for a given instance throughout Marathons logs.
+Marathon 1.8 introduces handling ephemeral instances similar to how it handled stateful instances since version 1.0. Until now, Marathon expunged ephemeral instances once all of their tasks ended up in a terminal state, and eventually launched replacements as a result of those instances being expunged. Instances will now only be expunged from the state once their goal is set to `Decommissioned` and all their tasks are in a terminal state. If their goal is still `Running`, they will be considered for scheduling and used to launch replacement tasks. This change not only merges two previously different code paths; this also simplifies debugging since users will be able to follow the task incarnations for a given instance throughout Marathons logs.
 
 This means that instance Ids are now stable for as long as an instance shall be kept running. New instances will be created only when replacing unreachable instances, and when replacing instances with new versions. Similar to the way we handle task Ids for stateful services, tasks of stateless services will now also provide an incarnation count, appended to the task Id. The first task created for an instance will be the .1, and subsequent replacements will increment that incarnation counter, e.g.
 
@@ -191,7 +191,7 @@ service-name.instance-c0caec0a-863a-11e9-915b-c610fee06dff._app.42
 
 The above example denotes the 42nd incaration of instance `c0caec0a-863a-11e9-915b-c610fee06dff`.
 
-When killing an instance using the wipe=true flag, its goal will be set to decommissioned, and it will eventually be expunged when all tasks are terminal. Note that as long as its tasks are e.g. unreachable, it will not be expunged until they are reported terminal (in case they stay unreachable: GONE, GONE_BY_OPERATOR, or UNKNOWN). When killing instances without the wipe=true flag, Marathon will only issue kill requests to Mesos, but keep the current goal and will therefore launch replacements that are still associated with the existing instance.
+When killing an instance using the `wipe=true` flag, its goal will be set to `Decommission` and it will eventually be expunged when all tasks are terminal. Note that as long as its tasks are e.g. unreachable, it will not be expunged until they are reported terminal (in case they stay unreachable: `GONE`, `GONE_BY_OPERATOR`, or `UNKNOWN`). When killing instances without the `wipe=true` flag, Marathon will only issue kill requests to Mesos, but keep the current goal and will, therefore, launch replacements that are still associated with the existing instance.
 
 ### AppC is now deprecated
 AppC is now deprecated and will be removed in Marathon 1.9

--- a/changelog.md
+++ b/changelog.md
@@ -179,6 +179,20 @@ when Marathon fails to clean up reservation which requires offers being sent.
 
 ## Changes from 1.7.xxx to 1.8.180
 
+### Aligning Ephemeral with Stateful Task Handling
+
+Marathon 1.8 introduces handling ephemeral instances similar to how it handled stateful instances since version 1.0. Until now, Marathon expunged instances once all of their tasks ended up in a terminal state, and eventually launched replacements as a result of those instances being expunged. Instances will now only be expunged from the state when their goal is to be Decommissioned and all their tasks are in a terminal state. If their goal is still Running, they will be considered to be scheduled and used to launch replacement tasks. This change not only merges two previously different code paths; this also simplifies debugging since users will be able to follow the task incarnations for a given instance throughout Marathons logs.
+
+This means that instance Ids are now stable for as long as an instance shall be kept running. New instances will be created only when replacing unreachable instances, and when replacing instances with new versions. Similar to the way we handle task Ids for stateful services, tasks of stateless services will now also provide an incarnation count, appended to the task Id. The first task created for an instance will be the .1, and subsequent replacements will increment that incarnation counter, e.g.
+
+```
+service-name.instance-c0caec0a-863a-11e9-915b-c610fee06dff._app.42
+```
+
+The above example denotes the 42nd incaration of instance `c0caec0a-863a-11e9-915b-c610fee06dff`.
+
+When killing an instance using the wipe=true flag, its goal will be set to decommissioned, and it will eventually be expunged when all tasks are terminal. Note that as long as its tasks are e.g. unreachable, it will not be expunged until they are reported terminal (in case they stay unreachable: GONE, GONE_BY_OPERATOR, or UNKNOWN). When killing instances without the wipe=true flag, Marathon will only issue kill requests to Mesos, but keep the current goal and will therefore launch replacements that are still associated with the existing instance.
+
 ### AppC is now deprecated
 AppC is now deprecated and will be removed in Marathon 1.9
 


### PR DESCRIPTION
We never added a backlog entry to point out instanceIds are stable meanwhile. This adds a section based on the original PR #6677