### PR TITLE
Fix pod status for `Scheduled` instances with a goal `Stopped`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
-## Changes from 1.8.212 to 1.8.xxx
+## Changes from 1.8.222 to 1.8.xxx
 
-## Changes from 1.8.218 to 1.8.212
+### Fixed issues
+
+- [MARATHON-8711](https://jira.mesosphere.com/browse/MARATHON-8711) - Fixed a rare issue where Marathon would fail to render a status for a resident scheduled pod instance with a goal `Stopped`
+
+## Changes from 1.8.218 to 1.8.222
 
 ### External Volume Validation changes
 
@@ -121,10 +125,10 @@ If you want to run in a specific seccomp profile.   That profile needs to be con
     }
   }
 }
-```     
+```
 
 ### Introduce global throttling to Marathon health checks
-Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.  
+Marathon health checks is a deprecated feature and customers are strongly recommended to switch to Mesos health checks for scalability reasons. However, we've seen a number of issues when excessive number of Marathon health checks (HTTP and TCP) would overload parts of Marathon. Hence we introduced a new parameter `--max_concurrent_marathon_health_checks` that defines maximum number (256 by default) of *Marathon* health checks (HTTP/S and TCP) that can be executed concurrently in the given moment. Note that setting a big value here and using many services with Marathon health checks will overload Marathon leading to internal timeouts and unstable behavior.
 
 ### `--gpu_scheduling_behavior` default is now `restricted`; `undefined` is deprecated and will be removed
 

--- a/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodStatusConversion.scala
@@ -255,6 +255,12 @@ trait PodStatusConversion {
       PodInstanceState.Pending -> None
     } else {
       instance.state.condition match {
+        // In this rare case, an instance never ran (e.g. not enough resources) and was
+        // stopped (e.g. due to a scale down) but still exists because this is a resident
+        // app/pod with a state.condition == Scheduled/Provisioned
+        case condition.Condition.Scheduled |
+          condition.Condition.Provisioned =>
+          PodInstanceState.Terminal -> None
         case condition.Condition.Staging |
           condition.Condition.Starting =>
           PodInstanceState.Staging -> None

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -92,6 +92,17 @@ class PodStatusConversionTest extends UnitTest {
       ))
     }
 
+    "resident pod instance scheduled and Stopped before it could be launched" in {
+      implicit val clock = new SettableClock()
+      val pod = podWithPersistentVolume.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))
+      var scheduled = core.instance.Instance.scheduled(pod)
+      scheduled = scheduled.copy(state = scheduled.state.copy(goal = core.instance.Goal.Stopped))
+
+      val status = PodStatusConversion.podInstanceStatusRamlWriter((pod, scheduled))
+      status.id shouldBe scheduled.instanceId.idString
+      status.status shouldBe PodInstanceState.Terminal
+    }
+
     "ephemeral pod launched, received STAGING status from Mesos" in {
       implicit val clock = new SettableClock()
       val pod = basicOneContainerPod.copy(versionInfo = state.VersionInfo.OnlyVersion(clock.now()))


### PR DESCRIPTION
Summary:
In a rare case where a resident pod instance is scheduled but can't be launched (e.g. there are not enough resources) and is then stopped due to a scale down, a `GET v2/pods/{podId}::status` request would fail. This is fixed now.

JIRA: MARATHON-8711

(cherry-picked from: 6c91539af17bfa10260b540eb0a8c020ab7d5b42)