### PR TITLE
Fix default role for top-level enforceRole: false groups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
-## Changes from 1.9.73 to 1.9.xxx
+## Changes from 1.9.100 to 1.9.xxx
+
+* [MARATHON-8713](https://jira.mesosphere.com/browse/MARATHON-8713) - Fixed issue where defaultRole for groups with enforceRole: false did not match the documentation and defaulted to the group-role, regardless.
+
+
+## Changes from 1.9.73 to 1.9.100
+
 
 ### Faster serialization
 

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -69,7 +69,7 @@ object RoleSettings extends StrictLogging {
       } else {
         // Without enforce role, we allow default role, group role and already existing role
         // The default role depends on the config parameter
-        val defaultRoleToUse = if (defaultForEnforceFromConfig) topLevelGroupRole else defaultRole
+        val defaultRoleToUse = if (enforceRole) topLevelGroupRole else defaultRole
         RoleSettings(validRoles = Set(defaultRole, topLevelGroupRole) ++ maybeExistingRole, defaultRole = defaultRoleToUse, previousRole = oldServiceRole, forceRoleUpdate = forceRoleUpdate)
       }
     }

--- a/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
+++ b/src/main/scala/mesosphere/marathon/util/RoleSettings.scala
@@ -67,8 +67,8 @@ object RoleSettings extends StrictLogging {
         // With enforceRole, we only allow the service to use the group-role or an existing role
         RoleSettings(validRoles = Set(topLevelGroupRole) ++ maybeExistingRole, defaultRole = topLevelGroupRole, previousRole = oldServiceRole, forceRoleUpdate = forceRoleUpdate)
       } else {
-        // Without enforce role, we allow default role, group role and already existing role
-        // The default role depends on the config parameter
+        // Without enforce role, we allow default role, group role, and the already existing role
+        // We always default to the configured Mesos default role.
         val defaultRoleToUse = if (enforceRole) topLevelGroupRole else defaultRole
         RoleSettings(validRoles = Set(defaultRole, topLevelGroupRole) ++ maybeExistingRole, defaultRole = defaultRoleToUse, previousRole = oldServiceRole, forceRoleUpdate = forceRoleUpdate)
       }


### PR DESCRIPTION
When --new_group_enforce_role=top is configured, and a group has
enforceRole: false set, Marathon was applying the group-role as the
default for new services in said group. This behavior was inconsistent
with the original design and the documentation.

In this commit we bring the behavior into alignment with the
documentation, and add a test case to assert it.

JIRA Issues: MARATHON-8713