### PR TITLE
Fix flakiness of RemoteRegionOffersIntegrationTest

### DIFF
--- a/docs/docs/developing.md
+++ b/docs/docs/developing.md
@@ -13,6 +13,20 @@ The following project configuration should be enabled when developing Marathon:
 
 ### Common issues
 
+#### Local maven repository is not seen
+
+If you are publishing USI dependencies locally using `./gradlew publishMavenJavaPublicationToMavenLocal` (please catch your breath if reading out loud), and get the error that the dependency is not found, you need to configure sbt to globally look for your local maven repo. Usually, this is done by adding the following file:
+
+`~/.sbt/1.0/local-maven.sbt`
+
+```scala
+resolvers := {
+  val localMaven = "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"
+  localMaven +: resolvers.value
+}
+```
+
+
 #### Compiler issue "Protos is already defined as class Protos"
 
 If you see the error:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -150,7 +150,7 @@ object Dependency {
     val Mockito = "1.10.19"
     val ScalaCheck = "1.13.5"
     val ScalaTest = "3.0.4"
-    val UsiTestUtil = "0.1.30-697e6e7-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/135
+    val UsiTestUtil = "0.1.30-a8aeddb-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/135
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -150,7 +150,7 @@ object Dependency {
     val Mockito = "1.10.19"
     val ScalaCheck = "1.13.5"
     val ScalaTest = "3.0.4"
-    val UsiTestUtil = "0.1.12"
+    val UsiTestUtil = "0.1.29-63fe7d2-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/134
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -150,7 +150,7 @@ object Dependency {
     val Mockito = "1.10.19"
     val ScalaCheck = "1.13.5"
     val ScalaTest = "3.0.4"
-    val UsiTestUtil = "0.1.30"
+    val UsiTestUtil = "0.1.30-a3216e6-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/135
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -150,7 +150,7 @@ object Dependency {
     val Mockito = "1.10.19"
     val ScalaCheck = "1.13.5"
     val ScalaTest = "3.0.4"
-    val UsiTestUtil = "0.1.30-a3216e6-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/135
+    val UsiTestUtil = "0.1.30-697e6e7-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/135
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -150,7 +150,7 @@ object Dependency {
     val Mockito = "1.10.19"
     val ScalaCheck = "1.13.5"
     val ScalaTest = "3.0.4"
-    val UsiTestUtil = "0.1.29-63fe7d2-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/134
+    val UsiTestUtil = "0.1.30"
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -150,7 +150,7 @@ object Dependency {
     val Mockito = "1.10.19"
     val ScalaCheck = "1.13.5"
     val ScalaTest = "3.0.4"
-    val UsiTestUtil = "0.1.30-a8aeddb-SNAPSHOT" // TODO - merge https://github.com/mesosphere/usi/pull/135
+    val UsiTestUtil = "0.1.31"
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
@@ -12,8 +12,6 @@ import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.SpecInstances
 import mesosphere.marathon.state.{AbsolutePathId, Timestamp, UnreachableDisabled, UnreachableEnabled}
 
-import scala.concurrent.duration.Duration
-
 /**
   * Business logic of overdue tasks actor.
   *
@@ -43,8 +41,8 @@ trait ExpungeOverdueLostTasksActorLogic extends StrictLogging {
     case UnreachableDisabled =>
       false
     case unreachableEnabled: UnreachableEnabled =>
-      unreachableEnabled.expungeAfter == Duration.Zero ||
-        instance.isUnreachableInactive &&
+      // Instances configured to expunge immediately will be expunged in response to the Mesos TASK_UNREACHABLE
+      instance.isUnreachableInactive &&
         instance.tasksMap.valuesIterator.exists(_.isUnreachableExpired(now, unreachableEnabled.expungeAfter))
   }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state.AbsolutePathId
 import mesosphere.mesos.Constraints
 import org.scalatest.Inside
-import org.scalatest.Inspectors.forAll
+//import org.scalatest.Inspectors.forAll
 
 class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -7,7 +7,7 @@ import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.state.AbsolutePathId
 import mesosphere.mesos.Constraints
 import org.scalatest.Inside
-//import org.scalatest.Inspectors.forAll
+import org.scalatest.Inspectors.forAll
 
 class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
 
@@ -34,16 +34,16 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
   )
 
   // This hook is also defined in TaskUnreachableIntegrationTest. We should probably move it into MesosClusterTest.
-//  override def afterAll(): Unit = {
-//    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
-//    mesosCluster.agents.foreach(_.start())
-//    eventually {
-//      val state = mesosFacade.state.value
-//      state.agents.size shouldBe mesosCluster.agents.size
-//      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
-//    }
-//    super.afterAll()
-//  }
+  override def afterAll(): Unit = {
+    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
+    mesosCluster.agents.foreach(_.start())
+    eventually {
+      val state = mesosFacade.state.value
+      state.agents.size shouldBe mesosCluster.agents.size
+      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
+    }
+    super.afterAll()
+  }
 
   def appId(suffix: String): AbsolutePathId = testBasePath / s"app-${suffix}"
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -34,16 +34,16 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
   )
 
   // This hook is also defined in TaskUnreachableIntegrationTest. We should probably move it into MesosClusterTest.
-  override def afterAll(): Unit = {
-    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
-    mesosCluster.agents.foreach(_.start())
-    eventually {
-      val state = mesosFacade.state.value
-      state.agents.size shouldBe mesosCluster.agents.size
-      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
-    }
-    super.afterAll()
-  }
+//  override def afterAll(): Unit = {
+//    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
+//    mesosCluster.agents.foreach(_.start())
+//    eventually {
+//      val state = mesosFacade.state.value
+//      state.agents.size shouldBe mesosCluster.agents.size
+//      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
+//    }
+//    super.afterAll()
+//  }
 
   def appId(suffix: String): AbsolutePathId = testBasePath / s"app-${suffix}"
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.App
 import mesosphere.marathon.state.{AbsolutePathId, UnreachableDisabled}
 import org.scalatest.Inside
-import org.scalatest.Inspectors.forAll
+//import org.scalatest.Inspectors.forAll
 
 import scala.concurrent.duration._
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -40,16 +40,16 @@ class TaskUnreachableIntegrationTest extends AkkaIntegrationTest with EmbeddedMa
     cleanUp()
   }
 
-  override def afterAll(): Unit = {
-    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
-    mesosCluster.agents.foreach(_.start())
-    eventually {
-      val state = mesosFacade.state.value
-      state.agents.size shouldBe mesosCluster.agents.size
-      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
-    }
-    super.afterAll()
-  }
+//  override def afterAll(): Unit = {
+//    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
+//    mesosCluster.agents.foreach(_.start())
+//    eventually {
+//      val state = mesosFacade.state.value
+//      state.agents.size shouldBe mesosCluster.agents.size
+//      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
+//    }
+//    super.afterAll()
+//  }
 
   "TaskUnreachable" should {
     "A task unreachable update will trigger a replacement task" in {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -10,7 +10,7 @@ import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.App
 import mesosphere.marathon.state.{AbsolutePathId, UnreachableDisabled}
 import org.scalatest.Inside
-//import org.scalatest.Inspectors.forAll
+import org.scalatest.Inspectors.forAll
 
 import scala.concurrent.duration._
 
@@ -40,16 +40,16 @@ class TaskUnreachableIntegrationTest extends AkkaIntegrationTest with EmbeddedMa
     cleanUp()
   }
 
-//  override def afterAll(): Unit = {
-//    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
-//    mesosCluster.agents.foreach(_.start())
-//    eventually {
-//      val state = mesosFacade.state.value
-//      state.agents.size shouldBe mesosCluster.agents.size
-//      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
-//    }
-//    super.afterAll()
-//  }
+  override def afterAll(): Unit = {
+    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
+    mesosCluster.agents.foreach(_.start())
+    eventually {
+      val state = mesosFacade.state.value
+      state.agents.size shouldBe mesosCluster.agents.size
+      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
+    }
+    super.afterAll()
+  }
 
   "TaskUnreachable" should {
     "A task unreachable update will trigger a replacement task" in {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -225,7 +225,11 @@ case class LocalMarathon(
 
     // Get JVM arguments, such as -javaagent:some.jar
     val runtimeMxBean = ManagementFactory.getRuntimeMXBean
-    val runtimeArguments = JavaConverters.collectionAsScalaIterable(runtimeMxBean.getInputArguments).toSeq
+    val runtimeArguments = JavaConverters.collectionAsScalaIterable(runtimeMxBean.getInputArguments)
+      .filterNot(_.contains("debugger-agent"))
+      .filterNot(_.startsWith("-javaagent"))
+      .filterNot(_.startsWith("-agentlib"))
+      .toSeq
 
     val cmd = Seq(java, "-Xmx1024m", "-Xms256m", "-XX:+UseConcMarkSweepGC", "-XX:ConcGCThreads=2") ++
       runtimeArguments ++ akkaJvmArgs ++


### PR DESCRIPTION
Change logic to check that all tasks for a agent that was stopped get
killed. This way, if Mesos GC's the task immediately when it is killed,
then the integration test still succeeds.

Also, fix a major regression to the ExpungeOverdueLostTaskActor

JIRA Issues: MARATHON-8720