### PR TITLE
Allow unreachable instances to actually be expunged immediately

### DIFF
--- a/src/main/scala/mesosphere/marathon/ScallopHelper.scala
+++ b/src/main/scala/mesosphere/marathon/ScallopHelper.scala
@@ -3,11 +3,12 @@ package mesosphere.marathon
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 object ScallopHelper {
-  /** Return all defined options for a Scallop config; uses Java reflection to search for and invoke the
-   * appropriate methods
-   *
-   * @return List of all found ScallopOptions
-   */
+  /**
+    * Return all defined options for a Scallop config; uses Java reflection to search for and invoke the
+    * appropriate methods
+    *
+    * @return List of all found ScallopOptions
+    */
   def scallopOptions(o: ScallopConf): Seq[ScallopOption[_]] = {
     o.getClass.getMethods.iterator.collect {
       case method if method.getParameterCount == 0 && method.getReturnType == classOf[ScallopOption[_]] =>

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -179,7 +179,7 @@ object Instance {
       * @param now           Timestamp of update.
       * @return new InstanceState
       */
-    def apply(
+    def transitionTo(
       maybeOldInstanceState: Option[InstanceState],
       newTaskMap: Map[Task.Id, Task],
       now: Timestamp,

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -38,7 +38,7 @@ object InstanceUpdater extends StrictLogging {
 
     instance.copy(
       tasksMap = updatedTasks,
-      state = Instance.InstanceState(Some(instance.state), updatedTasks, now, instance.unreachableStrategy, instance.state.goal),
+      state = Instance.InstanceState.transitionTo(Some(instance.state), updatedTasks, now, instance.unreachableStrategy, instance.state.goal),
       reservation = updatedReservation)
   }
 

--- a/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/update/InstanceUpdater.scala
@@ -56,7 +56,7 @@ object InstanceUpdater extends StrictLogging {
     InstanceUpdateEffect.Expunge(instance, events)
   }
 
-  private def shouldBeExpunged(instance: Instance): Boolean =
+  private def isTerminalDecomissionedAndEphemeral(instance: Instance): Boolean =
     instance.tasksMap.values.forall(t => t.isTerminal) && instance.state.goal == Goal.Decommissioned && instance.reservation.isEmpty
 
   private def shouldAbandonReservation(instance: Instance): Boolean = {
@@ -74,6 +74,35 @@ object InstanceUpdater extends StrictLogging {
     instance.reservation.nonEmpty && anyAreGoneByOperator && allAreTerminal
   }
 
+  private[marathon] def readyToExpungeUnreachable(instance: Instance, now: Timestamp): Boolean = {
+    instance.unreachableStrategy match {
+      case unreachableEnabled: UnreachableEnabled =>
+        instance.tasksMap.values.exists(_.isUnreachableExpired(now, unreachableEnabled.expungeAfter))
+      case _ =>
+        false
+    }
+  }
+  private[marathon] def instanceUpdateEffectForTask(instance: Instance, updatedTask: Task, now: Timestamp): InstanceUpdateEffect = {
+    val updated: Instance = applyTaskUpdate(instance, updatedTask, now)
+    if ((updated.state == instance.state) && (updated.tasksMap == instance.tasksMap)) {
+      InstanceUpdateEffect.Noop(instance.instanceId)
+    } else {
+      val events = eventsGenerator.events(updated, Some(updatedTask), now, previousState = Some(instance.state))
+      if (readyToExpungeUnreachable(updated, now)) {
+        logger.info("Expunging since the task is unreachable and the expungeAfter duration is surpassed", updated.instanceId)
+        InstanceUpdateEffect.Expunge(updated, events)
+      } else if (isTerminalDecomissionedAndEphemeral(updated)) {
+        logger.info("Requesting to expunge {}, all tasks are terminal, instance has no reservation and is not Stopped", updated.instanceId)
+        InstanceUpdateEffect.Expunge(updated, events)
+      } else if (shouldAbandonReservation(updated)) {
+        val withoutReservation = updated.copy(agentInfo = None, reservation = None, state = updated.state.copy(condition = Condition.Scheduled))
+        InstanceUpdateEffect.Update(withoutReservation, oldState = Some(instance), events)
+      } else {
+        InstanceUpdateEffect.Update(updated, oldState = Some(instance), events)
+      }
+    }
+  }
+
   private[marathon] def mesosUpdate(instance: Instance, op: MesosUpdate): InstanceUpdateEffect = {
     val now = op.now
     val taskId = Task.Id.parse(op.mesosStatus.getTaskId)
@@ -81,38 +110,29 @@ object InstanceUpdater extends StrictLogging {
       val taskEffect = task.update(instance, op.condition, op.mesosStatus, now)
       taskEffect match {
         case TaskUpdateEffect.Update(updatedTask) =>
-          val updated: Instance = applyTaskUpdate(instance, updatedTask, now)
-          val events = eventsGenerator.events(updated, Some(updatedTask), now, previousState = Some(instance.state))
-          if (shouldBeExpunged(updated)) {
-            logger.info("Requesting to expunge {}, all tasks are terminal, instance has no reservation and is not Stopped", updated.instanceId)
-            InstanceUpdateEffect.Expunge(updated, events)
-          } else if (shouldAbandonReservation(updated)) {
-            val withoutReservation = updated.copy(agentInfo = None, reservation = None, state = updated.state.copy(condition = Condition.Scheduled))
-            InstanceUpdateEffect.Update(withoutReservation, oldState = Some(instance), events)
-          } else {
-            InstanceUpdateEffect.Update(updated, oldState = Some(instance), events)
-          }
+          instanceUpdateEffectForTask(instance, updatedTask, now)
 
         // We might still become UnreachableInactive.
         case TaskUpdateEffect.Noop if op.condition == Condition.Unreachable &&
           instance.state.condition != Condition.UnreachableInactive =>
-          val updated: Instance = applyTaskUpdate(instance, task, now)
-          if (updated.state.condition == Condition.UnreachableInactive) {
-            updated.unreachableStrategy match {
-              case u: UnreachableEnabled =>
-                logger.info(
-                  s"${updated.instanceId} is updated to UnreachableInactive after being Unreachable for more than ${u.inactiveAfter.toSeconds} seconds.")
-              case _ =>
-                // We shouldn't get here
-                logger.error(
-                  s"${updated.instanceId} is updated to UnreachableInactive in spite of there being no UnreachableStrategy")
+          val u = instanceUpdateEffectForTask(instance, task, now)
+          u match {
+            case noop: InstanceUpdateEffect.Noop =>
+              noop
+            case update: InstanceUpdateEffect.Update =>
+              if (update.instance.state.condition == Condition.UnreachableInactive) {
+                update.instance.unreachableStrategy match {
+                  case u: UnreachableEnabled =>
+                    logger.info(
+                      s"${update.instance.instanceId} is updated to UnreachableInactive after being Unreachable for more than ${u.inactiveAfter.toSeconds} seconds.")
+                  case _ =>
+                    // We shouldn't get here
+                    logger.error(
+                      s"${update.instance.instanceId} is updated to UnreachableInactive in spite of there being no UnreachableStrategy")
 
-            }
-            val events = eventsGenerator.events(
-              updated, Some(task), now, previousState = Some(instance.state))
-            InstanceUpdateEffect.Update(updated, oldState = Some(instance), events)
-          } else {
-            InstanceUpdateEffect.Noop(instance.instanceId)
+                }
+              }
+              update
           }
 
         case TaskUpdateEffect.Noop =>
@@ -161,7 +181,7 @@ object InstanceUpdater extends StrictLogging {
     val updatedInstance = instance.copy(state = instance.state.copy(goal = op.goal))
     val events = eventsGenerator.events(updatedInstance, task = None, now, previousState = Some(instance.state))
 
-    if (InstanceUpdater.shouldBeExpunged(updatedInstance)) {
+    if (InstanceUpdater.isTerminalDecomissionedAndEphemeral(updatedInstance)) {
       logger.info(s"Instance ${instance.instanceId} with current condition ${instance.state.condition} has it's goal updated from ${instance.state.goal} to ${op.goal}. Because of that instance should be expunged now.")
       InstanceUpdateEffect.Expunge(updatedInstance, events = events)
     } else {

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
@@ -234,7 +234,6 @@ object ReviveOffersStreamLogic extends StrictLogging {
       repeatIn = newRepeatIn
 
       if (rolesForReviveRepetition.isEmpty) {
-        logger.info(s"Found no roles suitable for revive repetition.")
         Nil
       } else {
         logger.info(s"Repeat revive for roles $rolesForReviveRepetition.")

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
@@ -12,6 +12,8 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.SpecInstances
 import mesosphere.marathon.state.{AbsolutePathId, Timestamp, UnreachableDisabled, UnreachableEnabled}
 
+import scala.concurrent.duration.Duration
+
 /**
   * Business logic of overdue tasks actor.
   *
@@ -41,7 +43,8 @@ trait ExpungeOverdueLostTasksActorLogic extends StrictLogging {
     case UnreachableDisabled =>
       false
     case unreachableEnabled: UnreachableEnabled =>
-      instance.isUnreachableInactive &&
+      unreachableEnabled.expungeAfter == Duration.Zero ||
+        instance.isUnreachableInactive &&
         instance.tasksMap.valuesIterator.exists(_.isUnreachableExpired(now, unreachableEnabled.expungeAfter))
   }
 }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -45,7 +45,7 @@ abstract case class Timestamp private (private val instant: Instant) extends Ord
   /**
     * @return true if this timestamp is more than "by" duration older than other timestamp.
     */
-  def expired(other: Timestamp, by: FiniteDuration): Boolean = this.until(other) > by
+  def expired(other: Timestamp, by: FiniteDuration): Boolean = this.until(other) >= by
 
   def +(duration: FiniteDuration): Timestamp = Timestamp(instant.plusMillis(duration.toMillis))
   def -(duration: FiniteDuration): Timestamp = Timestamp(instant.minusMillis(duration.toMillis))

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -195,7 +195,7 @@ object Fixture {
       new Instance(
         instanceId = task.taskId.instanceId,
         agentInfo = Some(AgentInfo(host = "host", agentId = Some("agent"), region = None, zone = None, attributes = Nil)),
-        state = Instance.InstanceState(None, tasksMap, task.status.startedAt.getOrElse(task.status.stagedAt), app.unreachableStrategy, Goal.Running),
+        state = Instance.InstanceState.transitionTo(None, tasksMap, task.status.startedAt.getOrElse(task.status.stagedAt), app.unreachableStrategy, Goal.Running),
         tasksMap = tasksMap,
         app,
         None, "*")

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -527,7 +527,7 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
         Instance(
           instanceId = instanceId,
           agentInfo = Some(Instance.AgentInfo("", None, None, None, Nil)),
-          state = InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running),
+          state = InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running),
           tasksMap = tasks,
           runSpec = pod,
           None, "*"

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -72,7 +72,7 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       Instance(
         instanceId = instanceId,
         agentInfo = Some(Instance.AgentInfo("", None, None, None, Nil)),
-        state = InstanceState(None, tasks, clock.now(), UnreachableStrategy.default(), Goal.Running),
+        state = InstanceState.transitionTo(None, tasks, clock.now(), UnreachableStrategy.default(), Goal.Running),
         tasksMap = tasks,
         runSpec = pod,
         None, "*"

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
@@ -85,7 +85,7 @@ class HealthCheckWorkerTest extends AkkaUnitTest with ImplicitSender {
       val since = task.status.startedAt.getOrElse(task.status.stagedAt)
       val unreachableStrategy = UnreachableStrategy.default()
       val tasksMap = Map(task.taskId -> task)
-      val state = Instance.InstanceState(None, tasksMap, since, unreachableStrategy, Goal.Running)
+      val state = Instance.InstanceState.transitionTo(None, tasksMap, since, unreachableStrategy, Goal.Running)
 
       val instance = Instance(task.taskId.instanceId, Some(agentInfo), state, tasksMap, app, None, "*")
 

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
@@ -27,7 +27,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
             task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "set the oldest task timestamp as the activeSince timestamp" in { state.activeSince should be(Some(f.clock.now - 1.hour)) }
       "set the instance condition to running" in { state.condition should be(Condition.Running) }
@@ -37,7 +37,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
       val f = new Fixture
 
       val tasks: Map[Task.Id, Task] = f.tasks(Condition.Staging, Condition.Staging)
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "not set the activeSince timestamp" in { state.activeSince should not be 'defined }
       "set the instance condition to staging" in { state.condition should be(Condition.Staging) }
@@ -56,7 +56,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
             task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "set the activeSince timestamp to the one from running" in { state.activeSince should be(Some(f.clock.now - 1.hour)) }
       "set the instance condition to staging" in { state.condition should be(Condition.Staging) }
@@ -75,7 +75,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
             task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "set the activeSince timestamp to the one from running" in { state.activeSince should be(Some(f.clock.now - 1.hour)) }
       "set the instance condition to unreachable" in { state.condition should be(Condition.Unreachable) }

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -41,7 +41,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
 
       s"$from and tasks become ${withTasks.mkString(", ")}" should {
 
-        val status = Instance.InstanceState(Some(instance.state), tasks, f.clock.now(), UnreachableStrategy.default(), instance.state.goal)
+        val status = Instance.InstanceState.transitionTo(Some(instance.state), tasks, f.clock.now(), UnreachableStrategy.default(), instance.state.goal)
 
         s"change to $to" in {
           status.condition should be(to)
@@ -138,7 +138,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     def instanceWith(condition: Condition, conditions: Seq[Condition]): (Instance, Map[Task.Id, Task]) = {
       val currentTasks = tasks(conditions.map(_ => condition))
       val newTasks = tasks(conditions)
-      val state = Instance.InstanceState(None, currentTasks, clock.now(), UnreachableStrategy.default(), Goal.Running)
+      val state = Instance.InstanceState.transitionTo(None, currentTasks, clock.now(), UnreachableStrategy.default(), Goal.Running)
       val instance = Instance(Instance.Id.forRunSpec(id), Some(agentInfo), state, currentTasks, app, None, "*")
       (instance, newTasks)
     }

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -6,7 +6,7 @@ import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition._
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
-import mesosphere.marathon.state.{AbsolutePathId, AppDefinition, UnreachableStrategy}
+import mesosphere.marathon.state.{AbsolutePathId, AppDefinition, UnreachableDisabled, UnreachableStrategy}
 import mesosphere.marathon.test.SettableClock
 import org.apache.mesos.Protos.Attribute
 import org.apache.mesos.Protos.Value.{Text, Type}
@@ -65,7 +65,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
   }
 
   "be unreachable" in {
-    val f = new Fixture
+    val f = new Fixture(unreachableStrategy = UnreachableDisabled)
 
     val (instance, _) = f.instanceWith(Condition.Unreachable, Seq(Condition.Unreachable))
     instance.isUnreachable should be(true)
@@ -79,7 +79,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
   }
 
   "be active only for active conditions" in {
-    val f = new Fixture
+    val f = new Fixture(unreachableStrategy = UnreachableDisabled)
 
     val activeConditions: Seq[Condition] = Seq(Provisioned, Killing, Running, Staging, Starting, Unreachable)
     activeConditions.foreach { condition =>
@@ -119,9 +119,9 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     }
   }
 
-  class Fixture {
+  class Fixture(unreachableStrategy: UnreachableStrategy = UnreachableStrategy.default(false)) {
     val id = AbsolutePathId("/test")
-    val app = AppDefinition(id, role = "*")
+    val app = AppDefinition(id, role = "*", unreachableStrategy = unreachableStrategy)
     val clock = new SettableClock()
 
     val agentInfo = Instance.AgentInfo("", None, None, None, Nil)
@@ -138,7 +138,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     def instanceWith(condition: Condition, conditions: Seq[Condition]): (Instance, Map[Task.Id, Task]) = {
       val currentTasks = tasks(conditions.map(_ => condition))
       val newTasks = tasks(conditions)
-      val state = Instance.InstanceState.transitionTo(None, currentTasks, clock.now(), UnreachableStrategy.default(), Goal.Running)
+      val state = Instance.InstanceState.transitionTo(None, currentTasks, clock.now(), unreachableStrategy, Goal.Running)
       val instance = Instance(Instance.Id.forRunSpec(id), Some(agentInfo), state, currentTasks, app, None, "*")
       (instance, newTasks)
     }

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -179,7 +179,7 @@ object TestInstanceBuilder {
   def fromTask(task: Task, agentInfo: AgentInfo, unreachableStrategy: UnreachableStrategy): Instance = {
     val since = task.status.startedAt.getOrElse(task.status.stagedAt)
     val tasksMap = Map(task.taskId -> task)
-    val state = Instance.InstanceState(None, tasksMap, since, unreachableStrategy, Goal.Running)
+    val state = Instance.InstanceState.transitionTo(None, tasksMap, since, unreachableStrategy, Goal.Running)
     val runSpec = AppDefinition(
       task.taskId.instanceId.runSpecId,
       unreachableStrategy = unreachableStrategy,

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdateOpResolverTest.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.task.bus.{MesosTaskStatusTestHelper, TaskStatusUpdateTestHelper}
 import mesosphere.marathon.core.task.state.TaskConditionMapping
 import mesosphere.marathon.core.task.{Task, TaskCondition}
-import mesosphere.marathon.state.{AbsolutePathId, AppDefinition, Timestamp, VersionInfo}
+import mesosphere.marathon.state.{AbsolutePathId, AppDefinition, Timestamp, UnreachableDisabled, UnreachableStrategy, VersionInfo}
 import mesosphere.marathon.test.SettableClock
 import org.apache.mesos
 import org.scalatest.Inside
@@ -257,7 +257,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     }
 
     "Processing a TASK_UNREACHABLE update for a staging task" in new Fixture {
-      val builder = TestInstanceBuilder.newBuilder(appId)
+      val builder = TestInstanceBuilder.newBuilderForRunSpec(app)
       val instance = builder.addTaskStaged().getInstance()
       val update = TaskStatusUpdateTestHelper.unreachable(instance)
       val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
@@ -270,7 +270,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     }
 
     "Processing a TASK_UNREACHABLE update for a starting task" in new Fixture {
-      val builder = TestInstanceBuilder.newBuilder(appId)
+      val builder = TestInstanceBuilder.newBuilderForRunSpec(app)
       val instance = builder.addTaskStarting().getInstance()
       val update = TaskStatusUpdateTestHelper.unreachable(instance)
       val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
@@ -284,7 +284,7 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     }
 
     "Processing a TASK_UNREACHABLE update for a running task" in new Fixture {
-      val builder = TestInstanceBuilder.newBuilder(appId)
+      val builder = TestInstanceBuilder.newBuilderForRunSpec(app)
       val instance = builder.addTaskRunning().getInstance()
       val update = TaskStatusUpdateTestHelper.unreachable(instance)
       val stateChange = updateOpResolver.resolve(Some(instance), update.operation)
@@ -319,13 +319,14 @@ class InstanceUpdateOpResolverTest extends UnitTest with Inside {
     }
   }
 
-  class Fixture {
+  class Fixture(unreachableStrategy: UnreachableStrategy = UnreachableDisabled) {
     val eventsGenerator = InstanceChangedEventsGenerator
     val clock = SettableClock.ofNow()
     val updateOpResolver = new InstanceUpdateOpResolver(clock)
 
     lazy val appId = AbsolutePathId("/app")
-    lazy val existingInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
+    lazy val app = AppDefinition(appId, unreachableStrategy = unreachableStrategy, role = "*")
+    lazy val existingInstance: Instance = TestInstanceBuilder.newBuilderForRunSpec(app).addTaskRunning().getInstance()
     val existingDecommissionedInstance = existingInstance.copy(state = existingInstance.state.copy(goal = Goal.Decommissioned))
     lazy val existingTask: Task = existingInstance.appTask
 

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -73,7 +73,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
       val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
 
       // Forward time to expire unreachable status
-      f.clock.advanceBy(unreachableInactiveAfter + 1.minute)
+      f.clock.advanceBy(unreachableInactiveAfter)
       val operation = InstanceUpdateOperation.MesosUpdate(f.instance, newMesosStatus, f.clock.now())
       val result = InstanceUpdater.mesosUpdate(f.instance, operation)
 

--- a/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/update/InstanceUpdaterTest.scala
@@ -46,8 +46,8 @@ class InstanceUpdaterTest extends UnitTest with Inside {
 
   "A Running instance" when {
     "processing an Unreachable update" should {
-      val f = new Fixture
-      val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId)
+      val f = new Fixture(unreachableStrategy = UnreachableEnabled(0.seconds, 15.minutes))
+      val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
       val operation = InstanceUpdateOperation.MesosUpdate(f.instance, newMesosStatus, f.clock.now())
       val result = InstanceUpdater.mesosUpdate(f.instance, operation)
 
@@ -67,8 +67,8 @@ class InstanceUpdaterTest extends UnitTest with Inside {
       }
     }
 
-    "processing an expired unreachable" should {
-      val f = new Fixture
+    "should expunge instances immediately when the instance expunge" should {
+      val f = new Fixture(unreachableStrategy = UnreachableEnabled(0.seconds, 15.minutes))
       val unreachableInactiveAfter = f.instance.unreachableStrategy.asInstanceOf[UnreachableEnabled].inactiveAfter
       val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
 
@@ -89,6 +89,57 @@ class InstanceUpdaterTest extends UnitTest with Inside {
       }
       "add a task event" in {
         val effect = result.asInstanceOf[InstanceUpdateEffect.Update]
+        effect.events(0) match {
+          case MesosStatusUpdateEvent(_, _, taskStatus, _, _, _, _, _, _, _, _) =>
+            taskStatus should be(TASK_UNREACHABLE)
+          case _ => fail("Event did not match MesosStatusUpdateEvent")
+        }
+      }
+    }
+
+    "processing an expired unreachable, but not yet reaching the expunge threshold" should {
+      val f = new Fixture(unreachableStrategy = UnreachableEnabled(0.seconds, 15.minutes))
+      val unreachableInactiveAfter = f.instance.unreachableStrategy.asInstanceOf[UnreachableEnabled].inactiveAfter
+      val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
+
+      // Forward time to expire unreachable status
+      f.clock.advanceBy(unreachableInactiveAfter)
+      val operation = InstanceUpdateOperation.MesosUpdate(f.instance, newMesosStatus, f.clock.now())
+      val result = InstanceUpdater.mesosUpdate(f.instance, operation)
+
+      "result in an update effect" in { result shouldBe a[InstanceUpdateEffect.Update] }
+      "become unreachable inactive" in {
+        val effect = result.asInstanceOf[InstanceUpdateEffect.Update]
+        effect.events(1) match {
+          case InstanceChanged(instanceId, _, _, condition, _) =>
+            instanceId should be(f.instance.instanceId)
+            condition should be(Condition.UnreachableInactive)
+          case _ => fail("Event did not match InstanceChanged")
+        }
+      }
+      "add a task event" in {
+        val effect = result.asInstanceOf[InstanceUpdateEffect.Update]
+        effect.events(0) match {
+          case MesosStatusUpdateEvent(_, _, taskStatus, _, _, _, _, _, _, _, _) =>
+            taskStatus should be(TASK_UNREACHABLE)
+          case _ => fail("Event did not match MesosStatusUpdateEvent")
+        }
+      }
+    }
+
+    "processing an expired unreachable where the expunge threshold is reached" should {
+      val f = new Fixture(unreachableStrategy = UnreachableEnabled(0.seconds, 0.seconds))
+      val unreachableInactiveAfter = f.instance.unreachableStrategy.asInstanceOf[UnreachableEnabled].inactiveAfter
+      val newMesosStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
+
+      // Forward time to expire unreachable status
+      f.clock.advanceBy(unreachableInactiveAfter)
+      val operation = InstanceUpdateOperation.MesosUpdate(f.instance, newMesosStatus, f.clock.now())
+      val result = InstanceUpdater.mesosUpdate(f.instance, operation)
+
+      "result in an expunge effect" in { result shouldBe a[InstanceUpdateEffect.Expunge] }
+      "add a task event" in {
+        val effect = result.asInstanceOf[InstanceUpdateEffect.Expunge]
         effect.events(0) match {
           case MesosStatusUpdateEvent(_, _, taskStatus, _, _, _, _, _, _, _, _) =>
             taskStatus should be(TASK_UNREACHABLE)
@@ -148,10 +199,10 @@ class InstanceUpdaterTest extends UnitTest with Inside {
   "An unreachable instance" when {
 
     "updated to running" should {
-      val f = new Fixture
+      val f = new Fixture(unreachableStrategy = UnreachableEnabled(0.seconds, 15.minutes))
 
       // Setup unreachable instance with a unreachable task
-      val mesosTaskStatus = MesosTaskStatusTestHelper.unreachable(f.taskId)
+      val mesosTaskStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
       val unreachableStatus = f.taskStatus.copy(startedAt = None, condition = Condition.Unreachable, mesosStatus = Some(mesosTaskStatus))
       val unreachableTask = f.task.copy(status = unreachableStatus)
       val unreachableState = f.instanceState.copy(condition = Condition.Unreachable)
@@ -169,14 +220,17 @@ class InstanceUpdaterTest extends UnitTest with Inside {
     }
 
     "update to unknown" should {
-      val f = new Fixture
+      val f = new Fixture(unreachableStrategy = UnreachableEnabled(0.seconds, 15.minutes))
 
       // Setup unreachable instance with a unreachable task
-      val mesosTaskStatus = MesosTaskStatusTestHelper.unreachable(f.taskId)
+      val mesosTaskStatus = MesosTaskStatusTestHelper.unreachable(f.taskId, since = f.clock.now())
       val unreachableStatus = f.taskStatus.copy(startedAt = None, condition = Condition.Unreachable, mesosStatus = Some(mesosTaskStatus))
       val unreachableTask = f.task.copy(status = unreachableStatus)
       val unreachableState = f.instanceState.copy(condition = Condition.Unreachable)
-      val unreachableInstance = f.instance.copy(tasksMap = Map(f.taskId -> unreachableTask), state = unreachableState)
+      val unreachableInstance = f.instance.copy(
+        tasksMap = Map(f.taskId -> unreachableTask),
+        state = unreachableState,
+        runSpec = f.app.copy(unreachableStrategy = UnreachableEnabled(0.seconds, 15.minutes)))
 
       // Update to running
       val unknownMesosTaskStatus = MesosTaskStatusTestHelper.unknown(f.taskId)
@@ -456,7 +510,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
 
   }
 
-  class Fixture {
+  class Fixture(unreachableStrategy: UnreachableStrategy = UnreachableStrategy.default(resident = false)) {
     val container1 = MesosContainer(
       name = "container1",
       resources = Resources()
@@ -480,7 +534,7 @@ class InstanceUpdaterTest extends UnitTest with Inside {
       networkInfo = NetworkInfoPlaceholder()
     )
     val task = Task(taskId, runSpecVersion = clock.now(), status = taskStatus)
-    val app = AppDefinition(instanceId.runSpecId, role = "*", versionInfo = VersionInfo.OnlyVersion(clock.now()))
+    val app = AppDefinition(instanceId.runSpecId, role = "*", versionInfo = VersionInfo.OnlyVersion(clock.now()), unreachableStrategy = unreachableStrategy)
     val instance = Instance(
       instanceId, Some(agentInfo), instanceState, Map(taskId -> task), app, None, "*")
   }

--- a/src/test/scala/mesosphere/marathon/raml/ReadinessConversionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/ReadinessConversionsTest.scala
@@ -3,7 +3,6 @@ package raml
 
 import mesosphere.UnitTest
 import mesosphere.marathon.core.readiness.{ReadinessCheck => CoreReadinessCheck}
-import mesosphere.marathon.state.ReadinessCheckSerializer
 
 import scala.concurrent.duration._
 

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package test
 
+import java.io.{File, FileNotFoundException}
 import java.time.Clock
 
 import akka.stream.Materializer
@@ -532,4 +533,14 @@ object MarathonTestHelper {
     }
   }
 
+  def resourcePath(resourceName: String): File = {
+    val classLoader = getClass.getClassLoader
+
+    Option(classLoader.getResource(resourceName)) match {
+      case Some(fileName) =>
+        new File(fileName.getFile)
+      case None =>
+        throw new FileNotFoundException(s"Could not find resource ${resourceName}")
+    }
+  }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -85,6 +85,46 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
       task.region shouldBe Some(f.remoteRegion.value)
       task.zone shouldBe Some(f.remoteZone2.value)
     }
+
+    "Replace an unreachable instance in the same region" in {
+      val applicationId = appId("must-be-placed-in-remote-region-and-zone")
+      val strategy = raml.UnreachableEnabled(inactiveAfterSeconds = 0, expungeAfterSeconds = 4 * 60)
+      val app = appProxy(applicationId, "v1", instances = 4, healthCheck = None).copy(constraints = Set(
+        Constraints.regionField :: "GROUP_BY" :: "2" :: Nil
+      ), unreachableStrategy = Some(strategy))
+
+      Given("an app grouped by two regions")
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+      val tasks = marathon.tasks(applicationId).value
+      tasks should have size (4)
+      tasks.groupBy(_.region.value).keySet should be(Set("home_region", "remote_region"))
+      tasks.groupBy(_.region.value).get("home_region").value should have size (2)
+      tasks.groupBy(_.region.value).get("remote_region").value should have size (2)
+
+      When("one agent in the remote region becomes unreachable")
+      mesosCluster.agents.find(_.extraArgs.exists(_.contains("remote_region"))).value.stop()
+      waitForEventMatching("Task is declared lost") { event =>
+        event.info.get("taskStatus").contains("TASK_UNREACHABLE") &&
+          event.info.get("appId").contains(app.id)
+      }
+
+      Then("a replacement is launched in the remote region")
+      eventually {
+        val tasks = marathon.tasks(applicationId).value
+        tasks should have size (5)
+        tasks.groupBy(_.region.value).keySet should be(Set("home_region", "remote_region"))
+
+        // Actual
+        tasks.groupBy(_.region.value).get("home_region").value should have size (3)
+        tasks.groupBy(_.region.value).get("remote_region").value should have size (2)
+
+        // Expected
+        //tasks.groupBy(_.region.value).get("home_region").value should have size (2)
+        //tasks.groupBy(_.region.value).get("remote_region").value should have size (3)
+      }
+    }
   }
 
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -87,7 +87,7 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
     }
 
     "Replace an unreachable instance in the same region" in {
-      val applicationId = appId("must-be-placed-in-remote-region-and-zone")
+      val applicationId = appId("unreachable-instance-is-place-in-same-region")
       val strategy = raml.UnreachableEnabled(inactiveAfterSeconds = 0, expungeAfterSeconds = 4 * 60)
       val app = appProxy(applicationId, "v1", instances = 4, healthCheck = None).copy(constraints = Set(
         Constraints.regionField :: "GROUP_BY" :: "2" :: Nil

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -121,6 +121,20 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
         tasks.groupBy(_.region.value).get("home_region").value should have size (2)
         tasks.groupBy(_.region.value).get("remote_region").value should have size (2)
       }
+
+      When("the agent comes back")
+      agent.start()
+
+      Then("eventually Marathon kills the previously unreachable tasks")
+
+      eventually {
+        inside(mesosFacade.frameworks().value.frameworks) {
+          case Seq(marathonFramework) =>
+            val states = marathonFramework.tasks.map(_.state).flatten.toSet
+            logger.info(s"State: ${states}")
+            states shouldBe Set("TASK_KILLED", "TASK_RUNNING")
+        }
+      }
     }
   }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -29,6 +29,7 @@ import mesosphere.marathon.core.pod.{HostNetwork, MesosContainer, PodDefinition}
 import mesosphere.marathon.integration.facades._
 import mesosphere.marathon.raml.{App, AppCheck, AppHealthCheck, AppHostVolume, AppPersistentVolume, AppResidency, AppVolume, Container, EngineType, Network, NetworkMode, PersistentVolumeInfo, PortDefinition, ReadMode, UnreachableDisabled, UpgradeStrategy}
 import mesosphere.marathon.state.{AbsolutePathId, PathId, PersistentVolume, VolumeMount}
+import mesosphere.marathon.test.MarathonTestHelper
 import mesosphere.marathon.util.{Lock, Retry, Timeout}
 import mesosphere.{AkkaUnitTestLike, WaitTestSupport}
 import org.apache.commons.io.FileUtils
@@ -368,7 +369,7 @@ trait MarathonAppFixtures {
 
   def appMockCmd(appId: PathId, versionId: String): String = {
     val projectDir = sys.props.getOrElse("user.dir", ".")
-    val appMock: File = new File(projectDir, "src/test/resources/python/app_mock.py")
+    val appMock: File = MarathonTestHelper.resourcePath("python/app_mock.py")
     if (!appMock.exists()) {
       throw new IllegalStateException("Failed to locate app_mock.py (" + appMock.getAbsolutePath + ")")
     }


### PR DESCRIPTION
Summary:
In this change, we modify the expunge-after logic to evaluate in the same event cycle as the unreachable-inactive logic, allowing expungeAfterSeconds: 0 to expunge an instance immediately when it becomes unreachable.

This improves the evaluation of group-by and unique constraints.

JIRA issues: MARATHON-8719, DCOS-61251

Co-authored-by: Tim Harper <tharper@mesosphere.com>