### PR TITLE
Add `?containerNetworks` querystring parameter to /v2/tasks text output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,14 @@
   expungeAfterSeconds and inactiveAfterSeconds to the same value will cause the instance to be expunged immediately;
   this helps with `GROUP_BY` or `UNIQUE` constraints.
 
+#### `/v2/tasks` `application/text` output
+
+Marathon outputs a terse, text-formatted list of instances with corresponding port-mappings with a request to `/v2/tasks` with content-type: `application/text`. Usage of this endpoint is generally discouraged, but some older tools continue to rely on it.
+
+As of Marathon 1.5, the output would include user container network endpoinst without a host port mapping, but in a form that was completely unusable (the agent's hostname as the address, even though the endpoint is fundamentally unreachable at that address, and the port 0). This behavior has been removed, and such results are not included by `/v2/tasks` application/text output, by default.
+
+A parameter `containerNetworks` has been added to filter and include port mappings pertaining to a comma-delimited list of user container network names. Setting this flag does not affect the output for port mappings that are bound to a host port in some way (either directly, in the case of host networking, or through a bridge-network port mapping). To see all container ips and endpoints for all user container networks, pass `?containerNetworks=*`.
+
 ## Changes from 1.9.73 to 1.9.100
 
 ### Faster serialization

--- a/changelog.md
+++ b/changelog.md
@@ -13,12 +13,16 @@
 * [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) - With UnreachableStrategy, setting
   expungeAfterSeconds and inactiveAfterSeconds to the same value will cause the instance to be expunged immediately;
   this helps with `GROUP_BY` or `UNIQUE` constraints.
+* [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) - Marathon `/v2/tasks` text formatted output no
+  longer includes endpoints without host-port mappings at the agent hostname and port 0.
 
-#### `/v2/tasks` `application/text` output
+### `/v2/tasks` `application/text` output
+
+#### Addition of containerNetworks parameter
 
 Marathon outputs a terse, text-formatted list of instances with corresponding port-mappings with a request to `/v2/tasks` with content-type: `application/text`. Usage of this endpoint is generally discouraged, but some older tools continue to rely on it.
 
-As of Marathon 1.5, the output would include user container network endpoinst without a host port mapping, but in a form that was completely unusable (the agent's hostname as the address, even though the endpoint is fundamentally unreachable at that address, and the port 0). This behavior has been removed, and such results are not included by `/v2/tasks` application/text output, by default.
+As of Marathon 1.5, the output would include user container network endpoint without a host port mapping, but in a form that was completely unusable (the agent's hostname as the address, even though the endpoint is fundamentally unreachable at that address, and the port 0). This behavior has been removed, and such results are not included by `/v2/tasks` application/text output, by default.
 
 A parameter `containerNetworks` has been added to filter and include port mappings pertaining to a comma-delimited list of user container network names. Setting this flag does not affect the output for port mappings that are bound to a host port in some way (either directly, in the case of host networking, or through a bridge-network port mapping). To see all container ips and endpoints for all user container networks, pass `?containerNetworks=*`.
 

--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -468,6 +468,13 @@
       get:
         description: List all running tasks for application `app_id`.
         is: [ secured ]
+        queryParameters:
+          containerNetworks:
+            required: false
+            description: |
+              Filter and include port mappings pertaining to a comma-delimited list of user container network names.
+              To see all container ips and endpoints for all user container networks, pass <code>?containerNetworks=*</code>.
+            type: String
         responses:
           200:
             description: The list of running tasks for application `app_id`.

--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -474,7 +474,7 @@
             description: |
               Filter and include port mappings pertaining to a comma-delimited list of user container network names.
               To see all container ips and endpoints for all user container networks, pass <code>?containerNetworks=*</code>.
-            type: String
+            type: string
         responses:
           200:
             description: The list of running tasks for application `app_id`.

--- a/docs/docs/rest-api/public/api/v2/tasks.raml
+++ b/docs/docs/rest-api/public/api/v2/tasks.raml
@@ -11,6 +11,12 @@ get:
       required: false
       description: Filter the list of tasks by several statuses.
       type: task.TaskStatusCondition[]
+    containerNetworks:
+      required: false
+      description: |
+        Filter and include port mappings pertaining to a comma-delimited list of user container network names.
+        To see all container ips and endpoints for all user container networks, pass <code>?containerNetworks=*</code>.
+      type: String
   responses:
     200:
       description: The list of all tasks disregarding their status, or a list of tasks matching the specified status filter.

--- a/docs/docs/rest-api/public/api/v2/tasks.raml
+++ b/docs/docs/rest-api/public/api/v2/tasks.raml
@@ -16,7 +16,7 @@ get:
       description: |
         Filter and include port mappings pertaining to a comma-delimited list of user container network names.
         To see all container ips and endpoints for all user container networks, pass <code>?containerNetworks=*</code>.
-      type: String
+      type: string
   responses:
     200:
       description: The list of all tasks disregarding their status, or a list of tasks matching the specified status filter.

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -29,9 +29,9 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 8, 0),
     hardRemoveVersion = SemVer(1, 9, 0))
 
-  val marathon14Compatibility = DeprecatedFeature(
-    "marathon_14_compatible_tasks_endpoint",
-    description = "Enables Marathon to return 1.4 compatible format for /tasks?compatibilityMode=1.4 and /apps/task?compatibilityMode=1.4",
+  val marathon15Compatibility = DeprecatedFeature(
+    "marathon_15_compatible_tasks_endpoint",
+    description = "Enables Marathon to return 1.5 or 1.4 compatible format for application/text requests /tasks?compatibilityMode=1.4 and /apps/{...}/tasks?compatibilityMode=1.5",
     softRemoveVersion = SemVer(1, 9, 0),
     hardRemoveVersion = SemVer(1, 10, 0))
 
@@ -73,7 +73,7 @@ object DeprecatedFeatures {
     hardRemoveVersion = SemVer(1, 11, 0))
 
   def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC,
-    sanitizeAcceptedResourceRoles, marathon14Compatibility)
+    sanitizeAcceptedResourceRoles, marathon15Compatibility)
 
   def description: String = {
     "  - " + all.map { df =>

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -29,6 +29,12 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 8, 0),
     hardRemoveVersion = SemVer(1, 9, 0))
 
+  val marathon14Compatibility = DeprecatedFeature(
+    "marathon_14_compatible_tasks_endpoint",
+    description = "Enables Marathon to return 1.4 compatible format for /tasks?compatibilityMode=1.4 and /apps/task?compatibilityMode=1.4",
+    softRemoveVersion = SemVer(1, 9, 0),
+    hardRemoveVersion = SemVer(1, 10, 0))
+
   /* Removed */
   val syncProxy = DeprecatedFeature(
     "sync_proxy",
@@ -66,7 +72,8 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 10, 0),
     hardRemoveVersion = SemVer(1, 11, 0))
 
-  def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC, sanitizeAcceptedResourceRoles)
+  def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC,
+    sanitizeAcceptedResourceRoles, marathon14Compatibility)
 
   def description: String = {
     "  - " + all.map { df =>

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -29,12 +29,6 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 8, 0),
     hardRemoveVersion = SemVer(1, 9, 0))
 
-  val marathonTasksCompatibility = DeprecatedFeature(
-    "marathon_tasks_compatibility",
-    description = "Enables Marathon to return 1.8 or 1.4 compatible format for application/text requests /tasks?compatibilityMode=1.4 and /apps/{...}/tasks?compatibilityMode=1.8",
-    softRemoveVersion = SemVer(1, 10, 0),
-    hardRemoveVersion = SemVer(1, 11, 0))
-
   /* Removed */
   val syncProxy = DeprecatedFeature(
     "sync_proxy",
@@ -73,7 +67,7 @@ object DeprecatedFeatures {
     hardRemoveVersion = SemVer(1, 11, 0))
 
   def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC,
-    sanitizeAcceptedResourceRoles, marathonTasksCompatibility)
+    sanitizeAcceptedResourceRoles)
 
   def description: String = {
     "  - " + all.map { df =>

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -29,11 +29,11 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 8, 0),
     hardRemoveVersion = SemVer(1, 9, 0))
 
-  val marathon15Compatibility = DeprecatedFeature(
-    "marathon_15_compatible_tasks_endpoint",
-    description = "Enables Marathon to return 1.5 or 1.4 compatible format for application/text requests /tasks?compatibilityMode=1.4 and /apps/{...}/tasks?compatibilityMode=1.5",
-    softRemoveVersion = SemVer(1, 9, 0),
-    hardRemoveVersion = SemVer(1, 10, 0))
+  val marathonTasksCompatibility = DeprecatedFeature(
+    "marathon_tasks_compatibility",
+    description = "Enables Marathon to return 1.8 or 1.4 compatible format for application/text requests /tasks?compatibilityMode=1.4 and /apps/{...}/tasks?compatibilityMode=1.8",
+    softRemoveVersion = SemVer(1, 10, 0),
+    hardRemoveVersion = SemVer(1, 11, 0))
 
   /* Removed */
   val syncProxy = DeprecatedFeature(
@@ -73,7 +73,7 @@ object DeprecatedFeatures {
     hardRemoveVersion = SemVer(1, 11, 0))
 
   def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC,
-    sanitizeAcceptedResourceRoles, marathon15Compatibility)
+    sanitizeAcceptedResourceRoles, marathonTasksCompatibility)
 
   def description: String = {
     "  - " + all.map { df =>

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -1,7 +1,6 @@
 package mesosphere.marathon
 package api
 
-import mesosphere.marathon.api.v2.MarathonCompatibility
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.{ContainerNetwork, HostNetwork}
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
@@ -9,18 +8,7 @@ import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.Container.PortMapping
 
 object EndpointsHelper {
-  sealed trait Error { val msg: String }
-  case object NetworkFilterNotAvailable extends Error {
-    val msg = "In order to use the network filters, 1.10 output mode must be used"
-  }
-  case object MarathonCompatibilityNotEnabled extends Error {
-    val msg = s"In order to use the flag compatibilityMode, 1.5 compatible task output must be enabled with --deprecated_features=${DeprecatedFeatures.marathonTasksCompatibility.key}."
-  }
-  case class CompatibilityModeNotValid(mode: String) extends Error {
-    val msg = s"compatibilityMode ${mode} is invalid"
-  }
-
-  def parseNetworkPredicate(networkFilter: Option[String]): String => Boolean = networkFilter match {
+  private[api] def parseNetworkPredicate(networkFilter: Option[String]): String => Boolean = networkFilter match {
     case None => { _ => false }
     case Some("*") => { _ => true }
     case Some(list) =>
@@ -28,175 +16,19 @@ object EndpointsHelper {
   }
 
   /**
-    * When DeprecatedFeatures.marathon15Compatibility is removed, remove this dispatch function and collapse to just the single helper
-    * @param data
-    * @param maybeCompatibilityMode
-    * @param marathonCompatibilityEnabled
-    * @return
-    */
-  def dispatchAppsToEndpoint(data: ListTasks, maybeCompatibilityMode: Option[String], marathonCompatibilityEnabled: Boolean, containerNetworks: Option[String]): Either[Error, String] = {
-    val compatibilityMode = maybeCompatibilityMode.getOrElse { if (marathonCompatibilityEnabled) MarathonCompatibility.V1_8 else MarathonCompatibility.Latest }
-    compatibilityMode match {
-      case MarathonCompatibility.Latest =>
-        Right(appsToEndpointString(data, parseNetworkPredicate(containerNetworks)))
-      case _ if marathonCompatibilityEnabled == false =>
-        Left(MarathonCompatibilityNotEnabled)
-      case _ if containerNetworks.nonEmpty =>
-        Left(NetworkFilterNotAvailable)
-      case MarathonCompatibility.V1_4 =>
-        Right(MarathonCompatibility14.appsToEndpointString(data))
-      case MarathonCompatibility.V1_8 =>
-        Right(MarathonCompatibility15.appsToEndpointString(data))
-      case o =>
-        Left(CompatibilityModeNotValid(o))
-    }
-  }
-
-  object MarathonCompatibility14 {
-    /**
-      * Renders a text representation of tasks and their corresponding network ports, prioritized first by the host
-      * network, and then, if a mapping is not available, the container ip and container port.
-      *
-      * @param data The tasks to render
-      */
-    def appsToEndpointString(data: ListTasks): String = {
-
-      val delimiter = "\t"
-      val sb = new StringBuilder
-      val apps = data.apps
-      val instancesMap = data.instancesMap
-
-      apps.foreach { app =>
-        val instances = instancesMap.specInstances(app.id)
-        val cleanId = app.id.safePath
-
-        val servicePorts = app.servicePorts
-
-        if (servicePorts.isEmpty) {
-          sb.append(cleanId).append(delimiter).append(' ').append(delimiter)
-          for (
-            instance <- instances if instance.isRunning;
-            agentInfo <- instance.agentInfo
-          ) {
-            sb.append(agentInfo.host).append(' ')
-          }
-          sb.append('\n')
-        } else {
-          for ((port, i) <- servicePorts.zipWithIndex) {
-            sb.append(cleanId).append(delimiter).append(port).append(delimiter)
-
-            val ipPerTaskPortMapping = if (!app.networks.contains(HostNetwork)) containerPortMapping(app, i) else None
-            val runningInstances = instances.withFilter(_.isRunning)
-            ipPerTaskPortMapping match {
-              // port definition with no hostPort: container network
-              case Some(portMapping) if portMapping.hostPort.isEmpty =>
-                runningInstances.foreach { instance =>
-                  tryAppendContainerPort(sb, app, portMapping, instance, delimiter)
-                }
-              case Some(portMapping) if portMapping.hostPort.nonEmpty =>
-                // the task hostPorts only contains an entry for each portMapping that has a hostPort defined
-                // We need to compute and use the new index
-                hostPortIndexOffset(app, i).foreach { computedHostPortIndex =>
-                  runningInstances.foreach { task =>
-                    appendHostPortOrZero(sb, task, computedHostPortIndex, delimiter)
-                  }
-                }
-              case _ =>
-                runningInstances.foreach { instance =>
-                  appendHostPortOrZero(sb, instance, i, delimiter)
-                }
-            }
-            sb.append('\n')
-          }
-        }
-      }
-      sb.toString()
-    }
-
-    /**
-      * Append an entry to the provided string builder using the task's agent host IP and specified host port
-      *
-      * Remove this method when DeprecatedFeatures.marathon15Compatibility is fully removed
-      *
-      */
-    def appendHostPortOrZero(sb: StringBuilder, instance: Instance, portIdx: Integer, delimiter: String): Unit = {
-      instance.agentInfo.foreach { agentInfo =>
-        instance.tasksMap.values.withFilter(_.status.condition.isActive).foreach { task =>
-          val taskPort = task.status.networkInfo.hostPorts.lift(portIdx).getOrElse(0)
-          sb.append(agentInfo.host).append(':').append(taskPort).append(delimiter)
-        }
-      }
-    }
-  }
-
-  object MarathonCompatibility15 {
-    /**
-      * Produces a script-friendly string representation of the supplied
-      * apps' tasks.  The data columns in the result are separated by
-      * the supplied delimiter string.
-      *
-      * Generated line format is: * <pre>{app-id}{d}{service-port}{d}{address-list}</pre>.
-      * `{service-port}` is `" "` for apps without service ports.
-      * `{address-list}` is either `{host-list}` (for apps without service ports), or `{host-address-list}`.
-      * `{host-list}` is a delimited list of agents that are running the task.
-      * `{host-address-list}` is a delimited list of `{agent}:{hostPort}` tuples.
-      * The contents of `{address-list}` are sorted for deterministic output.
-      */
-    def appsToEndpointString(data: ListTasks): String = {
-
-      val delimiter = "\t"
-      val sb = new StringBuilder
-      val apps = data.apps
-      val instancesMap = data.instancesMap
-
-      apps.foreach { app =>
-        val instances = instancesMap.specInstances(app.id)
-        val cleanId = app.id.safePath
-
-        val servicePorts = app.servicePorts
-
-        if (servicePorts.isEmpty) {
-          sb.append(cleanId).append(delimiter).append(' ').append(delimiter)
-          instances.collect { case Instance.Running(_, agentInfo, _) => agentInfo.host }
-            .sorted.foreach { hostname =>
-              sb.append(hostname).append(delimiter)
-            }
-          sb.append('\n')
-        } else {
-          servicePorts.zipWithIndex.foreach {
-            case (port, i) =>
-              sb.append(cleanId).append(delimiter).append(port).append(delimiter)
-              instances.collect {
-                case Instance.Running(_, agentInfo, tasksMap) =>
-                  tasksMap.map {
-                    case (_, task) =>
-                      val taskPort = task.status.networkInfo.hostPorts.drop(i).headOption.getOrElse(0)
-                      s"${agentInfo.host}:$taskPort"
-                  }
-              }.flatten.sorted.foreach { address =>
-                sb.append(address).append(delimiter)
-              }
-              sb.append('\n')
-          }
-        }
-      }
-      sb.toString()
-    }
-  }
-
-  /**
     * Renders a text representation of tasks and their corresponding network ports, prioritized first by the host
     * network, and then, if a mapping is not available, the container ip and container port.
     *
     * @param data The tasks to render
-    * @param containerNetworkPredicate Whether or not to include the container-network ip and port in the list, when no host-mapping is available
+    * @param containerNetworks Whether or not to include the container-network ip and port in the list, when no host-mapping is available
     */
-  def appsToEndpointString(data: ListTasks, containerNetworkPredicate: String => Boolean): String = {
-
+  def appsToEndpointString(data: ListTasks, containerNetworks: Option[String]): String = {
     val delimiter = "\t"
     val sb = new StringBuilder
     val apps = data.apps
     val instancesMap = data.instancesMap
+
+    val containerNetworkPredicate = parseNetworkPredicate(containerNetworks)
 
     apps.foreach { app =>
       val instances = instancesMap.specInstances(app.id)

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -2,8 +2,10 @@ package mesosphere.marathon
 package api
 
 import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.pod.HostNetwork
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.Container.PortMapping
 
 object EndpointsHelper {
   /**
@@ -57,6 +59,114 @@ object EndpointsHelper {
       }
     }
     sb.toString()
+  }
+
+  def appsToEndpointStringCompatibleWith14(data: ListTasks): String = {
+
+    val delimiter = "\t"
+    val sb = new StringBuilder
+    val apps = data.apps
+    val instancesMap = data.instancesMap
+
+    apps.foreach { app =>
+      val instances = instancesMap.specInstances(app.id)
+      val cleanId = app.id.safePath
+
+      val servicePorts = app.servicePorts
+
+      if (servicePorts.isEmpty) {
+        sb.append(cleanId).append(delimiter).append(' ').append(delimiter)
+        for (
+          instance <- instances if instance.isRunning;
+          agentInfo <- instance.agentInfo
+        ) {
+          sb.append(agentInfo.host).append(' ')
+        }
+        sb.append('\n')
+      } else {
+        for ((port, i) <- servicePorts.zipWithIndex) {
+          sb.append(cleanId).append(delimiter).append(port).append(delimiter)
+
+          val ipPerTaskPortMapping = if (!app.networks.contains(HostNetwork)) CompatibilityWith14.containerPortMapping(app, i) else None
+          val runningInstances = instances.withFilter(_.isRunning)
+          ipPerTaskPortMapping match {
+            case Some(portMapping) if portMapping.hostPort.isEmpty =>
+              runningInstances.foreach { instance =>
+                CompatibilityWith14.tryAppendContainerPort(sb, app, portMapping, instance, delimiter)
+              }
+            case Some(portMapping) if portMapping.hostPort.nonEmpty =>
+              // the task hostPorts only contains an entry for each portMapping that has a hostPort defined
+              // We need to compute and use the new index
+              CompatibilityWith14.hostPortIndexOffset(app, i).foreach { computedHostPortIndex =>
+                runningInstances.foreach { task =>
+                  CompatibilityWith14.appendHostPortOrZero(sb, task, computedHostPortIndex, delimiter)
+                }
+              }
+            case _ =>
+              runningInstances.foreach { instance =>
+                CompatibilityWith14.appendHostPortOrZero(sb, instance, i, delimiter)
+              }
+          }
+          sb.append('\n')
+        }
+      }
+    }
+    sb.toString()
+  }
+
+  private object CompatibilityWith14 {
+    def containerPortMapping(app: AppDefinition, portIdx: Integer): Option[PortMapping] =
+      for {
+        container <- app.container
+        portMapping <- container.portMappings.lift(portIdx) // After MARATHON-7407 is addressed, this should probably throw.
+      } yield portMapping
+
+    /**
+      * Append an entry to the provided string builder for the specified containerPort. If we cannot tell the
+      * effectiveIpAddress, output nothing.
+      */
+    def tryAppendContainerPort(sb: StringBuilder, app: AppDefinition, portMapping: PortMapping, instance: Instance,
+      delimiter: String): Unit = {
+      for {
+        task <- instance.tasksMap.values
+        address <- task.status.networkInfo.effectiveIpAddress(app)
+      } {
+        sb.append(address).append(':').append(portMapping.containerPort).append(delimiter)
+      }
+    }
+
+    /**
+      * Adjusts the index based on portMapping definitions. Expects that the specified index refers to a nonEmpty hostPort
+      * portmapping record.
+      */
+    def hostPortIndexOffset(app: AppDefinition, idx: Integer): Option[Integer] = {
+      app.container.flatMap { container =>
+        val pm = container.portMappings
+        if (idx < 0 || idx >= pm.length) // index 2, length 2 invalid
+          None // linter:ignore:DuplicateIfBranches
+        else if (pm(idx).hostPort.isEmpty)
+          None
+        else
+          // count each preceeding nonEmpty hostPort to get new index
+          Some(pm.toIterator.take(idx).count(_.hostPort.nonEmpty))
+      }
+    }
+    /**
+      * Append an entry to the provided string builder using the task's agent host IP and specified host port
+      *
+      * Note, at some-point, as a work-around to MARATHON-7407, it was decided that it would be a good idea to output port
+      * 0 if no host port for the corresponding service port was found (this would happen in the event that you added a
+      * new portMapping). This is rather nonsensical and should be removed when MARATHON-7407 is properly addressed.
+      */
+    def appendHostPortOrZero(
+      sb: StringBuilder, instance: Instance, portIdx: Integer, delimiter: String): Unit = {
+      instance.agentInfo.foreach { agentInfo =>
+        instance.tasksMap.values.withFilter(_.status.condition.isActive).foreach { task =>
+          val taskPort = task.status.networkInfo.hostPorts.lift(portIdx).getOrElse(0)
+          sb.append(agentInfo.host).append(':').append(taskPort).append(delimiter)
+        }
+      }
+    }
   }
 
   case class ListTasks(instancesMap: InstancesBySpec, apps: Seq[AppDefinition])

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package api
 
+import mesosphere.marathon.api.v2.MarathonCompatibility
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.pod.HostNetwork
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
@@ -8,60 +9,176 @@ import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.Container.PortMapping
 
 object EndpointsHelper {
+  sealed trait Error { val msg: String }
+  case object MarathonCompatibilityNotEnabled extends Error {
+    val msg = s"In order to use the flag compatibilityMode, 1.5 compatible task output must be enabled with --deprecated_features=${DeprecatedFeatures.marathon15Compatibility.key}."
+  }
+  case class CompatibilityModeNotValid(mode: String) extends Error {
+    val msg = s"compatibilityMode ${mode} is invalid"
+  }
+
   /**
-    * Produces a script-friendly string representation of the supplied
-    * apps' tasks.  The data columns in the result are separated by
-    * the supplied delimiter string.
-    *
-    * Generated line format is: * <pre>{app-id}{d}{service-port}{d}{address-list}</pre>.
-    * `{service-port}` is `" "` for apps without service ports.
-    * `{address-list}` is either `{host-list}` (for apps without service ports), or `{host-address-list}`.
-    * `{host-list}` is a delimited list of agents that are running the task.
-    * `{host-address-list}` is a delimited list of `{agent}:{hostPort}` tuples.
-    * The contents of `{address-list}` are sorted for deterministic output.
+    * When DeprecatedFeatures.marathon15Compatibility is removed, remove this dispatch function and collapse to just the single helper
+    * @param data
+    * @param maybeCompatibilityMode
+    * @param marathon15CompatibilityEnabled
+    * @return
     */
-  def appsToEndpointString(data: ListTasks): String = {
+  def dispatchAppsToEndpoint(data: ListTasks, maybeCompatibilityMode: Option[String], marathon15CompatibilityEnabled: Boolean): Either[Error, String] = {
+    val compatibilityMode = maybeCompatibilityMode.getOrElse { if (marathon15CompatibilityEnabled) MarathonCompatibility.V1_5 else MarathonCompatibility.Latest }
+    (compatibilityMode, marathon15CompatibilityEnabled) match {
+      case (MarathonCompatibility.Latest, _) =>
+        Right(appsToEndpointString(data))
+      case (_, false) =>
+        Left(MarathonCompatibilityNotEnabled)
+      case (MarathonCompatibility.V1_4, _) =>
+        Right(MarathonCompatibility14.appsToEndpointString(data))
+      case (MarathonCompatibility.V1_5, _) =>
+        Right(MarathonCompatibility15.appsToEndpointString(data))
+      case (o, _) =>
+        Left(CompatibilityModeNotValid(o))
+    }
+  }
 
-    val delimiter = "\t"
-    val sb = new StringBuilder
-    val apps = data.apps
-    val instancesMap = data.instancesMap
+  object MarathonCompatibility14 {
+    /**
+      * Renders a text representation of tasks and their corresponding network ports, prioritized first by the host
+      * network, and then, if a mapping is not available, the container ip and container port.
+      *
+      * @param data The tasks to render
+      */
+    def appsToEndpointString(data: ListTasks): String = {
 
-    apps.foreach { app =>
-      val instances = instancesMap.specInstances(app.id)
-      val cleanId = app.id.safePath
+      val delimiter = "\t"
+      val sb = new StringBuilder
+      val apps = data.apps
+      val instancesMap = data.instancesMap
 
-      val servicePorts = app.servicePorts
+      apps.foreach { app =>
+        val instances = instancesMap.specInstances(app.id)
+        val cleanId = app.id.safePath
 
-      if (servicePorts.isEmpty) {
-        sb.append(cleanId).append(delimiter).append(' ').append(delimiter)
-        instances.collect { case Instance.Running(_, agentInfo, _) => agentInfo.host }
-          .sorted.foreach { hostname =>
-            sb.append(hostname).append(delimiter)
+        val servicePorts = app.servicePorts
+
+        if (servicePorts.isEmpty) {
+          sb.append(cleanId).append(delimiter).append(' ').append(delimiter)
+          for (
+            instance <- instances if instance.isRunning;
+            agentInfo <- instance.agentInfo
+          ) {
+            sb.append(agentInfo.host).append(' ')
           }
-        sb.append('\n')
-      } else {
-        servicePorts.zipWithIndex.foreach {
-          case (port, i) =>
+          sb.append('\n')
+        } else {
+          for ((port, i) <- servicePorts.zipWithIndex) {
             sb.append(cleanId).append(delimiter).append(port).append(delimiter)
-            instances.collect {
-              case Instance.Running(_, agentInfo, tasksMap) =>
-                tasksMap.map {
-                  case (_, task) =>
-                    val taskPort = task.status.networkInfo.hostPorts.drop(i).headOption.getOrElse(0)
-                    s"${agentInfo.host}:$taskPort"
+
+            val ipPerTaskPortMapping = if (!app.networks.contains(HostNetwork)) containerPortMapping(app, i) else None
+            val runningInstances = instances.withFilter(_.isRunning)
+            ipPerTaskPortMapping match {
+              // port definition with no hostPort: container network
+              case Some(portMapping) if portMapping.hostPort.isEmpty =>
+                runningInstances.foreach { instance =>
+                  tryAppendContainerPort(sb, app, portMapping, instance, delimiter)
                 }
-            }.flatten.sorted.foreach { address =>
-              sb.append(address).append(delimiter)
+              case Some(portMapping) if portMapping.hostPort.nonEmpty =>
+                // the task hostPorts only contains an entry for each portMapping that has a hostPort defined
+                // We need to compute and use the new index
+                hostPortIndexOffset(app, i).foreach { computedHostPortIndex =>
+                  runningInstances.foreach { task =>
+                    appendHostPortOrZero(sb, task, computedHostPortIndex, delimiter)
+                  }
+                }
+              case _ =>
+                runningInstances.foreach { instance =>
+                  appendHostPortOrZero(sb, instance, i, delimiter)
+                }
             }
             sb.append('\n')
+          }
+        }
+      }
+      sb.toString()
+    }
+
+    /**
+      * Append an entry to the provided string builder using the task's agent host IP and specified host port
+      *
+      * Remove this method when DeprecatedFeatures.marathon15Compatibility is fully removed
+      *
+      */
+    def appendHostPortOrZero(sb: StringBuilder, instance: Instance, portIdx: Integer, delimiter: String): Unit = {
+      instance.agentInfo.foreach { agentInfo =>
+        instance.tasksMap.values.withFilter(_.status.condition.isActive).foreach { task =>
+          val taskPort = task.status.networkInfo.hostPorts.lift(portIdx).getOrElse(0)
+          sb.append(agentInfo.host).append(':').append(taskPort).append(delimiter)
         }
       }
     }
-    sb.toString()
   }
 
-  def appsToEndpointStringCompatibleWith14(data: ListTasks): String = {
+  object MarathonCompatibility15 {
+    /**
+      * Produces a script-friendly string representation of the supplied
+      * apps' tasks.  The data columns in the result are separated by
+      * the supplied delimiter string.
+      *
+      * Generated line format is: * <pre>{app-id}{d}{service-port}{d}{address-list}</pre>.
+      * `{service-port}` is `" "` for apps without service ports.
+      * `{address-list}` is either `{host-list}` (for apps without service ports), or `{host-address-list}`.
+      * `{host-list}` is a delimited list of agents that are running the task.
+      * `{host-address-list}` is a delimited list of `{agent}:{hostPort}` tuples.
+      * The contents of `{address-list}` are sorted for deterministic output.
+      */
+    def appsToEndpointString(data: ListTasks): String = {
+
+      val delimiter = "\t"
+      val sb = new StringBuilder
+      val apps = data.apps
+      val instancesMap = data.instancesMap
+
+      apps.foreach { app =>
+        val instances = instancesMap.specInstances(app.id)
+        val cleanId = app.id.safePath
+
+        val servicePorts = app.servicePorts
+
+        if (servicePorts.isEmpty) {
+          sb.append(cleanId).append(delimiter).append(' ').append(delimiter)
+          instances.collect { case Instance.Running(_, agentInfo, _) => agentInfo.host }
+            .sorted.foreach { hostname =>
+              sb.append(hostname).append(delimiter)
+            }
+          sb.append('\n')
+        } else {
+          servicePorts.zipWithIndex.foreach {
+            case (port, i) =>
+              sb.append(cleanId).append(delimiter).append(port).append(delimiter)
+              instances.collect {
+                case Instance.Running(_, agentInfo, tasksMap) =>
+                  tasksMap.map {
+                    case (_, task) =>
+                      val taskPort = task.status.networkInfo.hostPorts.drop(i).headOption.getOrElse(0)
+                      s"${agentInfo.host}:$taskPort"
+                  }
+              }.flatten.sorted.foreach { address =>
+                sb.append(address).append(delimiter)
+              }
+              sb.append('\n')
+          }
+        }
+      }
+      sb.toString()
+    }
+  }
+
+  /**
+    * Renders a text representation of tasks and their corresponding network ports, prioritized first by the host
+    * network, and then, if a mapping is not available, the container ip and container port.
+    *
+    * @param data The tasks to render
+    */
+  def appsToEndpointString(data: ListTasks): String = {
 
     val delimiter = "\t"
     val sb = new StringBuilder
@@ -80,31 +197,33 @@ object EndpointsHelper {
           instance <- instances if instance.isRunning;
           agentInfo <- instance.agentInfo
         ) {
-          sb.append(agentInfo.host).append(' ')
+          sb.append(agentInfo.host).append('\t')
         }
         sb.append('\n')
       } else {
         for ((port, i) <- servicePorts.zipWithIndex) {
           sb.append(cleanId).append(delimiter).append(port).append(delimiter)
 
-          val ipPerTaskPortMapping = if (!app.networks.contains(HostNetwork)) CompatibilityWith14.containerPortMapping(app, i) else None
+          val ipPerTaskPortMapping = if (!app.networks.contains(HostNetwork)) containerPortMapping(app, i) else None
           val runningInstances = instances.withFilter(_.isRunning)
           ipPerTaskPortMapping match {
+            // port definition with no hostPort: container network
             case Some(portMapping) if portMapping.hostPort.isEmpty =>
+              // At a future point we may wish to only return port definitions pertaining to certain network types; this should be added as a separate parameter.
               runningInstances.foreach { instance =>
-                CompatibilityWith14.tryAppendContainerPort(sb, app, portMapping, instance, delimiter)
+                tryAppendContainerPort(sb, app, portMapping, instance, delimiter)
               }
             case Some(portMapping) if portMapping.hostPort.nonEmpty =>
               // the task hostPorts only contains an entry for each portMapping that has a hostPort defined
               // We need to compute and use the new index
-              CompatibilityWith14.hostPortIndexOffset(app, i).foreach { computedHostPortIndex =>
+              hostPortIndexOffset(app, i).foreach { computedHostPortIndex =>
                 runningInstances.foreach { task =>
-                  CompatibilityWith14.appendHostPortOrZero(sb, task, computedHostPortIndex, delimiter)
+                  appendHostPort(sb, task, computedHostPortIndex, delimiter)
                 }
               }
             case _ =>
               runningInstances.foreach { instance =>
-                CompatibilityWith14.appendHostPortOrZero(sb, instance, i, delimiter)
+                appendHostPort(sb, instance, i, delimiter)
               }
           }
           sb.append('\n')
@@ -114,58 +233,53 @@ object EndpointsHelper {
     sb.toString()
   }
 
-  private object CompatibilityWith14 {
-    def containerPortMapping(app: AppDefinition, portIdx: Integer): Option[PortMapping] =
-      for {
-        container <- app.container
-        portMapping <- container.portMappings.lift(portIdx) // After MARATHON-7407 is addressed, this should probably throw.
-      } yield portMapping
+  def containerPortMapping(app: AppDefinition, portIdx: Integer): Option[PortMapping] =
+    for {
+      container <- app.container
+      portMapping <- container.portMappings.lift(portIdx) // After MARATHON-7407 is addressed, this should probably throw.
+    } yield portMapping
 
-    /**
-      * Append an entry to the provided string builder for the specified containerPort. If we cannot tell the
-      * effectiveIpAddress, output nothing.
-      */
-    def tryAppendContainerPort(sb: StringBuilder, app: AppDefinition, portMapping: PortMapping, instance: Instance,
-      delimiter: String): Unit = {
-      for {
-        task <- instance.tasksMap.values
-        address <- task.status.networkInfo.effectiveIpAddress(app)
-      } {
-        sb.append(address).append(':').append(portMapping.containerPort).append(delimiter)
-      }
+  /**
+    * Append an entry to the provided string builder for the specified containerPort. If we cannot tell the
+    * effectiveIpAddress, output nothing.
+    */
+  def tryAppendContainerPort(sb: StringBuilder, app: AppDefinition, portMapping: PortMapping, instance: Instance,
+    delimiter: String): Unit = {
+    for {
+      task <- instance.tasksMap.values
+      address <- task.status.networkInfo.effectiveIpAddress(app)
+    } {
+      sb.append(address).append(':').append(portMapping.containerPort).append(delimiter)
     }
+  }
 
-    /**
-      * Adjusts the index based on portMapping definitions. Expects that the specified index refers to a nonEmpty hostPort
-      * portmapping record.
-      */
-    def hostPortIndexOffset(app: AppDefinition, idx: Integer): Option[Integer] = {
-      app.container.flatMap { container =>
-        val pm = container.portMappings
-        if (idx < 0 || idx >= pm.length) // index 2, length 2 invalid
-          None // linter:ignore:DuplicateIfBranches
-        else if (pm(idx).hostPort.isEmpty)
-          None
-        else
-          // count each preceeding nonEmpty hostPort to get new index
-          Some(pm.toIterator.take(idx).count(_.hostPort.nonEmpty))
-      }
+  /**
+    * Adjusts the index based on portMapping definitions. Expects that the specified index refers to a nonEmpty hostPort
+    * portmapping record.
+    */
+  def hostPortIndexOffset(app: AppDefinition, idx: Integer): Option[Integer] = {
+    app.container.flatMap { container =>
+      val pm = container.portMappings
+      if (idx < 0 || idx >= pm.length) // index 2, length 2 invalid
+        None // linter:ignore:DuplicateIfBranches
+      else if (pm(idx).hostPort.isEmpty)
+        None
+      else
+        // count each preceeding nonEmpty hostPort to get new index
+        Some(pm.toIterator.take(idx).count(_.hostPort.nonEmpty))
     }
-    /**
-      * Append an entry to the provided string builder using the task's agent host IP and specified host port
-      *
-      * Note, at some-point, as a work-around to MARATHON-7407, it was decided that it would be a good idea to output port
-      * 0 if no host port for the corresponding service port was found (this would happen in the event that you added a
-      * new portMapping). This is rather nonsensical and should be removed when MARATHON-7407 is properly addressed.
-      */
-    def appendHostPortOrZero(
-      sb: StringBuilder, instance: Instance, portIdx: Integer, delimiter: String): Unit = {
-      instance.agentInfo.foreach { agentInfo =>
-        instance.tasksMap.values.withFilter(_.status.condition.isActive).foreach { task =>
-          val taskPort = task.status.networkInfo.hostPorts.lift(portIdx).getOrElse(0)
-          sb.append(agentInfo.host).append(':').append(taskPort).append(delimiter)
-        }
-      }
+  }
+
+  /**
+    * Append an entry to the provided string builder using the task's agent host IP and specified host port
+    */
+  def appendHostPort(sb: StringBuilder, instance: Instance, portIdx: Integer, delimiter: String): Unit = {
+    for {
+      agentInfo <- instance.agentInfo
+      task <- instance.tasksMap.values if task.status.condition.isActive
+      taskPort <- task.status.networkInfo.hostPorts.lift(portIdx)
+    } {
+      sb.append(agentInfo.host).append(':').append(taskPort).append(delimiter)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -14,7 +14,7 @@ object EndpointsHelper {
     val msg = "In order to use the network filters, 1.10 output mode must be used"
   }
   case object MarathonCompatibilityNotEnabled extends Error {
-    val msg = s"In order to use the flag compatibilityMode, 1.5 compatible task output must be enabled with --deprecated_features=${DeprecatedFeatures.marathon15Compatibility.key}."
+    val msg = s"In order to use the flag compatibilityMode, 1.5 compatible task output must be enabled with --deprecated_features=${DeprecatedFeatures.marathonTasksCompatibility.key}."
   }
   case class CompatibilityModeNotValid(mode: String) extends Error {
     val msg = s"compatibilityMode ${mode} is invalid"
@@ -31,21 +31,21 @@ object EndpointsHelper {
     * When DeprecatedFeatures.marathon15Compatibility is removed, remove this dispatch function and collapse to just the single helper
     * @param data
     * @param maybeCompatibilityMode
-    * @param marathon15CompatibilityEnabled
+    * @param marathonCompatibilityEnabled
     * @return
     */
-  def dispatchAppsToEndpoint(data: ListTasks, maybeCompatibilityMode: Option[String], marathon15CompatibilityEnabled: Boolean, containerNetworks: Option[String]): Either[Error, String] = {
-    val compatibilityMode = maybeCompatibilityMode.getOrElse { if (marathon15CompatibilityEnabled) MarathonCompatibility.V1_5 else MarathonCompatibility.Latest }
+  def dispatchAppsToEndpoint(data: ListTasks, maybeCompatibilityMode: Option[String], marathonCompatibilityEnabled: Boolean, containerNetworks: Option[String]): Either[Error, String] = {
+    val compatibilityMode = maybeCompatibilityMode.getOrElse { if (marathonCompatibilityEnabled) MarathonCompatibility.V1_8 else MarathonCompatibility.Latest }
     compatibilityMode match {
       case MarathonCompatibility.Latest =>
         Right(appsToEndpointString(data, parseNetworkPredicate(containerNetworks)))
-      case _ if marathon15CompatibilityEnabled == false =>
+      case _ if marathonCompatibilityEnabled == false =>
         Left(MarathonCompatibilityNotEnabled)
       case _ if containerNetworks.nonEmpty =>
         Left(NetworkFilterNotAvailable)
       case MarathonCompatibility.V1_4 =>
         Right(MarathonCompatibility14.appsToEndpointString(data))
-      case MarathonCompatibility.V1_5 =>
+      case MarathonCompatibility.V1_8 =>
         Right(MarathonCompatibility15.appsToEndpointString(data))
       case o =>
         Left(CompatibilityModeNotValid(o))

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -8,11 +8,12 @@ import mesosphere.marathon.state.AppDefinition
 import mesosphere.marathon.state.Container.PortMapping
 
 object EndpointsHelper {
-  private[api] def parseNetworkPredicate(networkFilter: Option[String]): String => Boolean = networkFilter match {
-    case None => { _ => false }
-    case Some("*") => { _ => true }
-    case Some(list) =>
-      list.split(",").toSet
+  private[api] def parseNetworkPredicate(networkFilter: Set[String]): String => Boolean = {
+    if (networkFilter contains "*") {
+      { _ => true }
+    } else {
+      networkFilter
+    }
   }
 
   /**
@@ -20,9 +21,9 @@ object EndpointsHelper {
     * network, and then, if a mapping is not available, the container ip and container port.
     *
     * @param data The tasks to render
-    * @param containerNetworks Whether or not to include the container-network ip and port in the list, when no host-mapping is available
+    * @param containerNetworks Set of container network names to include in the output. A network name of "*" indicates all networks should be included.
     */
-  def appsToEndpointString(data: ListTasks, containerNetworks: Option[String]): String = {
+  def appsToEndpointString(data: ListTasks, containerNetworks: Set[String]): String = {
     val delimiter = "\t"
     val sb = new StringBuilder
     val apps = data.apps

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -72,6 +72,7 @@ trait RestResource extends JaxResource {
   }
 
   protected def status(code: Status) = Response.status(code).build()
+  protected def status(code: Status, entity: String) = Response.status(code).entity(new RestStreamingBody(entity)).build()
   protected def ok(): Response = Response.ok().build()
   protected def ok(entity: String): Response = Response.ok(entity).build()
   protected def ok(entity: String, mediaType: MediaType): Response = Response.ok(entity).`type`(mediaType).build()

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -37,7 +37,7 @@ class AppTasksResource @Inject() (
     groupManager: GroupManager,
     val authorizer: Authorizer,
     val authenticator: Authenticator,
-    marathon15CompatibilityEnabled: Boolean)(implicit val executionContext: ExecutionContext) extends AuthResource {
+    deprecatedFeaturesSet: DeprecatedFeatureConfig)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   val GroupTasks = """^((?:.+/)|)\*$""".r
 
@@ -93,7 +93,7 @@ class AppTasksResource @Inject() (
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
         val data = ListTasks(instancesBySpec, Seq(app))
-        EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode).filterNot(_.isEmpty), marathon15CompatibilityEnabled, Option(containerNetworks).filterNot(_.isEmpty)) match {
+        EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode).filterNot(_.isEmpty), deprecatedFeaturesSet.isEnabled(DeprecatedFeatures.marathonTasksCompatibility), Option(containerNetworks).filterNot(_.isEmpty)) match {
           case Right(response) =>
             ok(response)
           case Left(error) =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -5,6 +5,7 @@ import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.container.{AsyncResponse, Suspended}
+import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.{Context, MediaType}
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api._
@@ -35,7 +36,8 @@ class AppTasksResource @Inject() (
     val config: MarathonConf,
     groupManager: GroupManager,
     val authorizer: Authorizer,
-    val authenticator: Authenticator)(implicit val executionContext: ExecutionContext) extends AuthResource {
+    val authenticator: Authenticator,
+    deprecatedFeaturesSet: DeprecatedFeatureConfig)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   val GroupTasks = """^((?:.+/)|)\*$""".r
 
@@ -82,13 +84,23 @@ class AppTasksResource @Inject() (
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   def indexTxt(
     @PathParam("appId") appId: String,
+    @DefaultValue(MarathonCompatibility.Latest)@QueryParam("compatibilityMode") compatibilityMode: String = MarathonCompatibility.Latest,
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
       val id = appId.toAbsolutePath
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
-        ok(EndpointsHelper.appsToEndpointString(ListTasks(instancesBySpec, Seq(app))))
+        compatibilityMode match {
+          case MarathonCompatibility.V1_4 =>
+            if (deprecatedFeaturesSet.isEnabled(DeprecatedFeatures.marathon14Compatibility)) {
+              ok(EndpointsHelper.appsToEndpointStringCompatibleWith14(ListTasks(instancesBySpec, Seq(app))))
+            } else {
+              status(Status.BAD_REQUEST, s"1.4 compatible task output must be enabled with ${DeprecatedFeatures.marathon14Compatibility.key}.")
+            }
+          case _ =>
+            ok(EndpointsHelper.appsToEndpointString(ListTasks(instancesBySpec, Seq(app))))
+        }
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -90,7 +90,7 @@ class AppTasksResource @Inject() (
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
         val data = ListTasks(instancesBySpec, Seq(app))
-        ok(EndpointsHelper.appsToEndpointString(data, Option(containerNetworks).filterNot(_.isEmpty)))
+        ok(EndpointsHelper.appsToEndpointString(data, containerNetworks.split(",").toSet))
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -84,7 +84,8 @@ class AppTasksResource @Inject() (
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   def indexTxt(
     @PathParam("appId") appId: String,
-    @DefaultValue(MarathonCompatibility.Latest)@QueryParam("compatibilityMode") compatibilityMode: String = null,
+    @DefaultValue("")@QueryParam("compatibilityMode") compatibilityMode: String = "",
+    @DefaultValue("")@QueryParam("containerNetworks") containerNetworks: String = "",
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
@@ -92,7 +93,7 @@ class AppTasksResource @Inject() (
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
         val data = ListTasks(instancesBySpec, Seq(app))
-        EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode), marathon15CompatibilityEnabled) match {
+        EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode).filterNot(_.isEmpty), marathon15CompatibilityEnabled, Option(containerNetworks).filterNot(_.isEmpty)) match {
           case Right(response) =>
             ok(response)
           case Left(error) =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -82,7 +82,6 @@ class AppTasksResource @Inject() (
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   def indexTxt(
     @PathParam("appId") appId: String,
-    @DefaultValue(MarathonCompatibility.Latest)@QueryParam("compatibilityMode") compatibilityMode: String = MarathonCompatibility.Latest,
     @DefaultValue("")@QueryParam("containerNetworks") containerNetworks: String = "",
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {

--- a/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
@@ -4,6 +4,6 @@ package api.v2
 object MarathonCompatibility {
 
   final val V1_4 = "1.4"
-  final val V1_5 = "latest" // lamentably, "latest" actually does not mean latest, but for backwards compatibility sakes we must continue to return 1.5 output for "latest"
-  final val Latest = "1.10"
+  final val V1_8 = "1.8"
+  final val Latest = "latest"
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
@@ -1,8 +1,0 @@
-package mesosphere.marathon
-package api.v2
-
-object MarathonCompatibility {
-
-  final val V1_4 = "1.4"
-  final val Latest = "latest"
-}

--- a/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
@@ -4,6 +4,5 @@ package api.v2
 object MarathonCompatibility {
 
   final val V1_4 = "1.4"
-  final val V1_8 = "1.8"
   final val Latest = "latest"
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
@@ -1,0 +1,9 @@
+package mesosphere.marathon
+package api.v2
+
+object MarathonCompatibility {
+
+  final val V1_4 = "1.4"
+  final val Latest = "latest"
+
+}

--- a/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/MarathonCompatibility.scala
@@ -4,6 +4,6 @@ package api.v2
 object MarathonCompatibility {
 
   final val V1_4 = "1.4"
-  final val Latest = "latest"
-
+  final val V1_5 = "latest" // lamentably, "latest" actually does not mean latest, but for backwards compatibility sakes we must continue to return 1.5 output for "latest"
+  final val Latest = "1.10"
 }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -7,6 +7,7 @@ import javax.inject.Inject
 import javax.servlet.http.HttpServletRequest
 import javax.ws.rs._
 import javax.ws.rs.container.{AsyncResponse, Suspended}
+import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.{Context, MediaType, Response}
 import mesosphere.marathon.api.EndpointsHelper.ListTasks
 import mesosphere.marathon.api.{EndpointsHelper, TaskKiller, _}
@@ -36,7 +37,8 @@ class TasksResource @Inject() (
     groupManager: GroupManager,
     healthCheckManager: HealthCheckManager,
     val authenticator: Authenticator,
-    val authorizer: Authorizer)(implicit val executionContext: ExecutionContext) extends AuthResource {
+    val authorizer: Authorizer,
+    deprecatedFeaturesSet: DeprecatedFeatureConfig)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
@@ -88,15 +90,27 @@ class TasksResource @Inject() (
 
   @GET
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
-  def indexTxt(@Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
+  def indexTxt(
+    @DefaultValue(MarathonCompatibility.Latest)@QueryParam("compatibilityMode") compatibilityMode: String = MarathonCompatibility.Latest,
+    @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       val rootGroup = groupManager.rootGroup()
-      val appsToEndpointString = EndpointsHelper.appsToEndpointString(
-        ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
-      )
-      ok(appsToEndpointString)
+      compatibilityMode match {
+        case MarathonCompatibility.V1_4 =>
+          if (deprecatedFeaturesSet.isEnabled(DeprecatedFeatures.marathon14Compatibility)) {
+            ok(EndpointsHelper.appsToEndpointStringCompatibleWith14(
+              ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
+            ))
+          } else {
+            status(Status.BAD_REQUEST, s"1.4 compatible task output must be enabled with ${DeprecatedFeatures.marathon14Compatibility.key}.")
+          }
+
+        case _ =>
+          ok(EndpointsHelper.appsToEndpointString(
+            ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))))
+      }
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -91,7 +91,8 @@ class TasksResource @Inject() (
   @GET
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   def indexTxt(
-    @DefaultValue(MarathonCompatibility.Latest)@QueryParam("compatibilityMode") compatibilityMode: String = null,
+    @DefaultValue("")@QueryParam("compatibilityMode") compatibilityMode: String = "",
+    @DefaultValue("")@QueryParam("containerNetworks") containerNetworks: String = "",
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
@@ -99,7 +100,7 @@ class TasksResource @Inject() (
       val rootGroup = groupManager.rootGroup()
       val data = ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
 
-      EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode), marathon15CompatibilityEnabled) match {
+      EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode).filterNot(_.isEmpty), marathon15CompatibilityEnabled, Option(containerNetworks).filterNot(_.isEmpty)) match {
         case Right(response) =>
           ok(response)
         case Left(error) =>

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -97,7 +97,7 @@ class TasksResource @Inject() (
       val rootGroup = groupManager.rootGroup()
       val data = ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
 
-      ok(EndpointsHelper.appsToEndpointString(data, Option(containerNetworks).filterNot(_.isEmpty)))
+      ok(EndpointsHelper.appsToEndpointString(data, containerNetworks.split(",").toSet))
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -38,7 +38,7 @@ class TasksResource @Inject() (
     healthCheckManager: HealthCheckManager,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
-    marathon15CompatibilityEnabled: Boolean)(implicit val executionContext: ExecutionContext) extends AuthResource {
+    deprecatedFeaturesSet: DeprecatedFeatureConfig)(implicit val executionContext: ExecutionContext) extends AuthResource {
 
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
@@ -100,7 +100,7 @@ class TasksResource @Inject() (
       val rootGroup = groupManager.rootGroup()
       val data = ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
 
-      EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode).filterNot(_.isEmpty), marathon15CompatibilityEnabled, Option(containerNetworks).filterNot(_.isEmpty)) match {
+      EndpointsHelper.dispatchAppsToEndpoint(data, Option(compatibilityMode).filterNot(_.isEmpty), deprecatedFeaturesSet.isEnabled(DeprecatedFeatures.marathonTasksCompatibility), Option(containerNetworks).filterNot(_.isEmpty)) match {
         case Right(response) =>
           ok(response)
         case Left(error) =>

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -89,7 +89,6 @@ class TasksResource @Inject() (
   @GET
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   def indexTxt(
-    @DefaultValue(MarathonCompatibility.Latest)@QueryParam("compatibilityMode") compatibilityMode: String = MarathonCompatibility.Latest,
     @DefaultValue("")@QueryParam("containerNetworks") containerNetworks: String = "",
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -40,7 +40,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager,
       auth.auth,
       auth.auth,
-      true
+      DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
     )
 
     config.zkTimeoutDuration returns 1.second
@@ -67,7 +67,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager,
       auth.auth,
       auth.auth,
-      true
+      DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
     )
 
     config.zkTimeoutDuration returns 1.second

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -327,7 +327,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       indexJson.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", MarathonCompatibility.Latest, req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", MarathonCompatibility.Latest, req = req, asyncResponse = r) }
       Then("we receive a NotAuthenticated response")
       indexTxt.getStatus should be(auth.NotAuthenticatedStatus)
 
@@ -422,7 +422,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req = req, asyncResponse = r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -438,7 +438,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req = req, asyncResponse = r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -39,8 +39,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       config,
       groupManager,
       auth.auth,
-      auth.auth,
-      DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
+      auth.auth
     )
 
     config.zkTimeoutDuration returns 1.second
@@ -66,8 +65,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       config,
       groupManager,
       auth.auth,
-      auth.auth,
-      DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
+      auth.auth
     )
 
     config.zkTimeoutDuration returns 1.second

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -39,7 +39,8 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       config,
       groupManager,
       auth.auth,
-      auth.auth
+      auth.auth,
+      DeprecatedFeatureConfig.empty(SemVer(1, 8, 0))
     )
 
     config.zkTimeoutDuration returns 1.second
@@ -65,7 +66,8 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       config,
       groupManager,
       auth.auth,
-      auth.auth
+      auth.auth,
+      DeprecatedFeatureConfig.empty(SemVer(1, 8, 0))
     )
 
     config.zkTimeoutDuration returns 1.second
@@ -325,7 +327,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       indexJson.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", MarathonCompatibility.Latest, req, r) }
       Then("we receive a NotAuthenticated response")
       indexTxt.getStatus should be(auth.NotAuthenticatedStatus)
 
@@ -420,7 +422,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req, r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -436,7 +438,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req, r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -325,7 +325,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       indexJson.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", MarathonCompatibility.Latest, req = req, asyncResponse = r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", req = req, asyncResponse = r) }
       Then("we receive a NotAuthenticated response")
       indexTxt.getStatus should be(auth.NotAuthenticatedStatus)
 
@@ -420,7 +420,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req = req, asyncResponse = r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req = req, asyncResponse = r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -436,7 +436,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", MarathonCompatibility.Latest, req = req, asyncResponse = r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req = req, asyncResponse = r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -40,7 +40,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager,
       auth.auth,
       auth.auth,
-      DeprecatedFeatureConfig.empty(SemVer(1, 8, 0))
+      true
     )
 
     config.zkTimeoutDuration returns 1.second
@@ -67,7 +67,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       groupManager,
       auth.auth,
       auth.auth,
-      DeprecatedFeatureConfig.empty(SemVer(1, 8, 0))
+      true
     )
 
     config.zkTimeoutDuration returns 1.second

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -7,24 +7,26 @@ import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
 import mesosphere.marathon.api.{RestResource, TaskKiller, TestAuthFixture}
-import mesosphere.marathon.test.JerseyTest
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStep}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.pod.ContainerNetwork
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.auth.Identity
+import mesosphere.marathon.state.Container.PortMapping
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.state._
-import mesosphere.marathon.test.GroupCreation
+import mesosphere.marathon.test.{GroupCreation, JerseyTest}
+import org.apache.mesos
 import org.mockito.Matchers
 import org.mockito.Mockito._
 
 import scala.collection.immutable.Seq
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -73,6 +75,60 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
       Then("The status should be 200")
       response.getStatus shouldEqual 200
+    }
+
+    "list (txt) tasks with 1.4 compatibility mode outputs container network ips and ports" in new Fixture {
+      Given("a running instance of an app using container networks")
+      val app = AppDefinition(
+        "/foo".toAbsolutePath,
+        role = "*",
+        networks = Seq(ContainerNetwork("weave")),
+        container = Some(Container.Docker(
+          image = "alpine",
+          portMappings = Seq(
+            PortMapping(
+              name = Some("http"),
+              containerPort = 22,
+              hostPort = None,
+              servicePort = 20163),
+            PortMapping(
+              name = Some("https"),
+              containerPort = 6090,
+              hostPort = None,
+              servicePort = 13032)))))
+
+      val instance = TestInstanceBuilder.newBuilder(app.id).addTaskWithBuilder()
+        .taskRunning()
+        .withNetworkInfo(
+          NetworkInfo(
+            hostName = "hostname",
+            hostPorts = Nil,
+            ipAddresses = Seq(mesos.Protos.NetworkInfo.IPAddress.newBuilder().setIpAddress("10.11.12.13").build())))
+        .build()
+        .getInstance()
+
+      val tasksByApp = InstanceTracker.InstancesBySpec.forInstances(instance)
+      instanceTracker.instancesBySpec returns Future.successful(tasksByApp)
+
+      val rootGroup = createRootGroup(apps = Map(app.id -> app))
+      groupManager.rootGroup() returns rootGroup
+
+      When("Getting the txt tasks index")
+      val response = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_4, auth.request, r) }
+
+      /* Note that without compatibility 1.4, the following (less useful) response is returned:
+       * foo   20163   host.some:0
+       * foo   13032   host.some:0
+       */
+
+      Then("The status should be 200")
+      response.getStatus shouldEqual 200
+
+      And("the output should return the container ports used in container networks")
+      val lines = response.getEntity.toString.trim.split("\n").iterator.map(_.split("\t").toList).toList
+      lines.length shouldBe 2
+      lines(0) shouldBe List("foo", "20163", "10.11.12.13:22")
+      lines(1) shouldBe List("foo", "13032", "10.11.12.13:6090")
     }
 
     "list apps when there are no apps" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -48,8 +48,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       groupManager,
       healthCheckManager,
       auth.auth,
-      auth.auth,
-      DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
+      auth.auth
     )
   }
 
@@ -81,7 +80,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
     def parseTxtResponse(response: String): List[List[String]] =
       response.trim.split("\n").iterator.map(_.split("\t").toList).toList
 
-    "list (txt) tasks with 1.4 compatibility mode outputs container network ips and ports" in new Fixture {
+    "list (txt) tasks with  mode outputs container network ips and ports" in new Fixture {
       Given("a running instance of an app using container networks")
       val app = AppDefinition(
         "/foo".toAbsolutePath,
@@ -117,32 +116,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       val rootGroup = createRootGroup(apps = Map(app.id -> app))
       groupManager.rootGroup() returns rootGroup
 
-      When("Getting the txt tasks index with 1.4 compatibility mode")
-      val response14 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_4, req = auth.request, asyncResponse = r) }
-
-      Then("The status should be 200")
-      response14.getStatus shouldEqual 200
-
-      And("the output should return the container ports used in container networks")
-      inside(parseTxtResponse(response14.getEntity.toString)) {
-        case line1 :: line2 :: Nil =>
-          line1 shouldBe List("foo", "20163", "10.11.12.13:22")
-          line2 shouldBe List("foo", "13032", "10.11.12.13:6090")
-      }
-
-      When("Getting the txt tasks index with 1.5 compatibility mode")
-      val response15 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_8, req = auth.request, asyncResponse = r) }
-      Then("The status should be 200")
-      response15.getStatus shouldEqual 200
-
-      And("the output should return the nonsensical, useless entries of port:0")
-      inside(parseTxtResponse(response15.getEntity.toString)) {
-        case line1 :: line2 :: Nil =>
-          line1 shouldBe List("foo", "20163", "host.some:0")
-          line2 shouldBe List("foo", "13032", "host.some:0")
-      }
-
-      When("Getting the txt tasks index with lastest compatibility mode and including containerNetworks")
+      When("Getting the txt tasks index and including containerNetworks")
       val responseLatest = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, containerNetworks = "*", req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
@@ -410,8 +384,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
         groupManager,
         healthCheckManager,
         auth.auth,
-        auth.auth,
-        DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
+        auth.auth
       )
 
       Given("the app exists")

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -24,13 +24,14 @@ import mesosphere.marathon.test.{GroupCreation, JerseyTest}
 import org.apache.mesos
 import org.mockito.Matchers
 import org.mockito.Mockito._
+import org.scalatest.Inside
 
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
+class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with Inside {
   case class Fixture(
       auth: TestAuthFixture = new TestAuthFixture,
       instanceTracker: InstanceTracker = mock[InstanceTracker],
@@ -77,6 +78,9 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       response.getStatus shouldEqual 200
     }
 
+    def parseTxtResponse(response: String): List[List[String]] =
+      response.trim.split("\n").iterator.map(_.split("\t").toList).toList
+
     "list (txt) tasks with 1.4 compatibility mode outputs container network ips and ports" in new Fixture {
       Given("a running instance of an app using container networks")
       val app = AppDefinition(
@@ -113,22 +117,30 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       val rootGroup = createRootGroup(apps = Map(app.id -> app))
       groupManager.rootGroup() returns rootGroup
 
-      When("Getting the txt tasks index")
-      val response = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_4, auth.request, r) }
-
-      /* Note that without compatibility 1.4, the following (less useful) response is returned:
-       * foo   20163   host.some:0
-       * foo   13032   host.some:0
-       */
+      When("Getting the txt tasks index with 1.4 compatibility mode")
+      val response14 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_4, auth.request, r) }
 
       Then("The status should be 200")
-      response.getStatus shouldEqual 200
+      response14.getStatus shouldEqual 200
 
       And("the output should return the container ports used in container networks")
-      val lines = response.getEntity.toString.trim.split("\n").iterator.map(_.split("\t").toList).toList
-      lines.length shouldBe 2
-      lines(0) shouldBe List("foo", "20163", "10.11.12.13:22")
-      lines(1) shouldBe List("foo", "13032", "10.11.12.13:6090")
+      inside(parseTxtResponse(response14.getEntity.toString)) {
+        case line1 :: line2 :: Nil =>
+          line1 shouldBe List("foo", "20163", "10.11.12.13:22")
+          line2 shouldBe List("foo", "13032", "10.11.12.13:6090")
+      }
+
+      When("Getting the txt tasks index with Latest compatibility mode")
+      val responseLatest = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, auth.request, r) }
+      Then("The status should be 200")
+      responseLatest.getStatus shouldEqual 200
+
+      And("the output should return the nonsensical, useless entries of port:0")
+      inside(parseTxtResponse(responseLatest.getEntity.toString)) {
+        case line1 :: line2 :: Nil =>
+          line1 shouldBe List("foo", "20163", "host.some:0")
+          line2 shouldBe List("foo", "13032", "host.some:0")
+      }
     }
 
     "list apps when there are no apps" in new Fixture {

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -71,7 +71,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       assert(app.servicePorts.size > instance.appTask.status.networkInfo.hostPorts.size)
 
       When("Getting the txt tasks index")
-      val response = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req = auth.request, asyncResponse = r) }
+      val response = asyncRequest { r => taskResource.indexTxt(req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
       response.getStatus shouldEqual 200
@@ -117,7 +117,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       groupManager.rootGroup() returns rootGroup
 
       When("Getting the txt tasks index and including containerNetworks")
-      val responseLatest = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, containerNetworks = "*", req = auth.request, asyncResponse = r) }
+      val responseLatest = asyncRequest { r => taskResource.indexTxt(containerNetworks = "*", req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
       responseLatest.getStatus shouldEqual 200
@@ -353,7 +353,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one index as txt is fetched")
-      val cancel = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req = auth.request, asyncResponse = r) }
+      val cancel = asyncRequest { r => taskResource.indexTxt(req = auth.request, asyncResponse = r) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -72,7 +72,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       assert(app.servicePorts.size > instance.appTask.status.networkInfo.hostPorts.size)
 
       When("Getting the txt tasks index")
-      val response = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, auth.request, r) }
+      val response = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
       response.getStatus shouldEqual 200
@@ -118,7 +118,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       groupManager.rootGroup() returns rootGroup
 
       When("Getting the txt tasks index with 1.4 compatibility mode")
-      val response14 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_4, auth.request, r) }
+      val response14 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_4, req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
       response14.getStatus shouldEqual 200
@@ -131,7 +131,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       }
 
       When("Getting the txt tasks index with 1.5 compatibility mode")
-      val response15 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_5, auth.request, r) }
+      val response15 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_5, req = auth.request, asyncResponse = r) }
       Then("The status should be 200")
       response15.getStatus shouldEqual 200
 
@@ -143,7 +143,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       }
 
       When("Getting the txt tasks index with lastest compatibility mode")
-      val responseLatest = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, auth.request, r) }
+      val responseLatest = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
       responseLatest.getStatus shouldEqual 200
@@ -379,7 +379,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one index as txt is fetched")
-      val cancel = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req, r) }
+      val cancel = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req = auth.request, asyncResponse = r) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -49,7 +49,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       healthCheckManager,
       auth.auth,
       auth.auth,
-      marathon15CompatibilityEnabled = true
+      DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
     )
   }
 
@@ -131,7 +131,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       }
 
       When("Getting the txt tasks index with 1.5 compatibility mode")
-      val response15 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_5, req = auth.request, asyncResponse = r) }
+      val response15 = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.V1_8, req = auth.request, asyncResponse = r) }
       Then("The status should be 200")
       response15.getStatus shouldEqual 200
 
@@ -142,8 +142,8 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
           line2 shouldBe List("foo", "13032", "host.some:0")
       }
 
-      When("Getting the txt tasks index with lastest compatibility mode")
-      val responseLatest = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req = auth.request, asyncResponse = r) }
+      When("Getting the txt tasks index with lastest compatibility mode and including containerNetworks")
+      val responseLatest = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, containerNetworks = "*", req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
       responseLatest.getStatus shouldEqual 200
@@ -411,7 +411,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
         healthCheckManager,
         auth.auth,
         auth.auth,
-        marathon15CompatibilityEnabled = true
+        DeprecatedFeatureConfig.empty(SemVer(1, 9, 0))
       )
 
       Given("the app exists")

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -45,7 +45,8 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       groupManager,
       healthCheckManager,
       auth.auth,
-      auth.auth
+      auth.auth,
+      DeprecatedFeatureConfig.empty(SemVer(1, 8, 0))
     )
   }
 
@@ -68,7 +69,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       assert(app.servicePorts.size > instance.appTask.status.networkInfo.hostPorts.size)
 
       When("Getting the txt tasks index")
-      val response = asyncRequest { r => taskResource.indexTxt(auth.request, r) }
+      val response = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, auth.request, r) }
 
       Then("The status should be 200")
       response.getStatus shouldEqual 200
@@ -297,7 +298,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one index as txt is fetched")
-      val cancel = asyncRequest { r => taskResource.indexTxt(req, r) }
+      val cancel = asyncRequest { r => taskResource.indexTxt(MarathonCompatibility.Latest, req, r) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }
@@ -328,7 +329,8 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
         groupManager,
         healthCheckManager,
         auth.auth,
-        auth.auth
+        auth.auth,
+        DeprecatedFeatureConfig.empty(SemVer(1, 8, 0))
       )
 
       Given("the app exists")


### PR DESCRIPTION
In this commit we fixed the plaintext output of /v2/tasks to no longer include nonsensical addresses for container endpoints that lacked a host port mapping. Further, we introduce the parameter "containerNetworks" to opt in to include non-host mapped container endpoints.

containerNetworks is a comma delimited list of network names, where the value "*" is interpreted as including all container networks.

JIRA issues: MARATHON-8721