### PR TITLE
AgentInfo still may not be defined for instances

### DIFF
--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo19200.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo19200.scala
@@ -38,7 +38,7 @@ class MigrationTo19200(
 
     (
       (__ \ "instanceId").read[Id] ~
-      (__ \ "agentInfo").read[AgentInfo] ~
+      (__ \ "agentInfo").readNullable[AgentInfo] ~
       (__ \ "tasksMap").read[Map[Task.Id, Task]] ~
       (__ \ "runSpecVersion").read[Timestamp] ~
       (__ \ "state").read[InstanceState] ~
@@ -49,7 +49,7 @@ class MigrationTo19200(
 
         val role = persistedRole.orElse(Some(defaultMesosRole))
 
-        new Instance(instanceId, Some(agentInfo), state, tasksMap, runSpecVersion, reservation, role)
+        new Instance(instanceId, agentInfo, state, tasksMap, runSpecVersion, reservation, role)
       }
   }
 


### PR DESCRIPTION
Summary:
It's possible for there to be agentInfo-less instance records. This change
adjusts the migration so that Marathon can tolerate the lack of them.

JIRA Issues: MARATHON-8712
