### PR TITLE
Respect minimumHealthCapacity during leader election

### DIFF
--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/RestartStrategyTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/RestartStrategyTest.scala
@@ -24,7 +24,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 1
@@ -43,7 +43,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = 0)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 0)
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 1
@@ -62,7 +62,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -81,7 +81,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = app.instances + 2)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances + 2)
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -100,7 +100,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = app.instances - 2)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances - 2)
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -119,7 +119,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -137,7 +137,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.5, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
 
       Then("the app instance count is exceeded by one")
       strategy.maxCapacity shouldBe 2
@@ -155,7 +155,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.5, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = 0)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 0)
 
       Then("the app instance count does not need to be exceeded (since we can start a task without kills)")
       strategy.maxCapacity shouldBe 1
@@ -173,7 +173,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.5, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
 
       Then("the app instance count is exceeded by one")
       strategy.maxCapacity shouldBe 2
@@ -191,7 +191,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.1, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = 1)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 1)
 
       Then("the maxCapacity equals the app.instance count")
       strategy.maxCapacity shouldBe 10
@@ -209,7 +209,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.1, maximumOverCapacity = 1.0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = 10)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 10)
 
       Then("the maxCapacity is double the app.instance count")
       strategy.maxCapacity shouldBe 20
@@ -227,7 +227,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 1, maximumOverCapacity = 1.0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, runningInstancesCount = 10)
+      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 10)
 
       Then("the maxCapacity is double the app.instance count")
       strategy.maxCapacity shouldBe 20

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/RestartStrategyTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/RestartStrategyTest.scala
@@ -2,6 +2,8 @@ package mesosphere.marathon
 package core.deployment.impl
 
 import mesosphere.UnitTest
+import mesosphere.marathon.core.instance.Goal
+import mesosphere.marathon.core.instance.Instance.InstanceState
 import mesosphere.marathon.state._
 
 class RestartStrategyTest extends UnitTest {
@@ -11,6 +13,18 @@ class RestartStrategyTest extends UnitTest {
     mount = VolumeMount(volumeName = None, mountPath = "path")
   ))
   ))
+
+  def mockInstances(instanceCount: Int, healthy: (Int) => Boolean = _ => true): Seq[mesosphere.marathon.core.instance.Instance] = {
+    val instances: Seq[mesosphere.marathon.core.instance.Instance] = List.tabulate(instanceCount)(f = i => {
+      val instance = mock[mesosphere.marathon.core.instance.Instance]
+      instance.consideredHealthy returns healthy(i)
+      val goal = mock[InstanceState]
+      instance.state returns goal
+      instance.state.goal returns Goal.Running
+      instance
+    })
+    instances
+  }
 
   import mesosphere.marathon.core.deployment.impl.TaskReplaceActor._
   "RestartStrategy" should {
@@ -24,7 +38,8 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
+
+      val strategy = computeRestartStrategy(app, mockInstances(1))
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 1
@@ -43,7 +58,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 0)
+      val strategy = computeRestartStrategy(app, mockInstances(1, _ => false))
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 1
@@ -62,7 +77,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances))
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -81,7 +96,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances + 2)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances + 2))
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -100,7 +115,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances - 2)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances, i => (i < app.instances - 2)))
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -119,7 +134,7 @@ class RestartStrategyTest extends UnitTest {
         container = container)
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances))
 
       Then("the app instance count is not exceeded")
       strategy.maxCapacity shouldBe 5
@@ -137,7 +152,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.5, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances))
 
       Then("the app instance count is exceeded by one")
       strategy.maxCapacity shouldBe 2
@@ -155,7 +170,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.5, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 0)
+      val strategy = computeRestartStrategy(app, mockInstances(0))
 
       Then("the app instance count does not need to be exceeded (since we can start a task without kills)")
       strategy.maxCapacity shouldBe 1
@@ -173,7 +188,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.5, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = app.instances)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances))
 
       Then("the app instance count is exceeded by one")
       strategy.maxCapacity shouldBe 2
@@ -191,7 +206,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.1, maximumOverCapacity = 0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 1)
+      val strategy = computeRestartStrategy(app, mockInstances(1))
 
       Then("the maxCapacity equals the app.instance count")
       strategy.maxCapacity shouldBe 10
@@ -209,7 +224,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.1, maximumOverCapacity = 1.0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 10)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances))
 
       Then("the maxCapacity is double the app.instance count")
       strategy.maxCapacity shouldBe 20
@@ -227,7 +242,7 @@ class RestartStrategyTest extends UnitTest {
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 1, maximumOverCapacity = 1.0))
 
       When("the ignition strategy is computed")
-      val strategy = computeRestartStrategy(app, consideredHealthyInstancesCount = 10)
+      val strategy = computeRestartStrategy(app, mockInstances(app.instances))
 
       Then("the maxCapacity is double the app.instance count")
       strategy.maxCapacity shouldBe 20

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -514,7 +514,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
 
       // one task is killed directly because we are over capacity
       eventually {
-        verify(f.tracker).setGoal(instanceA.instanceId, Goal.Decommissioned, GoalChangeReason.Upgrading)
+        verify(f.tracker).setGoal(any, eq(Goal.Decommissioned), eq(GoalChangeReason.Upgrading))
       }
 
       // the kill is confirmed (see answer above) and the first new task is queued

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/TaskReplaceActorTest.scala
@@ -23,6 +23,7 @@ import mesosphere.marathon.state._
 import mesosphere.marathon.util.CancellableOnce
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.{Future, Promise}
 
@@ -233,6 +234,52 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
       verify(f.tracker).setGoal(instanceC.instanceId, Goal.Decommissioned, GoalChangeReason.Upgrading)
 
       expectTerminated(ref)
+    }
+
+    "respect upgrade strategy" in {
+      Given("An app with health checks, 1 task of new version already started but not passing health checks yet")
+      val f = new Fixture
+
+      val app = AppDefinition(
+        id = AbsolutePathId("/myApp"),
+        role = "*",
+        instances = 2,
+        versionInfo = VersionInfo.forNewConfig(Timestamp(0)),
+        healthChecks = Set(MarathonHttpHealthCheck(portIndex = Some(PortReference(0)))),
+        upgradeStrategy = UpgradeStrategy(0.50, 0)
+      )
+      val newApp = app.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(1)))
+
+      val instanceA = f.healthyInstance(app)
+      // instance B was already started during deployment started by a previous leader but is not healthy yet
+      val instanceB = f.healthyInstance(newApp, healthy = false)
+
+      f.tracker.specInstancesSync(app.id, readAfterWrite = true) returns Seq(instanceA, instanceB)
+      f.tracker.get(instanceA.instanceId) returns Future.successful(Some(instanceA))
+      f.tracker.get(instanceB.instanceId) returns Future.successful(Some(instanceB))
+
+      val promise = Promise[Unit]()
+
+      f.queue.add(newApp, 1) returns Future.successful(Done)
+      val ref = f.replaceActor(newApp, promise)
+      watch(ref)
+
+      // deployment should not complete within 1s, that's also a good way to wait for 1s to check for next assertion
+      assert(promise.future.isReadyWithin(timeout = Span(1000, Millis)) == false)
+      // that's the core of this test: we haven't replaced task yet, see MARATHON-8716
+      verify(f.tracker, never).setGoal(instanceA.instanceId, Goal.Decommissioned, GoalChangeReason.Upgrading)
+
+      // we can now make this new instance healthy
+      ref ! f.healthChanged(newApp, healthy = true)
+      // and we can check deployment continue as usual
+      eventually {
+        verify(f.tracker, times(1)).setGoal(any, any, any)
+      }
+      eventually {
+        verify(f.queue, times(1)).add(newApp, 1)
+      }
+
+      // and we don't need to wait for end of deployment
     }
 
     "replace tasks during rolling upgrade *without* over-capacity" in {
@@ -741,6 +788,12 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
         .getInstance()
     }
 
+    def healthyInstance(app: AppDefinition, healthy: Boolean = true): Instance = {
+      TestInstanceBuilder.newBuilderForRunSpec(app, now = app.version)
+        .addTaskWithBuilder().taskRunning().asHealthyTask(healthy).withNetworkInfo(hostName = Some(hostName), hostPorts = hostPorts).build()
+        .getInstance()
+    }
+
     def readinessResults(instance: Instance, checkName: String, ready: Boolean): (Cancellable, Source[ReadinessCheckResult, Cancellable]) = {
       val cancellable = new CancellableOnce(() => ())
       val source = Source(instance.tasksMap.values.map(task => ReadinessCheckResult(checkName, task.taskId, ready, None)).toList).
@@ -759,6 +812,7 @@ class TaskReplaceActorTest extends AkkaUnitTest with Eventually {
     def healthChanged(app: AppDefinition, healthy: Boolean): InstanceHealthChanged = {
       InstanceHealthChanged(Instance.Id.forRunSpec(app.id), app.version, app.id, healthy = Some(healthy))
     }
+
     def replaceActor(app: AppDefinition, promise: Promise[Unit]): ActorRef = system.actorOf(
       TaskReplaceActor.props(deploymentsManager, deploymentStatus, queue,
         tracker, system.eventStream, readinessCheckExecutor, app, promise)

--- a/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestInstanceBuilder.scala
@@ -162,7 +162,6 @@ object TestInstanceBuilder {
 
   def emptyInstanceForRunSpec(now: Timestamp = Timestamp.now(), runSpec: RunSpec, instanceId: Instance.Id): Instance = {
     val resolvedInstanceId = Option(instanceId).getOrElse(Instance.Id.forRunSpec(runSpec.id))
-
     require(resolvedInstanceId.runSpecId == runSpec.id, "provided instanceId did not match runSpec")
 
     Instance(

--- a/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/TestTaskBuilder.scala
@@ -196,11 +196,11 @@ case class TestTaskBuilder(task: Option[Task], instanceBuilder: TestInstanceBuil
     networkInfos: scala.collection.Seq[mesos.Protos.NetworkInfo] = Nil): TestTaskBuilder =
     copy(task = task.map(_.withNetworkInfo(hostName, hostPorts, networkInfos)))
 
-  def asHealthyTask(): TestTaskBuilder = {
+  def asHealthyTask(healthy: Boolean = true): TestTaskBuilder = {
     import mesosphere.marathon.test.MarathonTestHelper.Implicits._
     this.copy(task = task match {
       case Some(t: Task) => Some(t.withStatus(status =>
-        status.copy(mesosStatus = status.mesosStatus.map(_.toBuilder.setHealthy(true).build()))))
+        status.copy(mesosStatus = status.mesosStatus.map(_.toBuilder.setHealthy(healthy).build()))))
       case None => None
     })
   }


### PR DESCRIPTION
Before this patch, during a deployment, a leader election would lead
marathon to not respect minimumHealthCapacity parameter.
Reason is that TaskReplaceActor used to ignore instance healthyness when
considering instance that could be killed "immediately" upon actor
start.

We now respect minimumHealthCapacity by taking into account healthy
instances.

This patch required to add an property "this app has configured
healthchecks" to be able to distinguish following cases:
- app has HC but we don't have signal yet for given instance
- app has HC and we have signal of healthyness for given instance
- app has no HC

It also brings ability to fix TODO at
https://github.com/mesosphere/marathon/blob/master/src/main/scala/mesosphere/marathon/core/instance/Instance.scala#L267
in a future patch since we now know difference between no HC and no
information about HC.

Fixes: MARATHON-8716
Change-Id: Ia7b11cbb22f86967b49298f774c6d27fc01a6e58
Signed-off-by: Grégoire Seux <g.seux@criteo.com>
