### PR TITLE
Deprecate `text/plain output for tasks.`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,15 +16,21 @@
 * [MARATHON-8719](https://jira.mesosphere.com/browse/MARATHON-8719) - Marathon `/v2/tasks` text formatted output no
   longer includes endpoints without host-port mappings at the agent hostname and port 0.
 
-### `/v2/tasks` `application/text` output
+### `/v2/tasks` `text/plain` output
 
-#### Addition of containerNetworks parameter
+#### Addition of `containerNetworks` parameter
 
 Marathon outputs a terse, text-formatted list of instances with corresponding port-mappings with a request to `/v2/tasks` with content-type: `application/text`. Usage of this endpoint is generally discouraged, but some older tools continue to rely on it.
 
 As of Marathon 1.5, the output would include user container network endpoint without a host port mapping, but in a form that was completely unusable (the agent's hostname as the address, even though the endpoint is fundamentally unreachable at that address, and the port 0). This behavior has been removed, and such results are not included by `/v2/tasks` application/text output, by default.
 
 A parameter `containerNetworks` has been added to filter and include port mappings pertaining to a comma-delimited list of user container network names. Setting this flag does not affect the output for port mappings that are bound to a host port in some way (either directly, in the case of host networking, or through a bridge-network port mapping). To see all container ips and endpoints for all user container networks, pass `?containerNetworks=*`.
+
+#### Deprecation ####
+
+The `text/plain` output is deprecated. It will be soft removed with Marathon 1.10. Any request will
+result in an `HTTP 406 Not Accetable` if the accept header is `test/plain` unless `--deprecated_features text_plain_tasks`
+is enabled. It will be hard removed with Marathon 1.11.
 
 ## Changes from 1.9.73 to 1.9.100
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@
 
 #### Addition of `containerNetworks` parameter
 
-Marathon outputs a terse, text-formatted list of instances with corresponding port-mappings with a request to `/v2/tasks` with content-type: `application/text`. Usage of this endpoint is generally discouraged, but some older tools continue to rely on it.
+Marathon outputs a terse, text-formatted list of instances with corresponding port-mappings with a request to `/v2/tasks` with content-type: `text/plain`. Usage of this endpoint is generally discouraged, but some older tools continue to rely on it.
 
 As of Marathon 1.5, the output would include user container network endpoint without a host port mapping, but in a form that was completely unusable (the agent's hostname as the address, even though the endpoint is fundamentally unreachable at that address, and the port 0). This behavior has been removed, and such results are not included by `/v2/tasks` application/text output, by default.
 

--- a/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
+++ b/src/main/scala/mesosphere/marathon/DeprecatedFeatures.scala
@@ -66,8 +66,15 @@ object DeprecatedFeatures {
     softRemoveVersion = SemVer(1, 10, 0),
     hardRemoveVersion = SemVer(1, 11, 0))
 
+  val textPlainTasks = DeprecatedFeature(
+    "text_plain_tasks",
+    description = "Enables the v2/tasks and v2/apps/<id>/tasks endpoints to accept text/plain as response format.",
+    softRemoveVersion = SemVer(1, 10, 0),
+    hardRemoveVersion = SemVer(1, 11, 0)
+  )
+
   def all = Seq(syncProxy, jsonSchemasResource, apiHeavyEvents, proxyEvents, kamonMetrics, appC,
-    sanitizeAcceptedResourceRoles)
+    sanitizeAcceptedResourceRoles, textPlainTasks)
 
   def description: String = {
     "  - " + all.map { df =>

--- a/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppTasksResource.scala
@@ -96,7 +96,7 @@ class AppTasksResource @Inject() (
       } else {
         status(
           Response.Status.NOT_ACCEPTABLE,
-          s"The text/plain output is deprecated. It can be enable via ${DeprecatedFeatures.textPlainTasks.key}.")
+          s"The text/plain output is deprecated. It can be enabled via ${DeprecatedFeatures.textPlainTasks.key}.")
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -103,6 +103,7 @@ class TasksResource @Inject() (
         status(
           Response.Status.NOT_ACCEPTABLE,
           s"The text/plain output is deprecated. It can be enable via ${DeprecatedFeatures.textPlainTasks.key}.")
+      }
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -102,7 +102,7 @@ class TasksResource @Inject() (
       } else {
         status(
           Response.Status.NOT_ACCEPTABLE,
-          s"The text/plain output is deprecated. It can be enable via ${DeprecatedFeatures.textPlainTasks.key}.")
+          s"The text/plain output is deprecated. It can be enabled via ${DeprecatedFeatures.textPlainTasks.key}.")
       }
     }
   }

--- a/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/TasksResource.scala
@@ -92,12 +92,17 @@ class TasksResource @Inject() (
     @DefaultValue("")@QueryParam("containerNetworks") containerNetworks: String = "",
     @Context req: HttpServletRequest, @Suspended asyncResponse: AsyncResponse): Unit = sendResponse(asyncResponse) {
     async {
-      implicit val identity = await(authenticatedAsync(req))
-      val instancesBySpec = await(instanceTracker.instancesBySpec)
-      val rootGroup = groupManager.rootGroup()
-      val data = ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
+      if (config.availableDeprecatedFeatures.isEnabled(DeprecatedFeatures.textPlainTasks)) {
+        implicit val identity = await(authenticatedAsync(req))
+        val instancesBySpec = await(instanceTracker.instancesBySpec)
+        val rootGroup = groupManager.rootGroup()
+        val data = ListTasks(instancesBySpec, rootGroup.transitiveApps.filterAs(app => isAuthorized(ViewRunSpec, app))(collection.breakOut))
 
-      ok(EndpointsHelper.appsToEndpointString(data, containerNetworks.split(",").toSet))
+        ok(EndpointsHelper.appsToEndpointString(data, containerNetworks.split(",").toSet))
+      } else {
+        status(
+          Response.Status.NOT_ACCEPTABLE,
+          s"The text/plain output is deprecated. It can be enable via ${DeprecatedFeatures.textPlainTasks.key}.")
     }
   }
 

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -19,7 +19,6 @@ import org.mockito.Mockito._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
 class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyTest {
 
@@ -29,7 +28,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       instanceTracker: InstanceTracker = mock[InstanceTracker],
       taskKiller: TaskKiller = mock[TaskKiller],
       healthCheckManager: HealthCheckManager = mock[HealthCheckManager],
-      config: MarathonConf = mock[MarathonConf],
+      config: MarathonConf = AllConf.withTestConfig("--deprecated_features", "text_plain_tasks"),
       groupManager: GroupManager = mock[GroupManager]) {
     val identity = auth.identity
     val appsTaskResource = new AppTasksResource(
@@ -41,15 +40,13 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       auth.auth,
       auth.auth
     )
-
-    config.zkTimeoutDuration returns 1.second
   }
 
   case class FixtureWithRealTaskKiller(
       auth: TestAuthFixture = new TestAuthFixture,
       instanceTracker: InstanceTracker = mock[InstanceTracker],
       healthCheckManager: HealthCheckManager = mock[HealthCheckManager],
-      config: MarathonConf = mock[MarathonConf],
+      config: MarathonConf = AllConf.withTestConfig("--deprecated_features", "text_plain_tasks"),
       groupManager: GroupManager = mock[GroupManager]) {
     val identity = auth.identity
     val killService = mock[KillService]
@@ -67,8 +64,6 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       auth.auth,
       auth.auth
     )
-
-    config.zkTimeoutDuration returns 1.second
   }
 
   "SpecInstancesResource" should {
@@ -80,7 +75,6 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val instance2 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, now = clock.now(), version = clock.now()).addTaskStaged().getInstance()
       val toKill = Seq(instance1, instance2)
 
-      config.zkTimeoutDuration returns 5.seconds
       taskKiller.kill(any, any, any)(any) returns Future.successful(toKill)
       groupManager.runSpec(appId) returns Some(AppDefinition(appId, role = "*"))
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
@@ -160,7 +154,6 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val instance2 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, now = clock.now(), version = clock.now()).getInstance()
       val toKill = Seq(instance1)
 
-      config.zkTimeoutDuration returns 5.seconds
       instanceTracker.specInstances(appId) returns Future.successful(Seq(instance1, instance2))
       taskKiller.kill(any, any, any)(any) returns Future.successful(toKill)
       groupManager.app(appId) returns Some(AppDefinition(appId, role = "*"))
@@ -220,7 +213,6 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val instance2 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, now = clock.now(), version = clock.now()).getInstance()
       val toKill = Seq(instance1)
 
-      config.zkTimeoutDuration returns 5.seconds
       instanceTracker.specInstances(appId) returns Future.successful(Seq(instance1, instance2))
       taskKiller.kill(any, any, any)(any) returns Future.successful(toKill)
       groupManager.app(appId) returns Some(AppDefinition(appId, role = "*"))
@@ -265,7 +257,6 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
       val instance1 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, clock.now()).getInstance()
       val instance2 = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, clock.now()).getInstance()
 
-      config.zkTimeoutDuration returns 5.seconds
       instanceTracker.instancesBySpec returns Future.successful(InstanceTracker.InstancesBySpec.forInstances(instance1, instance2))
       healthCheckManager.statuses(appId) returns Future.successful(collection.immutable.Map.empty)
       groupManager.app(appId) returns Some(AppDefinition(appId, role = "*"))


### PR DESCRIPTION
Summary:
The buggy output for `v2/tasks` and `v2/apps<id>/tasks` was fixed with
MARATHON-8721. However, it is still an small overhead to maintain and
users should use the JSON output. Thus we deprecate `Accept: text/plain`
and soft remove it with Marathon 1.10.