### PR TITLE
Support Scala 2.13 in pipeline script.

### DIFF
--- a/ci/awsClient.sc
+++ b/ci/awsClient.sc
@@ -12,7 +12,7 @@ import com.amazonaws.auth._
 import com.amazonaws.services.s3.transfer._
 import com.amazonaws.services.s3.transfer.Transfer.TransferState
 import com.amazonaws.services.s3.model.{CopyObjectRequest, PutObjectRequest, CannedAccessControlList}
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
  * Describes an S3 location.

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -109,7 +109,6 @@ def zipLogs(logFileName: String = "ci.log", sandboxFileName: String = "sandboxes
  * @return Artifact description if it was uploaded.
  */
 def uploadTarballPackagesToS3(version: SemVer, buildLocation: String): Option[awsClient.Artifact] = utils.stage("Upload Tarball Packages") {
-  import scala.collection.breakOut
 
   // Upload docs
   PACKAGE_DOCS_DIR.toIO.listFiles.filter(f => f.getName.endsWith(".tgz"))

--- a/ci/upgrade.sc
+++ b/ci/upgrade.sc
@@ -1,6 +1,6 @@
 #!/usr/bin/env amm
 
-import $ivy.`com.typesafe.play::play-json:2.6.0`
+import $ivy.`com.typesafe.play::play-json:2.8.1`
 import $ivy.`org.eclipse.jgit:org.eclipse.jgit:4.8.0.201706111038-r`
 
 import ammonite.ops._


### PR DESCRIPTION
Summary:
Newer Ammonite versions use Scala 2.13. This change makes the pipeline
script compatible with the new version.
