### PR TITLE
Include reschuduled failed instances in pod status.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,14 @@
 
 ### Fixed issues
 
-* [MARATHON-8711](https://jira.mesosphere.com/browse/MARATHON-8711) - Fix pod status for `Scheduled` instances with a goal `Stopped`
-* [MARATHON-8712](https://jira.mesosphere.com/browse/MARATHON-8712) - Fix an issue where the upgrade migration would fail if there were any persisted instances in state "scheduled" (IE ongoing deployment) during the upgrade attempt.
-* [MARATHON-8713](https://jira.mesosphere.com/browse/MARATHON-8713) - Fixed issue where defaultRole for groups with enforceRole: false did not match the documentation and defaulted to the group-role, regardless.
+* [MARATHON-8711](https://jira.mesosphere.com/browse/MARATHON-8711) - Fix pod status for `Scheduled` instances with a
+  goal `Stopped`
+* [MARATHON-8712](https://jira.mesosphere.com/browse/MARATHON-8712) - Fix an issue where the upgrade migration would
+  fail if there were any persisted instances in state "scheduled" (IE ongoing deployment) during the upgrade attempt.
+* [MARATHON-8713](https://jira.mesosphere.com/browse/MARATHON-8713) - Fixed issue where defaultRole for groups with
+  enforceRole: false did not match the documentation and defaulted to the group-role, regardless.
+* [MARATHON-8710](https://jira.mesosphere.com/browse/MARATHON-8710) - Marathon would not include failed and re-scheduled
+  instances in `/v2/pods/::status` calls. This has been fixed. Note: freshly scheduled instances won't be shown.
 
 ## Changes from 1.9.73 to 1.9.100
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ### Fixed issues
 
 * [MARATHON-8711](https://jira.mesosphere.com/browse/MARATHON-8711) - Fix pod status for `Scheduled` instances with a
-  goal `Stopped`
+  goal `Stopped`, which was causing scaled-down, terminal resident instances to not show up anywhere in the list.
 * [MARATHON-8712](https://jira.mesosphere.com/browse/MARATHON-8712) - Fix an issue where the upgrade migration would
   fail if there were any persisted instances in state "scheduled" (IE ongoing deployment) during the upgrade attempt.
 * [MARATHON-8713](https://jira.mesosphere.com/browse/MARATHON-8713) - Fixed issue where defaultRole for groups with

--- a/src/main/scala/mesosphere/marathon/ScallopHelper.scala
+++ b/src/main/scala/mesosphere/marathon/ScallopHelper.scala
@@ -3,11 +3,12 @@ package mesosphere.marathon
 import org.rogach.scallop.{ScallopConf, ScallopOption}
 
 object ScallopHelper {
-  /** Return all defined options for a Scallop config; uses Java reflection to search for and invoke the
-   * appropriate methods
-   *
-   * @return List of all found ScallopOptions
-   */
+  /**
+    * Return all defined options for a Scallop config; uses Java reflection to search for and invoke the
+    * appropriate methods
+    *
+    * @return List of all found ScallopOptions
+    */
   def scallopOptions(o: ScallopConf): Seq[ScallopOption[_]] = {
     o.getClass.getMethods.iterator.collect {
       case method if method.getParameterCount == 0 && method.getReturnType == classOf[ScallopOption[_]] =>

--- a/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
+++ b/src/main/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseData.scala
@@ -166,7 +166,10 @@ class AppInfoBaseData(
     val now = clock.now().toOffsetDateTime
     val instances = await(instancesByRunSpecFuture).specInstances(podDef.id)
     val instanceStatus = instances
-      .filter(!_.isScheduled)
+      .filter { instance =>
+        // Ignore all freshly scheduled instances but include the re-scheduled ones.
+        !(instance.isScheduled && instance.agentInfo.isEmpty)
+      }
       .flatMap { inst => podInstanceStatus(inst) }
     val statusSince = if (instanceStatus.isEmpty) now else instanceStatus.map(_.statusSince).max
     val state = await(podState(podDef.instances, instanceStatus, isPodTerminating(podDef.id)))


### PR DESCRIPTION
Summary:
Marathon does not show scheduled pod instances in its API. This is due
to backwards compatibility when scheduled instances did not exist.
However, a resident pod might be re-scheduled. These should be shown
with their terminal or failed state. This patch will change the
filtering so that scheduled pods that do have a history, ie agent info,
are considered as re-scheduled and thus included.

JIRA issues: MARATHON-8710