### PR TITLE
Switch to use tools/packager makefile for docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Instructions on how to install prepackaged releases are available [in the Marath
 1.  Run `sbt universal:packageZipTarball` to package Marathon as an txz file
     containing bin/marathon fully packaged.
 
-1. Run `sbt docker:publishLocal` for a local marathon docker image.
+1. Run `cd tools/packager; make tag-docker` for a local Marathon docker image.
 
 ### Running in Development Mode
 
@@ -179,7 +179,7 @@ See [the documentation](https://mesosphere.github.io/marathon/docs/developing-vm
 
 Build it:
 
-    sbt docker:publishLocal
+    cd tools/packages; make tag-docker
 
 Note the version, e.g: `[info] Built image mesosphere/marathon:1.5.0-SNAPSHOT-461-gf1cc63e` => `1.5.0-SNAPSHOT-461-gf1cc63e`
 

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -207,8 +207,6 @@ def build(runTests: Boolean = true, buildName: String = "run"): SemVer = {
 @main
 def buildDockerAndLinuxPackages(): String = {
   utils.stage("Package Docker Image, Debian and RedHat Packages") {
-    %('sbt, "docker:publishLocal")
-
     val toolPath = pwd/'tools/'packager
     %('make, "clean")(toolPath)
     %('make, "all", "-j")(toolPath)

--- a/ci/releases.sc
+++ b/ci/releases.sc
@@ -93,5 +93,5 @@ def copyTarballBuildsToReleases(version: SemVer): Unit = {
  */
 def uploadLinuxPackagesToRepos(packageVersion: String): Unit = {
   val toolPath = pwd/'tools/'packager
-  %('make, "upload")(toolPath)
+  %('make, "upload-packages")(toolPath)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -139,7 +139,7 @@ object Dependency {
     val UUIDGenerator = "3.1.4"
     val WixAccord = "0.7.1"
 
-    // Version of Mesos to use in Dockerfile.
+    // Version of Mesos to use when building docker image or testing packages
     val MesosDebian = "1.9.0-2.0.1"
 
 

--- a/tests/package/README.md
+++ b/tests/package/README.md
@@ -22,9 +22,9 @@ Build with:
 ```
 cd {marathon_project_dir}
 rm -rf target/packages
-sbt docker:publishLocal
 cd tools/packager
-make clean all -j
+make clean
+make all -j
 ```
 
 ### 2) Build the test bed docker images

--- a/tests/package/test.sc
+++ b/tests/package/test.sc
@@ -9,7 +9,10 @@ import ammonite.ops._
 import ammonite.ops.ImplicitWd._
 import scala.util.Try
 
-val MarathonVersion = %%("./version")(pwd / up / up).out.string.trim
+val REF = sys.env.getOrElse("REF", "HEAD")
+val SKIP_CLEANUP = sys.env.contains("SKIP_CLEANUP")
+val MarathonVersion = %%("./version", "--ref", REF)(pwd / up / up).out.string.trim
+val DOCKER_TAG = sys.env.getOrElse("DOCKER_TAG", %%(pwd/up/up/'version, "docker", "--ref", REF).out.string.trim)
 
 abstract class UnitTest extends FlatSpec with GivenWhenThen with Matchers with Eventually {
   val veryPatient = PatienceConfig(timeout = scaled(60.seconds), interval = scaled(1.second))
@@ -29,8 +32,8 @@ trait FailureWatcher extends Suite {
 }
 
 trait MesosTest extends UnitTest with BeforeAndAfterAll with FailureWatcher {
-  val packagePath = pwd / up / up / 'tools / 'packager / 'target
-  val PackageFile = s"^marathon[_-]${MarathonVersion}-.+\\.([a-z0-9]+)_all.(rpm|deb)$$".r
+  val packagePath = pwd / up / up / 'tools / 'packager / 'target / MarathonVersion
+  val PackageFile = s"^marathon[_-]${MarathonVersion}-.+\\.([a-z0-9]+)(?:.noarch|_all).(rpm|deb)$$".r
 
   def assertPackagesCleanlyBuilt(): Unit = {
     assert(packagePath.toIO.exists, "package path ${packagePath} does not exist! Did you build packages?")
@@ -94,7 +97,7 @@ trait MesosTest extends UnitTest with BeforeAndAfterAll with FailureWatcher {
 
   override def afterAll(): Unit = {
     try {
-      if (!sys.env.contains("SKIP_CLEANUP")) {
+      if (!SKIP_CLEANUP) {
         removeStaleDockerInstances()
       }
     } finally super.afterAll()
@@ -312,8 +315,7 @@ EOF
 
 // Test the sbt-native-packager docker produced image
 class DockerImageTest extends MesosTest {
-  val tag = sys.env.getOrElse("DOCKER_TAG", %%(pwd/up/up/'version, "docker").out.string.trim)
-  val image = s"mesosphere/marathon:${tag}"
+  val image = s"mesosphere/marathon:${DOCKER_TAG}"
 
   var mesos: Container = _
   var dockerMarathon: Container = _

--- a/tests/performance/scripts/build.sh
+++ b/tests/performance/scripts/build.sh
@@ -17,7 +17,7 @@ fi
   # Cleanup marathon
   cd $MARATHON_DIR;
   rm -rf target;
-  sbt clean;
-
-  sbt docker:publishLocal
+  cd tools/packager
+  make clean
+  make all tag-docker
 )

--- a/tools/packager/Makefile
+++ b/tools/packager/Makefile
@@ -1,5 +1,5 @@
 # Note that the prefix affects the init scripts as well.
-PREFIX := usr tag-docker all clean help push-docker
+PREFIX := usr
 
 FPM_VERSION := 1.10.2
 FPM := FPM_VERSION=$(FPM_VERSION) bin/fpm-docker
@@ -11,9 +11,10 @@ PKG_COMMIT := $(shell cd ../../ && ./version commit --ref $(REF))
 PKG_VER := $(shell cd ../../ && ./version --ref $(PKG_COMMIT))
 
 MESOS_PKG_VERSION := $(shell cat ../../project/Dependencies.scala | grep MesosDebian | cut -f 2 -d '"')
+BUILD_TARGET_ROOT := target/$(PKG_VER)
 
 FPM_OPTS := -s dir -n marathon -v $(PKG_VER) \
-	-p target/ \
+	-p $(BUILD_TARGET_ROOT)/ \
 	--architecture all \
 	--url "https://github.com/mesosphere/marathon" \
 	--license Apache-2.0 \
@@ -41,26 +42,28 @@ FPM_OPTS_RPM := -t rpm \
 	-d redhat-lsb-core
 
 
-EL6_PKG_PATH=target/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm
-EL7_PKG_PATH=target/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm
-UBUNTU_1604_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb
-UBUNTU_1804_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb
-DEBIAN_9_PKG_PATH=target/marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb
+EL6_PKG_PATH=$(BUILD_TARGET_ROOT)/marathon-$(PKG_VER)-$(PKG_REL).el6.noarch.rpm
+EL7_PKG_PATH=$(BUILD_TARGET_ROOT)/marathon-$(PKG_VER)-$(PKG_REL).el7.noarch.rpm
+UBUNTU_1604_PKG_PATH=$(BUILD_TARGET_ROOT)/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1604_all.deb
+UBUNTU_1804_PKG_PATH=$(BUILD_TARGET_ROOT)/marathon_$(PKG_VER)-$(PKG_REL).ubuntu1804_all.deb
+DEBIAN_9_PKG_PATH=$(BUILD_TARGET_ROOT)/marathon_$(PKG_VER)-$(PKG_REL).debian9_all.deb
 
 ALL_PKGS=$(EL6_PKG_PATH) $(EL7_PKG_PATH) $(DEBIAN_9_PKG_PATH) $(UBUNTU_1804_PKG_PATH) $(UBUNTU_1604_PKG_PATH)
 
 .PHONY: help
 help:
 	@echo "Please choose one of the following targets:"
-	@echo "  all, deb, rpm, ubuntu, debian or el"
-	@echo "For build packages for the current checked-out version of Marathon:"
+	@echo "  all, deb, rpm, ubuntu, debian, docker or el"
+	@echo "To build all packages for the current checked-out version of Marathon:"
 	@echo "  make all"
+	@echo "To build and upload all packages, including docker:"
+	@echo "  make upload-packages push-docker"
 	@echo "To build packages for a different artifact version of Marathon:"
 	@echo "  make REF=v1.9.100 all"
 	@exit 0
 
 .PHONY: all
-all: $(foreach pkg,$(ALL_PKGS),$(pkg)) target/docker.tagged
+all: $(foreach pkg,$(ALL_PKGS),$(pkg)) $(BUILD_TARGET_ROOT)/docker.tagged
 
 .PHONY: deb
 deb: ubuntu debian
@@ -79,8 +82,8 @@ debian: debian-stretch-9
 
 .PHONY: el6
 el6: $(EL6_PKG_PATH)
-$(EL6_PKG_PATH): target/toor/el6/etc/init.d/marathon target/toor/el6/$(PREFIX)/share/marathon target/toor/el6/etc/default/marathon target/fpm-docker/.provisioned
-	$(FPM) -C target/toor/el6 \
+$(EL6_PKG_PATH): $(BUILD_TARGET_ROOT)/toor/el6/etc/init.d/marathon $(BUILD_TARGET_ROOT)/toor/el6/$(PREFIX)/share/marathon $(BUILD_TARGET_ROOT)/toor/el6/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C $(BUILD_TARGET_ROOT)/toor/el6 \
 	        --config-files etc/default/marathon \
 		--iteration $(PKG_REL).el6 \
 	        --before-install scripts/adduser \
@@ -90,8 +93,8 @@ $(EL6_PKG_PATH): target/toor/el6/etc/init.d/marathon target/toor/el6/$(PREFIX)/s
 
 .PHONY: el7
 el7: $(EL7_PKG_PATH)
-$(EL7_PKG_PATH): target/toor/el7/usr/lib/systemd/system/marathon.service target/toor/el7/$(PREFIX)/share/marathon target/toor/el7/etc/default/marathon target/fpm-docker/.provisioned
-	$(FPM) -C target/toor/el7 \
+$(EL7_PKG_PATH): $(BUILD_TARGET_ROOT)/toor/el7/usr/lib/systemd/system/marathon.service $(BUILD_TARGET_ROOT)/toor/el7/$(PREFIX)/share/marathon $(BUILD_TARGET_ROOT)/toor/el7/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C $(BUILD_TARGET_ROOT)/toor/el7 \
 		--iteration $(PKG_REL).el7 \
 		--config-files usr/lib/systemd/system/marathon.service \
                 --config-files etc/default/marathon \
@@ -103,46 +106,46 @@ $(EL7_PKG_PATH): target/toor/el7/usr/lib/systemd/system/marathon.service target/
 
 .PHONY: ubuntu-xenial-1604
 ubuntu-xenial-1604: $(UBUNTU_1604_PKG_PATH)
-$(UBUNTU_1604_PKG_PATH): target/toor/ubuntu-xenial/lib/systemd/system/marathon.service target/toor/ubuntu-xenial/$(PREFIX)/share/marathon target/toor/ubuntu-xenial/etc/default/marathon target/fpm-docker/.provisioned
-	$(FPM) -C target/toor/ubuntu-xenial \
+$(UBUNTU_1604_PKG_PATH): $(BUILD_TARGET_ROOT)/toor/ubuntu-xenial/lib/systemd/system/marathon.service $(BUILD_TARGET_ROOT)/toor/ubuntu-xenial/$(PREFIX)/share/marathon $(BUILD_TARGET_ROOT)/toor/ubuntu-xenial/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C $(BUILD_TARGET_ROOT)/toor/ubuntu-xenial \
 		--iteration $(PKG_REL).ubuntu1604 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
 .PHONY: ubuntu-bionic-1804
 ubuntu-bionic-1804: $(UBUNTU_1804_PKG_PATH)
-$(UBUNTU_1804_PKG_PATH): target/toor/ubuntu-bionic/lib/systemd/system/marathon.service target/toor/ubuntu-bionic/$(PREFIX)/share/marathon target/toor/ubuntu-bionic/etc/default/marathon target/fpm-docker/.provisioned
-	$(FPM) -C target/toor/ubuntu-bionic \
+$(UBUNTU_1804_PKG_PATH): $(BUILD_TARGET_ROOT)/toor/ubuntu-bionic/lib/systemd/system/marathon.service $(BUILD_TARGET_ROOT)/toor/ubuntu-bionic/$(PREFIX)/share/marathon $(BUILD_TARGET_ROOT)/toor/ubuntu-bionic/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C $(BUILD_TARGET_ROOT)/toor/ubuntu-bionic \
 		--iteration $(PKG_REL).ubuntu1804 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
 .PHONY: debian-stretch-9
 debian-stretch-9: $(DEBIAN_9_PKG_PATH)
-$(DEBIAN_9_PKG_PATH): target/toor/debian-stretch-9/lib/systemd/system/marathon.service target/toor/debian-stretch-9/$(PREFIX)/share/marathon target/toor/debian-stretch-9/etc/default/marathon target/fpm-docker/.provisioned
-	$(FPM) -C target/toor/debian-stretch-9 \
+$(DEBIAN_9_PKG_PATH): $(BUILD_TARGET_ROOT)/toor/debian-stretch-9/lib/systemd/system/marathon.service $(BUILD_TARGET_ROOT)/toor/debian-stretch-9/$(PREFIX)/share/marathon $(BUILD_TARGET_ROOT)/toor/debian-stretch-9/etc/default/marathon target/fpm-docker/.provisioned
+	$(FPM) -C $(BUILD_TARGET_ROOT)/toor/debian-stretch-9 \
 		--iteration $(PKG_REL).debian9 \
 		$(FPM_OPTS_DEB_SYSTEMD) $(FPM_OPTS) .
 
-target/toor/%/etc/default/marathon:
+$(BUILD_TARGET_ROOT)/toor/%/etc/default/marathon:
 	mkdir -p "$(dir $@)"
 	cp marathon.defaults $@
 
-target/toor/el6/etc/init.d/marathon: scripts/el6.init
+$(BUILD_TARGET_ROOT)/toor/el6/etc/init.d/marathon: scripts/el6.init
 	mkdir -p "$(dir $@)"
 	cp scripts/el6.init "$@"
 	chmod 0755 "$@"
 
-target/toor/%/usr/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
+$(BUILD_TARGET_ROOT)/toor/%/usr/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
 	mkdir -p "$(dir $@)"
 	cp scripts/marathon.systemd.service "$@"
 
-target/toor/%/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
+$(BUILD_TARGET_ROOT)/toor/%/lib/systemd/system/marathon.service: scripts/marathon.systemd.service
 	mkdir -p "$(dir $@)"
 	cp scripts/marathon.systemd.service "$@"
 
-target/%/marathon: target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+$(BUILD_TARGET_ROOT)/%/share/marathon: $(BUILD_TARGET_ROOT)/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 	rm -rf "$(dir $@)"
 	mkdir -p "$(dir $@)"
-	tar xzf target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz -C "$(dir $@)"
+	tar xzf $(BUILD_TARGET_ROOT)/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz -C "$(dir $@)"
 	mv $@-$(PKG_VER)-$(PKG_COMMIT) $@
 	touch $@
 
@@ -150,12 +153,12 @@ ifeq ($(REF), HEAD)
 ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
 	cd ../../ && sbt universal:packageZipTarball
 
-target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz: ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
-	mkdir -p target/toor
+$(BUILD_TARGET_ROOT)/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz: ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+	mkdir -p $(BUILD_TARGET_ROOT)/toor
 	cp ../../target/universal/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz $@
 else
-target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
-	mkdir -p target/toor
+$(BUILD_TARGET_ROOT)/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz:
+	mkdir -p $(BUILD_TARGET_ROOT)/toor
 	curl -f -o $@ https://downloads.mesosphere.io/marathon/builds/$(PKG_VER)-$(PKG_COMMIT)/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 endif
 
@@ -168,9 +171,11 @@ endef
 
 $(foreach target,$(ALL_PKGS),$(eval $(call upload_target,$(target))))
 
+.PHONY: upload-packages
 upload-packages: $(foreach target,$(ALL_PKGS),$(target).uploaded)
 
-download-marathon: | target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+.PHONY: download
+download: | $(BUILD_TARGET_ROOT)/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 
 target/fpm-docker/.provisioned:
 	cd fpm-docker && docker build . --build-arg FPM_VERSION=$(FPM_VERSION) -t fpm:$(FPM_VERSION)
@@ -179,26 +184,31 @@ target/fpm-docker/.provisioned:
 
 ### DOCKER BUILD section
 
-target/docker/Dockerfile: docker/Dockerfile
+$(BUILD_TARGET_ROOT)/docker/Dockerfile: docker/Dockerfile
 	mkdir -p "$(dir $@)"
 	cp $< $@
 
-target/docker.tagged: target/docker/Dockerfile target/docker/marathon
-	cd target/docker && docker build --build-arg MESOS_PKG_VERSION=$(MESOS_PKG_VERSION) --tag mesosphere/marathon:v$(PKG_VER) . 2>&1 | tee ../../$@.work
+$(BUILD_TARGET_ROOT)/docker.tagged: $(BUILD_TARGET_ROOT)/docker/Dockerfile $(BUILD_TARGET_ROOT)/docker/share/marathon
+	cd $(BUILD_TARGET_ROOT)/docker && docker build --build-arg MESOS_PKG_VERSION=$(MESOS_PKG_VERSION) --tag mesosphere/marathon:v$(PKG_VER) . 2>&1 | tee "$(PWD)/$@.work"
 	mv $@.work $@
 
-target/docker.pushed: target/docker.tagged
+$(BUILD_TARGET_ROOT)/docker.pushed: $(BUILD_TARGET_ROOT)/docker.tagged
 	docker push mesosphere/marathon:v$(PKG_VER) 2>&1 | tee $@.work
 
-tag-docker: target/docker.tagged
-push-docker: target/docker.pushed
+.PHONY: docker
+docker: $(BUILD_TARGET_ROOT)/docker.tagged
+
+.PHONY: push-docker
+push-docker: $(BUILD_TARGET_ROOT)/docker.pushed
 
 ### END DOCKER
 
 
+.PHONY: clean
 clean:
 	rm -rf marathon*.deb marathon*.rpm marathon*.pkg target
 
+.PHONY: purge
 purge: | clean
 	# We could also use 'sbt clean' but it takes forever and is not as thorough.
 	## || true is so that we still get an exit 0 to allow builds to proceed

--- a/tools/packager/Makefile
+++ b/tools/packager/Makefile
@@ -1,5 +1,5 @@
 # Note that the prefix affects the init scripts as well.
-PREFIX := usr
+PREFIX := usr tag-docker all clean help push-docker
 
 FPM_VERSION := 1.10.2
 FPM := FPM_VERSION=$(FPM_VERSION) bin/fpm-docker
@@ -9,6 +9,8 @@ REF ?= HEAD
 PKG_REL ?= 1
 PKG_COMMIT := $(shell cd ../../ && ./version commit --ref $(REF))
 PKG_VER := $(shell cd ../../ && ./version --ref $(PKG_COMMIT))
+
+MESOS_PKG_VERSION := $(shell cat ../../project/Dependencies.scala | grep MesosDebian | cut -f 2 -d '"')
 
 FPM_OPTS := -s dir -n marathon -v $(PKG_VER) \
 	-p target/ \
@@ -51,14 +53,14 @@ ALL_PKGS=$(EL6_PKG_PATH) $(EL7_PKG_PATH) $(DEBIAN_9_PKG_PATH) $(UBUNTU_1804_PKG_
 help:
 	@echo "Please choose one of the following targets:"
 	@echo "  all, deb, rpm, ubuntu, debian or el"
-	@echo "For release builds:"
-	@echo "  make PKG_REL=1.0 deb"
-	@echo "To override package release version:"
-	@echo "  make PKG_REL=0.2.20141228050159 rpm"
+	@echo "For build packages for the current checked-out version of Marathon:"
+	@echo "  make all"
+	@echo "To build packages for a different artifact version of Marathon:"
+	@echo "  make REF=v1.9.100 all"
 	@exit 0
 
 .PHONY: all
-all: $(foreach pkg,$(ALL_PKGS),$(pkg))
+all: $(foreach pkg,$(ALL_PKGS),$(pkg)) target/docker.tagged
 
 .PHONY: deb
 deb: ubuntu debian
@@ -137,7 +139,7 @@ target/toor/%/lib/systemd/system/marathon.service: scripts/marathon.systemd.serv
 	mkdir -p "$(dir $@)"
 	cp scripts/marathon.systemd.service "$@"
 
-target/toor/%/share/marathon: target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+target/%/marathon: target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 	rm -rf "$(dir $@)"
 	mkdir -p "$(dir $@)"
 	tar xzf target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz -C "$(dir $@)"
@@ -166,14 +168,33 @@ endef
 
 $(foreach target,$(ALL_PKGS),$(eval $(call upload_target,$(target))))
 
-upload: $(foreach target,$(ALL_PKGS),$(target).uploaded)
+upload-packages: $(foreach target,$(ALL_PKGS),$(target).uploaded)
 
-download: | target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
+download-marathon: | target/toor/marathon-$(PKG_VER)-$(PKG_COMMIT).tgz
 
 target/fpm-docker/.provisioned:
 	cd fpm-docker && docker build . --build-arg FPM_VERSION=$(FPM_VERSION) -t fpm:$(FPM_VERSION)
 	mkdir -p target/fpm-docker
 	touch $@
+
+### DOCKER BUILD section
+
+target/docker/Dockerfile: docker/Dockerfile
+	mkdir -p "$(dir $@)"
+	cp $< $@
+
+target/docker.tagged: target/docker/Dockerfile target/docker/marathon
+	cd target/docker && docker build --build-arg MESOS_PKG_VERSION=$(MESOS_PKG_VERSION) --tag mesosphere/marathon:v$(PKG_VER) . 2>&1 | tee ../../$@.work
+	mv $@.work $@
+
+target/docker.pushed: target/docker.tagged
+	docker push mesosphere/marathon:v$(PKG_VER) 2>&1 | tee $@.work
+
+tag-docker: target/docker.tagged
+push-docker: target/docker.pushed
+
+### END DOCKER
+
 
 clean:
 	rm -rf marathon*.deb marathon*.rpm marathon*.pkg target

--- a/tools/packager/docker/Dockerfile
+++ b/tools/packager/docker/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /marathon
 ARG MESOS_PKG_VERSION
 
 ENV JAVA_HOME /docker-java-home
-ADD --chown=nobody:nogroup marathon /marathon
+ADD --chown=nobody:nogroup share/marathon /marathon
 
 RUN apt-get update && apt-get install -my wget gnupg && \
   apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF && \

--- a/tools/packager/docker/Dockerfile
+++ b/tools/packager/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:stretch-slim
+LABEL MAINTAINER="Mesosphere Package Builder <support@mesosphere.io>"
+WORKDIR /marathon
+
+ARG MESOS_PKG_VERSION
+
+ENV JAVA_HOME /docker-java-home
+ADD --chown=nobody:nogroup marathon /marathon
+
+RUN apt-get update && apt-get install -my wget gnupg && \
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv DF7D54CBE56151BF && \
+  apt-get update -y && \
+  apt-get upgrade -y && \
+  echo "deb http://repos.mesosphere.com/debian stretch-testing main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+  echo "deb http://repos.mesosphere.com/debian stretch main" | tee -a /etc/apt/sources.list.d/mesosphere.list && \
+  apt-get update && \
+  # jdk setup
+  mkdir -p /usr/share/man/man1 && \
+  apt-get install -y openjdk-8-jdk-headless openjdk-8-jre-headless ca-certificates-java && \
+  /var/lib/dpkg/info/ca-certificates-java.postinst configure && \
+  ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home && \
+  # mesos setup
+  echo exit 0 > /usr/bin/systemctl && chmod +x /usr/bin/systemctl && \
+  # Workaround required due to https://github.com/mesosphere/mesos-deb-packaging/issues/102
+  # Remove after upgrading to Mesos 1.7.0
+  apt-get install -y libcurl3-nss && \
+  apt-get install --no-install-recommends -y mesos=${MESOS_PKG_VERSION}.debian9 && \
+  rm /usr/bin/systemctl && \
+  apt-get clean && \
+  chown nobody:nogroup /marathon && \
+  ln -sf /marathon/bin/marathon /marathon/bin/start && \
+  chmod a+x /marathon/bin/marathon
+
+USER nobody
+ENTRYPOINT ["/marathon/bin/marathon"]
+CMD []


### PR DESCRIPTION
This allows us to build and publish Docker images for previously built
and uploaded Marathon artifacts, similar to that which can be done for
native packages
