### PR TITLE
Add `?containerNetworks` querystring parameter to /v2/tasks text output

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,18 @@
 * [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) - With UnreachableStrategy, setting
   expungeAfterSeconds and inactiveAfterSeconds to the same value will cause the instance to be expunged immediately;
   this helps with `GROUP_BY` or `UNIQUE` constraints.
+* [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) - Marathon `/v2/tasks` text formatted output no
+  longer includes endpoints without host-port mappings at the agent hostname and port 0.
+
+### `/v2/tasks` `application/text` output
+
+#### Addition of containerNetworks parameter
+
+Marathon outputs a terse, text-formatted list of instances with corresponding port-mappings with a request to `/v2/tasks` with content-type: `application/text`. Usage of this endpoint is generally discouraged, but some older tools continue to rely on it.
+
+As of Marathon 1.5, the output would include user container network endpoint without a host port mapping, but in a form that was completely unusable (the agent's hostname as the address, even though the endpoint is fundamentally unreachable at that address, and the port 0). This behavior has been removed, and such results are not included by `/v2/tasks` application/text output, by default.
+
+A parameter `containerNetworks` has been added to filter and include port mappings pertaining to a comma-delimited list of user container network names. Setting this flag does not affect the output for port mappings that are bound to a host port in some way (either directly, in the case of host networking, or through a bridge-network port mapping). To see all container ips and endpoints for all user container networks, pass `?containerNetworks=*`.
 
 ## Changes from 1.8.218 to 1.8.222
 

--- a/docs/docs/rest-api/public/api/v2/apps.raml
+++ b/docs/docs/rest-api/public/api/v2/apps.raml
@@ -468,6 +468,13 @@
       get:
         description: List all running tasks for application `app_id`.
         is: [ secured ]
+        queryParameters:
+          containerNetworks:
+            required: false
+            description: |
+              Filter and include port mappings pertaining to a comma-delimited list of user container network names.
+              To see all container ips and endpoints for all user container networks, pass <code>?containerNetworks=*</code>.
+            type: string
         responses:
           200:
             description: The list of running tasks for application `app_id`.

--- a/docs/docs/rest-api/public/api/v2/tasks.raml
+++ b/docs/docs/rest-api/public/api/v2/tasks.raml
@@ -11,6 +11,12 @@ get:
       required: false
       description: Filter the list of tasks by several statuses.
       type: task.TaskStatusCondition[]
+    containerNetworks:
+      required: false
+      description: |
+        Filter and include port mappings pertaining to a comma-delimited list of user container network names.
+        To see all container ips and endpoints for all user container networks, pass <code>?containerNetworks=*</code>.
+      type: string
   responses:
     200:
       description: The list of all tasks disregarding their status, or a list of tasks matching the specified status filter.

--- a/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
+++ b/src/main/scala/mesosphere/marathon/api/EndpointsHelper.scala
@@ -2,61 +2,137 @@ package mesosphere.marathon
 package api
 
 import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.pod.{ContainerNetwork, HostNetwork}
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
 import mesosphere.marathon.state.AppDefinition
+import mesosphere.marathon.state.Container.PortMapping
 
 object EndpointsHelper {
-  /**
-    * Produces a script-friendly string representation of the supplied
-    * apps' tasks.  The data columns in the result are separated by
-    * the supplied delimiter string.
-    *
-    * Generated line format is: * <pre>{app-id}{d}{service-port}{d}{address-list}</pre>.
-    * `{service-port}` is `" "` for apps without service ports.
-    * `{address-list}` is either `{host-list}` (for apps without service ports), or `{host-address-list}`.
-    * `{host-list}` is a delimited list of agents that are running the task.
-    * `{host-address-list}` is a delimited list of `{agent}:{hostPort}` tuples.
-    * The contents of `{address-list}` are sorted for deterministic output.
-    */
-  def appsToEndpointString(data: ListTasks): String = {
+  private[api] def parseNetworkPredicate(networkFilter: Set[String]): String => Boolean = {
+    if (networkFilter contains "*") {
+      { _ => true }
+    } else {
+      networkFilter
+    }
+  }
 
+  /**
+    * Renders a text representation of tasks and their corresponding network ports, prioritized first by the host
+    * network, and then, if a mapping is not available, the container ip and container port.
+    *
+    * @param data The tasks to render
+    * @param containerNetworks Set of container network names to include in the output. A network name of "*" indicates all networks should be included.
+    */
+  def appsToEndpointString(data: ListTasks, containerNetworks: Set[String]): String = {
     val delimiter = "\t"
     val sb = new StringBuilder
     val apps = data.apps
     val instancesMap = data.instancesMap
 
+    val containerNetworkPredicate = parseNetworkPredicate(containerNetworks)
+
     apps.foreach { app =>
       val instances = instancesMap.specInstances(app.id)
       val cleanId = app.id.safePath
+      val appContainerNetworkNames = app.networks.collect { case ContainerNetwork(name, _) => name }
 
       val servicePorts = app.servicePorts
 
       if (servicePorts.isEmpty) {
         sb.append(cleanId).append(delimiter).append(' ').append(delimiter)
-        instances.collect { case Instance.Running(_, agentInfo, _) => agentInfo.host }
-          .sorted.foreach { hostname =>
-            sb.append(hostname).append(delimiter)
-          }
+        for (
+          instance <- instances if instance.isRunning;
+          agentInfo <- instance.agentInfo
+        ) {
+          sb.append(agentInfo.host).append('\t')
+        }
         sb.append('\n')
       } else {
-        servicePorts.zipWithIndex.foreach {
-          case (port, i) =>
-            sb.append(cleanId).append(delimiter).append(port).append(delimiter)
-            instances.collect {
-              case Instance.Running(_, agentInfo, tasksMap) =>
-                tasksMap.map {
-                  case (_, task) =>
-                    val taskPort = task.status.networkInfo.hostPorts.drop(i).headOption.getOrElse(0)
-                    s"${agentInfo.host}:$taskPort"
+        for ((port, i) <- servicePorts.zipWithIndex) {
+          sb.append(cleanId).append(delimiter).append(port).append(delimiter)
+
+          val ipPerTaskPortMapping = if (!app.networks.contains(HostNetwork)) containerPortMapping(app, i) else None
+          val runningInstances = instances.withFilter(_.isRunning)
+          ipPerTaskPortMapping match {
+            // port definition with no hostPort: container network
+            case Some(portMapping) if portMapping.hostPort.isEmpty =>
+              runningInstances.foreach { instance =>
+                val networkNames = if (portMapping.networkNames.isEmpty)
+                  appContainerNetworkNames
+                else
+                  portMapping.networkNames
+                // note: this excludes bridge-networks
+                if (networkNames.exists(containerNetworkPredicate))
+                  tryAppendContainerPort(sb, app, portMapping, instance, delimiter)
+              }
+            case Some(portMapping) if portMapping.hostPort.nonEmpty =>
+              // the task hostPorts only contains an entry for each portMapping that has a hostPort defined
+              // We need to compute and use the new index
+              hostPortIndexOffset(app, i).foreach { computedHostPortIndex =>
+                runningInstances.foreach { task =>
+                  appendHostPort(sb, task, computedHostPortIndex, delimiter)
                 }
-            }.flatten.sorted.foreach { address =>
-              sb.append(address).append(delimiter)
-            }
-            sb.append('\n')
+              }
+            case _ =>
+              runningInstances.foreach { instance =>
+                appendHostPort(sb, instance, i, delimiter)
+              }
+          }
+          sb.append('\n')
         }
       }
     }
     sb.toString()
+  }
+
+  def containerPortMapping(app: AppDefinition, portIdx: Integer): Option[PortMapping] =
+    for {
+      container <- app.container
+      portMapping <- container.portMappings.lift(portIdx) // After MARATHON-7407 is addressed, this should probably throw.
+    } yield portMapping
+
+  /**
+    * Append an entry to the provided string builder for the specified containerPort. If we cannot tell the
+    * effectiveIpAddress, output nothing.
+    */
+  def tryAppendContainerPort(sb: StringBuilder, app: AppDefinition, portMapping: PortMapping, instance: Instance,
+    delimiter: String): Unit = {
+    for {
+      task <- instance.tasksMap.values
+      address <- task.status.networkInfo.effectiveIpAddress(app)
+    } {
+      sb.append(address).append(':').append(portMapping.containerPort).append(delimiter)
+    }
+  }
+
+  /**
+    * Adjusts the index based on portMapping definitions. Expects that the specified index refers to a nonEmpty hostPort
+    * portmapping record.
+    */
+  def hostPortIndexOffset(app: AppDefinition, idx: Integer): Option[Integer] = {
+    app.container.flatMap { container =>
+      val pm = container.portMappings
+      if (idx < 0 || idx >= pm.length) // index 2, length 2 invalid
+        None // linter:ignore:DuplicateIfBranches
+      else if (pm(idx).hostPort.isEmpty)
+        None
+      else
+        // count each preceeding nonEmpty hostPort to get new index
+        Some(pm.toIterator.take(idx).count(_.hostPort.nonEmpty))
+    }
+  }
+
+  /**
+    * Append an entry to the provided string builder using the task's agent host IP and specified host port
+    */
+  def appendHostPort(sb: StringBuilder, instance: Instance, portIdx: Integer, delimiter: String): Unit = {
+    for {
+      agentInfo <- instance.agentInfo
+      task <- instance.tasksMap.values if task.status.condition.isActive
+      taskPort <- task.status.networkInfo.hostPorts.lift(portIdx)
+    } {
+      sb.append(agentInfo.host).append(':').append(taskPort).append(delimiter)
+    }
   }
 
   case class ListTasks(instancesMap: InstancesBySpec, apps: Seq[AppDefinition])

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -85,13 +85,15 @@ class AppTasksResource @Inject() (
   @Produces(Array(RestResource.TEXT_PLAIN_LOW))
   def indexTxt(
     @PathParam("appId") appId: String,
+    @DefaultValue("")@QueryParam("containerNetworks") containerNetworks: String = "",
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
       implicit val identity = await(authenticatedAsync(req))
       val id = appId.toRootPath
       val instancesBySpec = await(instanceTracker.instancesBySpec)
       withAuthorization(ViewRunSpec, groupManager.app(id), unknownApp(id)) { app =>
-        ok(EndpointsHelper.appsToEndpointString(ListTasks(instancesBySpec, Seq(app))))
+        val data = ListTasks(instancesBySpec, Seq(app))
+        ok(EndpointsHelper.appsToEndpointString(data, containerNetworks.split(",").toSet))
       }
     }
   }

--- a/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/EndpointsHelperTest.scala
@@ -12,8 +12,27 @@ import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.tracker.InstanceTracker.{InstancesBySpec, SpecInstances}
 import mesosphere.marathon.state._
 import org.apache.mesos.{Protos => Mesos}
+import org.scalatest.Inside
 
-class EndpointsHelperTest extends UnitTest {
+import scala.collection.immutable.Seq
+
+class EndpointsHelperTest extends UnitTest with Inside {
+  private val allContainerNetworks = Set("*")
+  private val noContainerNetworks = Set.empty[String]
+
+  def parseOutput(output: String): List[(String, String, Seq[String])] = {
+    output.trim.split("\n").iterator
+      .map {
+        case line =>
+          line.split("\t", -1).toList match {
+            case app :: port :: endpoints =>
+              (app, port, endpoints.filter(_.nonEmpty).sorted)
+            case o =>
+              throw new RuntimeException(s"parse error: ${o}")
+          }
+      }
+      .toList
+  }
 
   def instances(app: AppDefinition, taskCounts: Seq[Int]): InstancesBySpec = {
     val instances = SpecInstances(taskCounts.zipWithIndex.flatMap {
@@ -25,8 +44,7 @@ class EndpointsHelperTest extends UnitTest {
         1.to(numTasks).map { taskIndex =>
           val instanceId = Instance.Id.forRunSpec(app.id)
           val ipAddresses: Seq[Mesos.NetworkInfo.IPAddress] =
-            if (app.networks.hasNonHostNetworking) Nil
-            else Seq(Mesos.NetworkInfo.IPAddress.newBuilder()
+            Seq(Mesos.NetworkInfo.IPAddress.newBuilder()
               .setIpAddress(s"1.1.1.${agentId * 10 + taskIndex}")
               .setProtocol(Mesos.NetworkInfo.Protocol.IPv4)
               .build)
@@ -49,53 +67,53 @@ class EndpointsHelperTest extends UnitTest {
     InstancesBySpec(Map(app.id -> instances))
   }
 
-  def fakeApp(appId: PathId = PathId("/foo"), container: => Option[Container] = None, network: => Network): AppDefinition =
-    AppDefinition(appId, cmd = Option("sleep"), container = container, networks = Seq(network))
+  def fakeApp(appId: PathId = PathId("/foo"), container: => Option[Container] = None, networks: Seq[Network]): AppDefinition =
+    AppDefinition(appId, cmd = Option("sleep"), container = container, networks = networks)
 
   def endpointsWithoutServicePorts(app: AppDefinition): Unit = {
     "handle single instance without service ports" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)))
-      val expected = "foo\t \tagent1\t\n"
+      val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)), allContainerNetworks))
+      val expected = List(("foo", " ", Seq("agent1")))
       report should equal(expected)
     }
     "handle multiple instances, same agent, without service ports" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2)), Seq(app)))
-      val expected = "foo\t \tagent1\tagent1\t\n"
+      val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2)), Seq(app)), allContainerNetworks))
+      val expected = List(("foo", " ", Seq("agent1", "agent1")))
       report should equal(expected)
     }
     "handle multiple instances, different agents, without service ports" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2, 1, 2)), Seq(app)))
-      val expected = "foo\t \tagent1\tagent1\tagent2\tagent3\tagent3\t\n"
+      val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2, 1, 2)), Seq(app)), allContainerNetworks))
+      val expected = List(("foo", " ", Seq("agent1", "agent1", "agent2", "agent3", "agent3")))
       report should equal(expected)
     }
   }
 
   def endpointsWithSingleDynamicServicePorts(app: AppDefinition): Unit = {
     "handle single instance with 1 service port" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)), allContainerNetworks)
       val expected = "foo\t80\tagent1:1010\t\n"
       report should equal(expected)
     }
     "handle multiple instances, same agent, with 1 service port" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2)), Seq(app)))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2)), Seq(app)), allContainerNetworks)
       val expected = "foo\t80\tagent1:1010\tagent1:1020\t\n"
       report should equal(expected)
     }
     "handle multiple instances, different agents, with 1 service port" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2, 1, 2)), Seq(app)))
-      val expected = "foo\t80\tagent1:1010\tagent1:1020\tagent2:1010\tagent3:1010\tagent3:1020\t\n"
+      val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(2, 1, 2)), Seq(app)), allContainerNetworks))
+      val expected = List(("foo", "80", Seq("agent1:1010", "agent1:1020", "agent2:1010", "agent3:1010", "agent3:1020")))
       report should equal(expected)
     }
   }
 
   def endpointsWithSingleStaticServicePorts(app: AppDefinition, servicePort: Int, hostPort: Int): Unit = {
     s"handle single instance with 1 (static) service port $servicePort and host port $hostPort" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)))
-      val expected = s"foo\t$servicePort\tagent1:$hostPort\t\n"
+      val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1)), Seq(app)), allContainerNetworks))
+      val expected = List(("foo", servicePort.toString, Seq(s"agent1:$hostPort")))
       report should equal(expected)
     }
     s"handle multiple instances, different agents, with 1 (static) service port $servicePort and host port $hostPort" in {
-      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1, 1, 1)), Seq(app)))
+      val report = EndpointsHelper.appsToEndpointString(ListTasks(instances(app, Seq(1, 1, 1)), Seq(app)), allContainerNetworks)
       val expected = s"foo\t$servicePort\tagent1:$hostPort\tagent2:$hostPort\tagent3:$hostPort\t\n"
       report should equal(expected)
     }
@@ -103,9 +121,10 @@ class EndpointsHelperTest extends UnitTest {
 
   "EndpointsHelper" when {
     "generating (host network) app service port reports" should {
-      behave like endpointsWithoutServicePorts(fakeApp(network = HostNetwork))
+      val hostNetworkedFakeApp = fakeApp(networks = Seq(HostNetwork))
+      behave like endpointsWithoutServicePorts(hostNetworkedFakeApp)
 
-      val singleServicePort = fakeApp(network = HostNetwork).copy(portDefinitions = PortDefinitions(80))
+      val singleServicePort = fakeApp(networks = Seq(HostNetwork)).copy(portDefinitions = PortDefinitions(80))
 
       behave like endpointsWithSingleDynamicServicePorts(singleServicePort)
       behave like endpointsWithSingleStaticServicePorts(
@@ -114,16 +133,17 @@ class EndpointsHelperTest extends UnitTest {
         hostPort = 80
       )
     }
+
     "generating (bridge network) app service port reports" should {
       val bridgeNetwork = BridgeNetwork()
       val container = Container.Mesos()
 
       behave like endpointsWithoutServicePorts(
-        fakeApp(container = Option(container), network = bridgeNetwork))
+        fakeApp(container = Option(container), networks = Seq(bridgeNetwork)))
 
       val singleServicePort = fakeApp(container = Option(container.copy(
         portMappings = Seq(Container.PortMapping(servicePort = 80, hostPort = Option(0)))
-      )), network = bridgeNetwork)
+      )), networks = Seq(bridgeNetwork))
 
       behave like endpointsWithSingleDynamicServicePorts(singleServicePort)
 
@@ -138,16 +158,25 @@ class EndpointsHelperTest extends UnitTest {
         hostPort = 80
       )
     }
-    "generating (container network) app service port reports" should {
-      val containerNetwork = ContainerNetwork("whatever")
-      val container = Container.Mesos()
 
-      behave like endpointsWithoutServicePorts(
-        fakeApp(container = Option(container), network = containerNetwork))
+    "generating (container network) app service port reports" should {
+      val containerNetwork = ContainerNetwork("macvlan")
+      val containerNetwork2 = ContainerNetwork("weave")
+      val container = Container.Mesos()
+      val servicePort = 80
 
       val singleServicePort = fakeApp(container = Option(container.copy(
-        portMappings = Seq(Container.PortMapping(servicePort = 80, hostPort = Option(0)))
-      )), network = containerNetwork)
+        portMappings = Seq(Container.PortMapping(servicePort = servicePort, hostPort = Option(0)))
+      )), networks = Seq(containerNetwork))
+
+      val appWithoutHostPorts = singleServicePort.copy(
+        requirePorts = true,
+        container = singleServicePort.container.map { c =>
+          c.copyWith(c.portMappings.map(_.copy(servicePort = servicePort, containerPort = 8080, hostPort = None)))
+        })
+
+      behave like endpointsWithoutServicePorts(
+        fakeApp(container = Option(container), networks = Seq(containerNetwork)))
 
       behave like endpointsWithSingleDynamicServicePorts(singleServicePort)
 
@@ -155,23 +184,56 @@ class EndpointsHelperTest extends UnitTest {
         singleServicePort.copy(
           requirePorts = true,
           container = singleServicePort.container.map { c =>
-            c.copyWith(c.portMappings.map(_.copy(servicePort = 88, hostPort = Option(80))))
+            c.copyWith(c.portMappings.map(_.copy(servicePort = servicePort, hostPort = Option(80))))
           }
         ),
-        servicePort = 88,
+        servicePort = servicePort,
         hostPort = 80
       )
 
-      behave like endpointsWithSingleStaticServicePorts(
-        singleServicePort.copy(
-          requirePorts = true,
-          container = singleServicePort.container.map { c =>
-            c.copyWith(c.portMappings.map(_.copy(servicePort = 88, hostPort = None)))
-          }
-        ),
-        servicePort = 88,
-        hostPort = 0 // weird edge case for tasks on container networks without hostPort defined
-      )
+      s"handle single instance with 1 (static) service port $servicePort and no host port by outputting the container ip and container port" in {
+        val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(appWithoutHostPorts, Seq(1)), Seq(appWithoutHostPorts)), allContainerNetworks))
+        val expected = List(("foo", servicePort.toString, Seq("1.1.1.11:8080")))
+        report should equal(expected)
+      }
+
+      "handle multiple instances, different agents and no host port mapping by outputting the container ip and container port" in {
+        val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(appWithoutHostPorts, Seq(1, 1, 1)), Seq(appWithoutHostPorts)), allContainerNetworks))
+        val expected = List(("foo", "80", List("1.1.1.11:8080", "1.1.1.21:8080", "1.1.1.31:8080")))
+        report should equal(expected)
+      }
+
+      "exclude container-networked endpoints when not included in the network list" in {
+        val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(appWithoutHostPorts, Seq(1)), Seq(appWithoutHostPorts)), noContainerNetworks))
+        val expected = List(("foo", servicePort.toString, Seq()))
+        report should equal(expected)
+      }
+
+      "include only container-networked endpoints that are in the network list" in {
+        val dualServicePorts = fakeApp(
+          container = Option(container.copy(
+            portMappings = Seq(
+              Container.PortMapping(servicePort = 80, hostPort = None, containerPort = 8080, networkNames = Seq(containerNetwork.name)),
+              Container.PortMapping(servicePort = 81, hostPort = None, containerPort = 8081, networkNames = Seq(containerNetwork2.name)),
+            )
+          )),
+          networks = Seq(containerNetwork, containerNetwork2)
+        ).copy(
+          requirePorts = true
+        )
+
+        val report = parseOutput(EndpointsHelper.appsToEndpointString(ListTasks(instances(dualServicePorts, Seq(1)), Seq(dualServicePorts)), Set(containerNetwork.name)))
+        inside(report) {
+          case (app1, port1, mappings1) :: (app2, port2, mappings2) :: Nil =>
+            app1 shouldBe "foo"
+            port1 shouldBe "80"
+            mappings1 shouldBe List("1.1.1.11:8080") // we include containerNetwork port mappings
+
+            app2 shouldBe "foo"
+            port2 shouldBe "81"
+            mappings2 shouldBe List() // but not containerNetwork2 port mappings
+        }
+      }
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -321,7 +321,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       indexJson.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("", req = req, asyncResponse = r) }
       Then("we receive a NotAuthenticated response")
       indexTxt.getStatus should be(auth.NotAuthenticatedStatus)
 
@@ -416,7 +416,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req = req, asyncResponse = r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(auth.UnauthorizedStatus)
     }
@@ -432,7 +432,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.empty)
 
       When("the index as txt is fetched")
-      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req, r) }
+      val indexTxt = asyncRequest { r => appsTaskResource.indexTxt("/app", req = req, asyncResponse = r) }
       Then("we receive a not authorized response")
       indexTxt.getStatus should be(404)
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -7,28 +7,31 @@ import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import mesosphere.UnitTest
 import mesosphere.marathon.api.{RestResource, TaskKiller, TestAuthFixture}
-import mesosphere.marathon.test.JerseyTest
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStep}
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.HealthCheckManager
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.pod.ContainerNetwork
 import mesosphere.marathon.core.task.Task
+import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.core.task.termination.KillService
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.plugin.auth.Identity
+import mesosphere.marathon.state.Container.PortMapping
 import mesosphere.marathon.state.PathId.StringPathId
 import mesosphere.marathon.state._
-import mesosphere.marathon.test.GroupCreation
+import mesosphere.marathon.test.{GroupCreation, JerseyTest}
+import org.apache.mesos
 import org.mockito.Matchers
 import org.mockito.Mockito._
+import org.scalatest.Inside
 
 import scala.collection.immutable.Seq
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
+class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with Inside {
   case class Fixture(
       auth: TestAuthFixture = new TestAuthFixture,
       instanceTracker: InstanceTracker = mock[InstanceTracker],
@@ -68,10 +71,62 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       assert(app.servicePorts.size > instance.appTask.status.networkInfo.hostPorts.size)
 
       When("Getting the txt tasks index")
-      val response = asyncRequest { r => taskResource.indexTxt(auth.request, r) }
+      val response = asyncRequest { r => taskResource.indexTxt(req = auth.request, asyncResponse = r) }
 
       Then("The status should be 200")
       response.getStatus shouldEqual 200
+    }
+
+    def parseTxtResponse(response: String): List[List[String]] =
+      response.trim.split("\n").iterator.map(_.split("\t").toList).toList
+
+    "list (txt) tasks with  mode outputs container network ips and ports" in new Fixture {
+      Given("a running instance of an app using container networks")
+      val app = AppDefinition(
+        "/foo".toPath,
+        networks = Seq(ContainerNetwork("weave")),
+        container = Some(Container.Docker(
+          image = "alpine",
+          portMappings = Seq(
+            PortMapping(
+              name = Some("http"),
+              containerPort = 22,
+              hostPort = None,
+              servicePort = 20163),
+            PortMapping(
+              name = Some("https"),
+              containerPort = 6090,
+              hostPort = None,
+              servicePort = 13032)))))
+
+      val instance = TestInstanceBuilder.newBuilder(app.id).addTaskWithBuilder()
+        .taskRunning()
+        .withNetworkInfo(
+          NetworkInfo(
+            hostName = "hostname",
+            hostPorts = Nil,
+            ipAddresses = Seq(mesos.Protos.NetworkInfo.IPAddress.newBuilder().setIpAddress("10.11.12.13").build())))
+        .build()
+        .getInstance()
+
+      val tasksByApp = InstanceTracker.InstancesBySpec.forInstances(instance)
+      instanceTracker.instancesBySpec returns Future.successful(tasksByApp)
+
+      val rootGroup = createRootGroup(apps = Map(app.id -> app))
+      groupManager.rootGroup() returns rootGroup
+
+      When("Getting the txt tasks index and including containerNetworks")
+      val responseLatest = asyncRequest { r => taskResource.indexTxt(containerNetworks = "*", req = auth.request, asyncResponse = r) }
+
+      Then("The status should be 200")
+      responseLatest.getStatus shouldEqual 200
+
+      And("the output should return the container ports used in container networks")
+      inside(parseTxtResponse(responseLatest.getEntity.toString)) {
+        case line1 :: line2 :: Nil =>
+          line1 shouldBe List("foo", "20163", "10.11.12.13:22")
+          line2 shouldBe List("foo", "13032", "10.11.12.13:6090")
+      }
     }
 
     "list apps when there are no apps" in new Fixture {
@@ -297,7 +352,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest {
       running.getStatus should be(auth.NotAuthenticatedStatus)
 
       When("one index as txt is fetched")
-      val cancel = asyncRequest { r => taskResource.indexTxt(req, r) }
+      val cancel = asyncRequest { r => taskResource.indexTxt(req = auth.request, asyncResponse = r) }
       Then("we receive a NotAuthenticated response")
       cancel.getStatus should be(auth.NotAuthenticatedStatus)
     }


### PR DESCRIPTION
Backport of #7123

In this commit we fixed the plaintext output of /v2/tasks to no longer
include nonsensical addresses for container endpoints that lacked a host
port mapping. Further, we introduce the parameter "containerNetworks" to
opt in to include non-host mapped container endpoints.

containerNetworks is a comma delimited list of network names, where the
value "*" is interpreted as including all container networks.

JIRA issues: MARATHON-8721
