### PR TITLE
Don't consume the "/v2" portion of the URL when parsing logs

### DIFF
--- a/tools/elk/conf/filter-marathon.conf
+++ b/tools/elk/conf/filter-marathon.conf
@@ -29,7 +29,7 @@ filter {
     remove_tag => ["unclassified"]
   }
   grok {
-    match => {"message" => "^%{IP:httpHost} - (?<user>%{WORD}|-)[^\"]*\"(?<method>GET|PUT|DELETE|POST|HEAD)\s+(http://|https://|/+)(?<authority>[^/]+)%{URIPATH:uri}(?:%{URIPARAM:params})?.*?\" %{POSINT:httpStatus:int} %{POSINT:size:int} \"[^\"]+\" \"(?<httpUserAgent>[^\"]+)\"" }
+    match => {"message" => "^%{IP:httpHost} - (?<user>%{WORD}|-)[^\"]*\"(?<method>GET|PUT|DELETE|POST|HEAD)\s+((http://|https://|://)(?<authority>[^/]+))?%{URIPATH:uri}(?:%{URIPARAM:params})?.*?\" %{POSINT:httpStatus:int} %{POSINT:size:int} \"[^\"]+\" \"(?<httpUserAgent>[^\"]+)\"" }
     add_field => {"class" => "http"}
     add_field => {"class2" => "response"}
     tag_on_failure => []

--- a/tools/elk/lib/main.sc
+++ b/tools/elk/lib/main.sc
@@ -145,7 +145,7 @@ def generateLogstashConfig(inputPath: Path, targetPath: Path, logFormat: LogForm
   writeFiles(
     printing / "10-input.conf" -> tcpReader,
     printing / "15-filters-format.conf" -> logFormat.unframe,
-    printing / "20-filters.conf" -> (read!(pwd / "conf" / "filter-marathon-1.4.x.conf")),
+    printing / "20-filters.conf" -> (read!(pwd / "conf" / "filter-marathon.conf")),
     printing / "30-output.conf" -> (read!(pwd / "conf" / "output-console.conf")))
 
   for {
@@ -169,14 +169,14 @@ def generateLogstashConfig(inputPath: Path, targetPath: Path, logFormat: LogForm
   writeFiles(
     loading / "11-filters-host.conf" -> (read!(pwd / "conf" / "filter-overwrite-host-with-file-host.conf")),
     loading / "15-filters-format.conf" -> logFormat.unframe,
-    loading / "20-filters.conf" -> (read!(pwd / "conf" / "filter-marathon-1.4.x.conf")),
+    loading / "20-filters.conf" -> (read!(pwd / "conf" / "filter-marathon.conf")),
     loading / "30-output.conf" -> (read!(pwd / "conf" / "output-elasticsearch.conf")),
     target / "data-path.txt" -> inputPath.toString)
 
   writeFiles(
     json / "11-filters-host.conf" -> (read!(pwd / "conf" / "filter-overwrite-host-with-file-host.conf")),
     json / "15-filters-format.conf" -> logFormat.unframe,
-    json / "20-filters.conf" -> (read!(pwd / "conf" / "filter-marathon-1.4.x.conf")),
+    json / "20-filters.conf" -> (read!(pwd / "conf" / "filter-marathon.conf")),
     json / "30-output.conf" -> renderTemplate(
       pwd / "conf" / "output-json-ld.conf.template",
       "FILE" ->  util.escapeString((target / "output.json.ld").toString)))


### PR DESCRIPTION
There was an issue where the parsed uri component would be "/apps" instead of "/v2/apps", because "/v2" was being consumed incorrectly as the authority section by the matching regex.

Also, remove the -1.4.x extension because these grok filters should
target the current major version of Marathon
