### PR TITLE
Fix pod status for `Scheduled` instances with a goal `Stopped`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -83,6 +83,9 @@ Revive offers repetitions functionality no longer optional; after the duration s
 
 For more detailed information, see the JIRA ticket [MARATHON-8663](https://jira.mesosphere.com/browse/MARATHON-8663)
 
+### Fixed issues
+- [MARATHON-8711](https://jira.mesosphere.com/browse/MARATHON-8711) - Fixed a rare issue where Marathon would fail to render a status for a resident scheduled pod instance with a goal `Stopped` 
+
 ## Changes from 1.8.218 to 1.8.222
 
 ### External Volume Validation changes

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -256,6 +256,12 @@ trait PodStatusConversion {
       PodInstanceState.Pending -> None
     } else {
       instance.state.condition match {
+        // In this rare case, an instance never ran (e.g. not enough resources) and was
+        // stopped (e.g. due to a scale down) but still exists because this is a resident
+        // app/pod with a state.condition == Scheduled/Provisioned
+        case condition.Condition.Scheduled |
+          condition.Condition.Provisioned =>
+          PodInstanceState.Terminal -> None
         case condition.Condition.Staging |
           condition.Condition.Starting =>
           PodInstanceState.Staging -> None


### PR DESCRIPTION
Summary:
In a rare case where a resident pod instance is scheduled but can't be launched (e.g. there are not enough resources) and is then stopped due to a scale down, a `GET v2/pods/{podId}::status` request would fail. This is fixed now.

JIRA issues: MARATHON-8711
