### PR TITLE
Redact sensitive args

### DIFF
--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -189,7 +189,7 @@ object Main {
     * Serialize configuration in form that can be presented in a log
     */
   def configToLogLines(conf: AllConf): Seq[String] = {
-    Seq("(* suffix means value was explicitly supplied, and not defaulted)") ++
+    Seq("Marathon configuration: (* suffix means value was explicitly supplied, and not defaulted)") ++
       ScallopHelper.scallopOptions(conf).filter(_.isDefined).map { opt =>
         val wasSupplied = if (opt.isSupplied) " (*)" else ""
         val redactedValue = opt() match {

--- a/src/main/scala/mesosphere/marathon/ScallopHelper.scala
+++ b/src/main/scala/mesosphere/marathon/ScallopHelper.scala
@@ -3,6 +3,11 @@ package mesosphere.marathon
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 object ScallopHelper {
+  /** Return all defined options for a Scallop config; uses Java reflection to search for and invoke the
+   * appropriate methods
+   *
+   * @return List of all found ScallopOptions
+   */
   def scallopOptions(o: ScallopConf): Seq[ScallopOption[_]] = {
     o.getClass.getMethods.iterator.collect {
       case method if method.getParameterCount == 0 && method.getReturnType == classOf[ScallopOption[_]] =>

--- a/src/main/scala/mesosphere/marathon/ScallopHelper.scala
+++ b/src/main/scala/mesosphere/marathon/ScallopHelper.scala
@@ -1,0 +1,12 @@
+package mesosphere.marathon
+
+import org.rogach.scallop.{ScallopConf, ScallopOption}
+
+object ScallopHelper {
+  def scallopOptions(o: ScallopConf): Seq[ScallopOption[_]] = {
+    o.getClass.getMethods.iterator.collect {
+      case method if method.getParameterCount == 0 && method.getReturnType == classOf[ScallopOption[_]] =>
+        method.invoke(o).asInstanceOf[ScallopOption[_]]
+    }.toList
+  }
+}

--- a/src/test/scala/mesosphere/marathon/MainTest.scala
+++ b/src/test/scala/mesosphere/marathon/MainTest.scala
@@ -21,4 +21,15 @@ class MainTest extends UnitTest {
       Main.envToArgs(Map("MARATHON_APP_VERSION" -> "1.5")) shouldBe Seq()
     }
   }
+
+  "configToLogLines" should {
+    val conf = AllConf("--master", "zk://super:secret@127.0.0.1:2181/master", "--zk", "zk://also:special@localhost:2181/marathon", "--mesos_role", "super")
+    "redact credentials from Zookeeper" in {
+      val Some(masterLine) = Main.configToLogLines(conf).find(_.startsWith("master "))
+      masterLine shouldBe "master (*) = zk://xxxxxxxx:xxxxxxxx@127.0.0.1:2181/master"
+
+      val Some(zkLine) = Main.configToLogLines(conf).find(_.startsWith("zk "))
+      zkLine shouldBe "zk (*) = zk://xxxxxxxx:xxxxxxxx@localhost:2181/marathon"
+    }
+  }
 }

--- a/src/test/scala/mesosphere/marathon/MainTest.scala
+++ b/src/test/scala/mesosphere/marathon/MainTest.scala
@@ -25,11 +25,12 @@ class MainTest extends UnitTest {
   "configToLogLines" should {
     val conf = AllConf("--master", "zk://super:secret@127.0.0.1:2181/master", "--zk", "zk://also:special@localhost:2181/marathon", "--mesos_role", "super")
     "redact credentials from Zookeeper" in {
-      val Some(masterLine) = Main.configToLogLines(conf).find(_.startsWith("master "))
-      masterLine shouldBe "master (*) = zk://xxxxxxxx:xxxxxxxx@127.0.0.1:2181/master"
+      val lines = Main.configToLogLines(conf).split("\n")
+      val Some(masterLine) = lines.find(_.startsWith(" - master "))
+      masterLine shouldBe " - master (*) = zk://xxxxxxxx:xxxxxxxx@127.0.0.1:2181/master"
 
-      val Some(zkLine) = Main.configToLogLines(conf).find(_.startsWith("zk "))
-      zkLine shouldBe "zk (*) = zk://xxxxxxxx:xxxxxxxx@localhost:2181/marathon"
+      val Some(zkLine) = lines.find(_.startsWith(" - zk "))
+      zkLine shouldBe " - zk (*) = zk://xxxxxxxx:xxxxxxxx@localhost:2181/marathon"
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/ScallopHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/ScallopHelperTest.scala
@@ -1,0 +1,17 @@
+package mesosphere.marathon
+
+import mesosphere.UnitTest
+
+class ScallopHelperTest extends UnitTest {
+  val conf = AllConf("--master", "zk://super:secret@127.0.0.1:2181/master", "--zk", "zk://also:special@localhost:2181/marathon", "--mesos_role", "super")
+
+  "return the defined scallop options for a ScallopConf, specified or not" in {
+    val opts = ScallopHelper.scallopOptions(conf).groupBy(_.name).mapValues(_.head)
+    opts.keys should contain("zk")
+    opts.keys should contain("mesos_role")
+    opts.keys should contain("hostname")
+    opts.keys shouldNot contain("number") // this is a builder method which returns a ScallopOption
+    opts.keys shouldNot contain("opt") // this is a builder method which returns a ScallopOption
+    opts("zk").apply().toString shouldBe (conf.zooKeeperUrl().toString)
+  }
+}


### PR DESCRIPTION
Previously, Marathon would log credentials container in zookeeper connection strings, even when the parameters were specified via environment variables. This presents a security concern since, by default, service log files are viewable by non-root users in many linux environments. Further, persisting copies of these credentials is generally ill-advised.

In this commit, we change the log line which logs all provided options, verbatim, to log the parsed Marathon configuration.

JIRA Issues: MARATHON-2071
