### PR TITLE
Allow unreachable instances to actually be expunged immediately

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.2.8

--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -116,11 +116,12 @@ object Instance {
       * @param now           Timestamp of update.
       * @return new InstanceState
       */
-    def apply(
+    def transitionTo(
       maybeOldState: Option[InstanceState],
       newTaskMap: Map[Task.Id, Task],
       now: Timestamp,
-      unreachableStrategy: UnreachableStrategy): InstanceState = {
+      unreachableStrategy: UnreachableStrategy,
+      goal: Goal): InstanceState = {
 
       val tasks = newTaskMap.values
 
@@ -132,7 +133,7 @@ object Instance {
       val healthy = computeHealth(tasks.toVector)
       maybeOldState match {
         case Some(state) if state.condition == condition && state.healthy == healthy => state
-        case _ => InstanceState(condition, now, active, healthy, maybeOldState.map(_.goal).getOrElse(Goal.Running))
+        case _ => InstanceState(condition, now, active, healthy, goal)
       }
     }
 

--- a/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/launcher/impl/InstanceOpFactoryImpl.scala
@@ -124,7 +124,7 @@ class InstanceOpFactoryImpl(
         val instance = new Instance(
           task.taskId.instanceId,
           agentInfo,
-          Instance.InstanceState(None, tasksMap, now, app.unreachableStrategy),
+          Instance.InstanceState.transitionTo(None, tasksMap, now, app.unreachableStrategy, Goal.Running),
           tasksMap,
           task.runSpecVersion,
           app.unreachableStrategy,

--- a/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/jobs/impl/ExpungeOverdueLostTasksActor.scala
@@ -41,6 +41,7 @@ trait ExpungeOverdueLostTasksActorLogic extends StrictLogging {
     case UnreachableDisabled =>
       false
     case unreachableEnabled: UnreachableEnabled =>
+      // Instances configured to expunge immediately will be expunged in response to the Mesos TASK_UNREACHABLE
       instance.isUnreachableInactive &&
         instance.tasksMap.valuesIterator.exists(_.isUnreachableExpired(now, unreachableEnabled.expungeAfter))
   }

--- a/src/main/scala/mesosphere/marathon/state/Timestamp.scala
+++ b/src/main/scala/mesosphere/marathon/state/Timestamp.scala
@@ -44,7 +44,7 @@ abstract case class Timestamp private (private val instant: Instant) extends Ord
   /**
     * @return true if this timestamp is more than "by" duration older than other timestamp.
     */
-  def expired(other: Timestamp, by: FiniteDuration): Boolean = this.until(other) > by
+  def expired(other: Timestamp, by: FiniteDuration): Boolean = this.until(other) >= by
 
   def +(duration: FiniteDuration): Timestamp = Timestamp(instant.plusMillis(duration.toMillis))
   def -(duration: FiniteDuration): Timestamp = Timestamp(instant.minusMillis(duration.toMillis))

--- a/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/TaskCountsTest.scala
@@ -5,7 +5,7 @@ import mesosphere.UnitTest
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.health.Health
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.{Instance, TestTaskBuilder}
+import mesosphere.marathon.core.instance.{Goal, Instance, TestTaskBuilder}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfoPlaceholder
 import mesosphere.marathon.state.{PathId, Timestamp, UnreachableStrategy}
@@ -195,7 +195,7 @@ object Fixture {
       new Instance(
         instanceId = task.taskId.instanceId,
         agentInfo = AgentInfo(host = "host", agentId = Some("agent"), region = None, zone = None, attributes = Nil),
-        state = Instance.InstanceState(None, tasksMap, task.status.startedAt.getOrElse(task.status.stagedAt), unreachableStrategy),
+        state = Instance.InstanceState.transitionTo(None, tasksMap, task.status.startedAt.getOrElse(task.status.stagedAt), unreachableStrategy, Goal.Running),
         tasksMap = tasksMap,
         task.runSpecVersion,
         unreachableStrategy,

--- a/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/appinfo/impl/AppInfoBaseDataTest.scala
@@ -9,7 +9,7 @@ import mesosphere.marathon.core.deployment.{DeploymentPlan, DeploymentStep, Depl
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.core.health.{Health, HealthCheckManager}
 import mesosphere.marathon.core.instance.Instance.InstanceState
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.pod.{HostNetwork, MesosContainer, PodDefinition}
 import mesosphere.marathon.core.readiness.ReadinessCheckResult
 import mesosphere.marathon.core.task.Task
@@ -72,7 +72,7 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       Instance(
         instanceId = instanceId,
         agentInfo = Instance.AgentInfo("", None, None, None, Nil),
-        state = InstanceState(None, tasks, clock.now(), UnreachableStrategy.default()),
+        state = InstanceState.transitionTo(None, tasks, clock.now(), UnreachableStrategy.default(), Goal.Running),
         tasksMap = tasks,
         runSpecVersion = pod.version,
         unreachableStrategy = UnreachableStrategy.default(),
@@ -489,10 +489,10 @@ class AppInfoBaseDataTest extends UnitTest with GroupCreation {
       f.groupManager.podVersion(any, any) returns Future.successful(None)
       f.marathonSchedulerService.listRunningDeployments() returns Future.successful(Seq.empty)
 
-      When("requesting pod status")
-      f.baseData.podStatus(pod).futureValue
-
-      Then("no exception was thrown so status was successfully fetched")
+      Then("requesting pod status should not throw an exception")
+      noException should be thrownBy {
+        f.baseData.podStatus(pod).futureValue
+      }
     }
 
     "requesting Pod lastTaskFailure when one exists" in {

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckWorkerTest.scala
@@ -11,7 +11,7 @@ import akka.testkit.ImplicitSender
 import mesosphere.AkkaUnitTest
 import mesosphere.marathon.core.health._
 import mesosphere.marathon.core.instance.Instance.AgentInfo
-import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder, TestTaskBuilder}
+import mesosphere.marathon.core.instance.{Goal, Instance, TestInstanceBuilder, TestTaskBuilder}
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.state.NetworkInfo
 import mesosphere.marathon.state.{AppDefinition, PathId, PortDefinition, UnreachableStrategy}
@@ -85,7 +85,7 @@ class HealthCheckWorkerTest extends AkkaUnitTest with ImplicitSender {
       val since = task.status.startedAt.getOrElse(task.status.stagedAt)
       val unreachableStrategy = UnreachableStrategy.default()
       val tasksMap = Map(task.taskId -> task)
-      val state = Instance.InstanceState(None, tasksMap, since, unreachableStrategy)
+      val state = Instance.InstanceState.transitionTo(None, tasksMap, since, unreachableStrategy, Goal.Running)
 
       val instance = Instance(task.taskId.instanceId, agentInfo, state, tasksMap, task.runSpecVersion, unreachableStrategy, None)
 

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceStateTest.scala
@@ -28,7 +28,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
             task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default())
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "set the oldest task timestamp as the activeSince timestamp" in { state.activeSince should be(Some(f.clock.now - 1.hour)) }
       "set the instance condition to running" in { state.condition should be(Condition.Running) }
@@ -38,7 +38,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
       val f = new Fixture
 
       val tasks: Map[Task.Id, Task] = f.tasks(Condition.Staging, Condition.Staging)
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default())
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "not set the activeSince timestamp" in { state.activeSince should not be 'defined }
       "set the instance condition to staging" in { state.condition should be(Condition.Staging) }
@@ -57,7 +57,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
             task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default())
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "set the activeSince timestamp to the one from running" in { state.activeSince should be(Some(f.clock.now - 1.hour)) }
       "set the instance condition to staging" in { state.condition should be(Condition.Staging) }
@@ -76,7 +76,7 @@ class InstanceStateTest extends UnitTest with TableDrivenPropertyChecks {
             task.taskId -> task.copy(status = newStatus)
         }(collection.breakOut)
 
-      val state = Instance.InstanceState(None, tasks, f.clock.now(), UnreachableStrategy.default())
+      val state = Instance.InstanceState.transitionTo(None, tasks, f.clock.now(), UnreachableStrategy.default(), Goal.Running)
 
       "set the activeSince timestamp to the one from running" in { state.activeSince should be(Some(f.clock.now - 1.hour)) }
       "set the instance condition to unreachable" in { state.condition should be(Condition.Unreachable) }

--- a/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/instance/InstanceTest.scala
@@ -2,16 +2,15 @@ package mesosphere.marathon
 package core.instance
 
 import mesosphere.UnitTest
-import mesosphere.marathon.test.SettableClock
 import mesosphere.marathon.core.condition.Condition
 import mesosphere.marathon.core.condition.Condition._
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.bus.MesosTaskStatusTestHelper
-import mesosphere.marathon.state.PathId._
-import mesosphere.marathon.state.UnreachableStrategy
-import org.scalatest.prop.TableDrivenPropertyChecks
+import mesosphere.marathon.state.{PathId, UnreachableDisabled, UnreachableStrategy}
+import mesosphere.marathon.test.SettableClock
 import org.apache.mesos.Protos.Attribute
 import org.apache.mesos.Protos.Value.{Text, Type}
+import org.scalatest.prop.TableDrivenPropertyChecks
 import play.api.libs.json._
 
 class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
@@ -42,7 +41,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
 
       s"$from and tasks become ${withTasks.mkString(", ")}" should {
 
-        val status = Instance.InstanceState(Some(instance.state), tasks, f.clock.now(), UnreachableStrategy.default())
+        val status = Instance.InstanceState.transitionTo(Some(instance.state), tasks, f.clock.now(), UnreachableStrategy.default(), instance.state.goal)
 
         s"change to $to" in {
           status.condition should be(to)
@@ -73,7 +72,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
   }
 
   "be unreachable" in {
-    val f = new Fixture
+    val f = new Fixture(unreachableStrategy = UnreachableDisabled)
 
     val (instance, _) = f.instanceWith(Condition.Unreachable, Seq(Condition.Unreachable))
     instance.isUnreachable should be(true)
@@ -87,7 +86,7 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
   }
 
   "be active only for active conditions" in {
-    val f = new Fixture
+    val f = new Fixture(unreachableStrategy = UnreachableDisabled)
 
     val activeConditions: Seq[Condition] = Seq(Created, Killing, Running, Staging, Starting, Unreachable)
     activeConditions.foreach { condition =>
@@ -120,8 +119,8 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     }
   }
 
-  class Fixture {
-    val id = "/test".toPath
+  class Fixture(unreachableStrategy: UnreachableStrategy = UnreachableStrategy.default(false)) {
+    val id = PathId("/test")
     val clock = new SettableClock()
 
     val agentInfo = Instance.AgentInfo("", None, None, None, Nil)
@@ -137,9 +136,8 @@ class InstanceTest extends UnitTest with TableDrivenPropertyChecks {
     def instanceWith(condition: Condition, conditions: Seq[Condition]): (Instance, Map[Task.Id, Task]) = {
       val currentTasks = tasks(conditions.map(_ => condition))
       val newTasks = tasks(conditions)
-      val state = Instance.InstanceState(None, currentTasks, clock.now(), UnreachableStrategy.default())
-      val instance = Instance(Instance.Id.forRunSpec(id), agentInfo, state, currentTasks,
-        runSpecVersion = clock.now(), UnreachableStrategy.default(), None)
+      val state = Instance.InstanceState.transitionTo(None, currentTasks, clock.now(), unreachableStrategy, Goal.Running)
+      val instance = Instance(Instance.Id.forRunSpec(id), agentInfo, state, currentTasks, runSpecVersion = clock.now(), unreachableStrategy, None)
       (instance, newTasks)
     }
   }

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/TaskLauncherActorTest.scala
@@ -53,8 +53,8 @@ class TaskLauncherActorTest extends AkkaUnitTest {
 
   object f {
     import org.apache.mesos.{Protos => Mesos}
-    val app = AppDefinition(id = PathId("/testapp"))
-    val marathonInstance = TestInstanceBuilder.newBuilderWithLaunchedTask(app.id, version = app.version, now = Timestamp.now()).getInstance()
+    val app = AppDefinition(id = PathId("/testapp"), unreachableStrategy = UnreachableEnabled(inactiveAfter = 15.minutes, expungeAfter = 15.minutes))
+    val marathonInstance = TestInstanceBuilder.newBuilderForRunSpec(app).addTaskLaunched().getInstance()
     val marathonTask: Task = marathonInstance.appTask
     val instanceId = marathonInstance.instanceId
     val task = MarathonTestHelper.makeOneCPUTask(Task.Id.forInstanceId(instanceId, None)).build()

--- a/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
+++ b/src/test/scala/mesosphere/marathon/test/MarathonTestHelper.scala
@@ -1,6 +1,7 @@
 package mesosphere.marathon
 package test
 
+import java.io.{File, FileNotFoundException}
 import java.time.Clock
 
 import akka.stream.Materializer
@@ -552,4 +553,14 @@ object MarathonTestHelper {
     }
   }
 
+  def resourcePath(resourceName: String): File = {
+    val classLoader = getClass.getClassLoader
+
+    Option(classLoader.getResource(resourceName)) match {
+      case Some(fileName) =>
+        new File(fileName.getFile)
+      case None =>
+        throw new FileNotFoundException(s"Could not find resource ${resourceName}")
+    }
+  }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/HealthCheckIntegrationTest.scala
@@ -4,8 +4,6 @@ package integration
 import java.util.UUID
 
 import mesosphere.AkkaIntegrationTest
-import mesosphere.marathon.core.event.UnhealthyInstanceKillEvent
-import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
 import mesosphere.marathon.raml.{AppHealthCheck, AppHealthCheckProtocol}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.state.PathId._
 import mesosphere.marathon.state.{FaultDomain, PathId, Region, Zone}
 import mesosphere.mesos.Constraints
 import org.scalatest.Inside
+import org.scalatest.Inspectors.forAll
 
 class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
 
@@ -30,6 +31,18 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
     Some(FaultDomain(region = f.remoteRegion, zone = f.remoteZone1)),
     Some(FaultDomain(region = f.remoteRegion, zone = f.remoteZone2)),
     Some(FaultDomain(region = f.homeRegion, zone = f.homeZone)))
+
+  // This hook is also defined in TaskUnreachableIntegrationTest. We should probably move it into MesosClusterTest.
+  override def afterAll(): Unit = {
+    // We need to start all the agents for the teardown to be able to kill all the (UNREACHABLE) executors/tasks
+    mesosCluster.agents.foreach(_.start())
+    eventually {
+      val state = mesos.state.value
+      state.agents.size shouldBe mesosCluster.agents.size
+      forAll(state.frameworks) { _.unreachable_tasks should be('empty) }
+    }
+    super.afterAll()
+  }
 
   def appId(suffix: String): PathId = testBasePath / s"app-${suffix}"
 
@@ -84,6 +97,48 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
       task.region shouldBe Some(f.remoteRegion.value)
       task.zone shouldBe Some(f.remoteZone2.value)
     }
-  }
 
+    "Replace an unreachable instance in the same region" in {
+      val applicationId = appId("unreachable-instance-is-placed-in-same-region")
+      val strategy = raml.UnreachableEnabled(inactiveAfterSeconds = 0, expungeAfterSeconds = 0)
+      val app = appProxy(applicationId, "v1", instances = 4, healthCheck = None).copy(constraints = Set(
+        Constraints.regionField :: "GROUP_BY" :: "2" :: Nil
+      ), unreachableStrategy = Some(strategy))
+
+      Given("an app grouped by two regions")
+      val result = marathon.createAppV2(app)
+      result should be(Created)
+      waitForDeployment(result)
+      val tasks = eventually {
+        val tasks = marathon.tasks(applicationId).value
+        tasks.filter(_.slaveId.nonEmpty) should have size (4)
+        tasks
+      }
+      val originalAgentIds = tasks.map(_.slaveId).flatten.toSet
+      tasks.groupBy(_.region.value).keySet should be(Set("home_region", "remote_region"))
+      tasks.groupBy(_.region.value).get("home_region").value should have size (2)
+      tasks.groupBy(_.region.value).get("remote_region").value should have size (2)
+
+      When("an agent in the remote region with running tasks becomes unreachable")
+      val Some(agent) = mesosCluster.agents.filter { agent =>
+        (originalAgentIds contains mesosCluster.agentIdFor(agent)) &&
+          agent.extraArgs.exists(_.contains("remote_region"))
+      }.headOption
+
+      agent.stop()
+      eventually {
+        marathon.tasks(applicationId).value.flatMap(_.slaveId).toSet shouldNot be(originalAgentIds)
+      }
+
+      Then("a replacement is launched in the remote region, and the constraints are still honored")
+      eventually {
+        val tasks = marathon.tasks(applicationId).value
+        tasks should have size (4)
+        tasks.groupBy(_.region.value).keySet should be(Set("home_region", "remote_region"))
+
+        tasks.groupBy(_.region.value).get("home_region").value should have size (2)
+        tasks.groupBy(_.region.value).get("remote_region").value should have size (2)
+      }
+    }
+  }
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -93,9 +93,11 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
       result should be(Created)
       waitForDeployment(result)
       waitForTasks(app.id.toPath, 1)
-      val task = marathon.tasks(applicationId).value.head
-      task.region shouldBe Some(f.remoteRegion.value)
-      task.zone shouldBe Some(f.remoteZone2.value)
+      eventually {
+        val task = marathon.tasks(applicationId).value.head
+        task.region shouldBe Some(f.remoteRegion.value)
+        task.zone shouldBe Some(f.remoteZone2.value)
+      }
     }
 
     "Replace an unreachable instance in the same region" in {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/TaskUnreachableIntegrationTest.scala
@@ -3,7 +3,7 @@ package integration
 
 import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.core.task.Task
-import mesosphere.{AkkaIntegrationTest, WhenEnvSet}
+import mesosphere.AkkaIntegrationTest
 import mesosphere.marathon.integration.facades.ITEnrichedTask
 import mesosphere.marathon.integration.setup._
 import mesosphere.marathon.raml.App

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
@@ -115,7 +115,7 @@ class MesosFacade(val url: String, val waitTime: FiniteDuration = 30.seconds)(im
 
   def state(): RestResult[ITMesosState] = {
     logger.info(s"fetching state from $url")
-    result(requestFor[ITMesosState](Get(s"$url/state.json")), waitTime)
+    result(requestFor[ITMesosState](Get(s"$url/state")), waitTime)
   }
 
   def frameworks(): RestResult[ITFrameworks] = {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MesosFacade.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model.{HttpEntity, HttpResponse}
 import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import de.heikoseeberger.akkahttpplayjson.PlayJsonSupport
-import mesosphere.marathon.integration.setup.RestResult
+import mesosphere.marathon.integration.setup.{MesosTest, RestResult}
 import mesosphere.marathon.integration.setup.AkkaHttpResponse._
 
 import scala.concurrent.Await._
@@ -21,7 +21,10 @@ object MesosFacade {
   case class ITMesosState(
       version: String,
       gitTag: Option[String],
-      agents: Seq[ITAgent])
+      agents: Seq[ITAgent],
+      frameworks: Seq[ITFramework],
+      completed_frameworks: Seq[ITFramework],
+      unregistered_framework_ids: Seq[String])
 
   case class ITAgent(
       id: String,
@@ -80,11 +83,24 @@ object MesosFacade {
     override def toString: String = '"' + portString + '"'
   }
 
-  case class ITFramework(id: String, name: String)
+  case class ITask(id: String, name: String, framework_id: String, state: Option[String])
+
+  case class ITFramework(id: String, name: String, tasks: Seq[ITask], unreachable_tasks: Seq[ITask])
+
   case class ITFrameworks(
       frameworks: Seq[ITFramework],
       completed_frameworks: Seq[ITFramework],
       unregistered_frameworks: Seq[ITFramework])
+
+  case class ITFaultDomain(region: String, Zone: String)
+
+  case class ITAgentDetails(
+      id: String,
+      pid: String,
+      hostname: String,
+      capabilities: Seq[String],
+      domain: Option[ITFaultDomain],
+      flags: Map[String, String])
 }
 
 class MesosFacade(val url: String, val waitTime: FiniteDuration = 30.seconds)(implicit val system: ActorSystem, materializer: Materializer)
@@ -96,13 +112,18 @@ class MesosFacade(val url: String, val waitTime: FiniteDuration = 30.seconds)(im
 
   // `waitTime` is passed implicitly to the `request` and `requestFor` methods
   implicit val requestTimeout = waitTime
-  def state: RestResult[ITMesosState] = {
+
+  def state(): RestResult[ITMesosState] = {
     logger.info(s"fetching state from $url")
     result(requestFor[ITMesosState](Get(s"$url/state.json")), waitTime)
   }
 
   def frameworks(): RestResult[ITFrameworks] = {
     result(requestFor[ITFrameworks](Get(s"$url/frameworks")), waitTime)
+  }
+
+  def agentDetails(agent: MesosTest.AgentLike): RestResult[ITAgentDetails] = {
+    result(requestFor[ITAgentDetails](Get(s"http://${agent.ip}:${agent.port}/state")), waitTime)
   }
 
   def frameworkIds(): RestResult[Seq[String]] = {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MesosFormats.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MesosFormats.scala
@@ -52,10 +52,22 @@ object MesosFormats {
   implicit lazy val ITStatusFormat: Format[ITMesosState] = (
     (__ \ "version").format[String] ~
     (__ \ "git_sha").formatNullable[String] ~
-    (__ \ "slaves").format[Seq[ITAgent]]
+    (__ \ "slaves").format[Seq[ITAgent]] ~
+    (__ \ "frameworks").format[Seq[ITFramework]] ~
+    (__ \ "completed_frameworks").format[Seq[ITFramework]] ~
+    (__ \ "unregistered_frameworks").format[Seq[String]]
   )(ITMesosState.apply, unlift(ITMesosState.unapply))
+
+  implicit lazy val ITaskFormat: Format[ITask] = Json.format[ITask]
 
   implicit lazy val ITFrameworkFormat: Format[ITFramework] = Json.format[ITFramework]
 
   implicit lazy val ITFrameworksFormat: Format[ITFrameworks] = Json.format[ITFrameworks]
+
+  implicit val ITFaultDomainFormat: Format[ITFaultDomain] = (
+    (__ \ "fault_domain" \ "region" \ "name").format[String] ~
+    (__ \ "fault_domain" \ "zone" \ "name").format[String]
+  )(ITFaultDomain.apply, unlift(ITFaultDomain.unapply))
+
+  implicit val ITAgentDetailsFormat: Format[ITAgentDetails] = Json.format[ITAgentDetails]
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MesosTest.scala
@@ -11,6 +11,8 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.stream.Materializer
 import mesosphere.marathon.integration.facades.MesosFacade
+import mesosphere.marathon.integration.facades.MesosFacade.ITAgentDetails
+import mesosphere.marathon.integration.setup.MesosTest.AgentLike
 import mesosphere.marathon.state.FaultDomain
 import mesosphere.marathon.util.{Retry, ZookeeperServerTest}
 import mesosphere.util.PortAllocator
@@ -76,6 +78,8 @@ case class MesosCluster(
       "--max_slave_ping_timeouts=4",
       s"--quorum=$quorumSize") ++ faultDomainJson.map(fd => s"--domain=$fd"))
   }
+
+  private var initialCachedAgentDetails: Map[AgentLike, ITAgentDetails] = Map.empty
 
   lazy val agents = 0.until(numSlaves).map { i =>
     // We can add additional resources constraints for our test clusters here.
@@ -162,6 +166,9 @@ case class MesosCluster(
       if (numAgents != agents.size) {
         throw new Exception(s"Agents are not ready. Found $numAgents but expected ${agents.size}")
       }
+      initialCachedAgentDetails = agents.map { a =>
+        a -> mesosFacade.agentDetails(a).value
+      }.toMap
       Done
     }
   }
@@ -218,6 +225,23 @@ case class MesosCluster(
       config.isolation.map("MESOS_ISOLATION" -> _).to[Seq] ++
       config.imageProviders.map("MESOS_IMAGE_PROVIDERS" -> _).to[Seq]
   }
+
+  /**
+    * Returns a agent id for an agent as it was initially queried during test cluster launch
+    *
+    * @param agent
+    */
+  def agentIdFor(agent: AgentLike): String = {
+    initialCachedAgentDetails(agent).id
+  }
+
+  /**
+    * Return the cached agent details that were returned when the agent first initialized
+    * @param agent Reference to the MesosTest Agent process
+    */
+  def initialAgentDetailsFor(agent: AgentLike): ITAgentDetails =
+    initialCachedAgentDetails(agent)
+
 
   // format: OFF
   case class Resources(cpus: Option[Int] = None, mem: Option[Int] = None, ports: (Int, Int), gpus: Option[Int] = None) {
@@ -288,7 +312,15 @@ case class MesosCluster(
     val processName: String = "Master"
   }
 
-  case class Agent(resources: Resources, extraArgs: Seq[String]) extends Mesos {
+  case class Agent(resources: Resources, extraArgs: Seq[String]) extends Mesos with MesosTest.AgentLike {
+    /**
+      * We can only specify the cgroups_root flag if running the integration tests under Linux; on Mac OS this flag is unrecognized.
+      */
+    private val cgroupsRootArgs: Seq[String] =
+      if (MesosTest.isLinux)
+        Seq(s"--cgroups_root=mesos$port") // See MESOS-9960 for more info
+      else
+        Nil
     override val workDir = Files.createTempDirectory(s"$suiteName-mesos-agent-$port").toFile
     override val processBuilder = Process(
       command = Seq(
@@ -300,9 +332,10 @@ case class MesosCluster(
         s"--resources=${resources.resourceString()}",
         s"--master=$masterUrl",
         s"--work_dir=${workDir.getAbsolutePath}",
-        s"--cgroups_root=mesos$port", // See MESOS-9960 for more info
-        s"""--executor_environment_variables={"GLOG_v": "2"}""") ++ extraArgs,
-      cwd = None, extraEnv = mesosEnv(workDir): _*)
+        s"""--executor_environment_variables={"GLOG_v": "2"}""") ++
+        cgroupsRootArgs ++
+        extraArgs,
+      cwd = None, extraEnv = Seq(("GLOG_v", "2")) ++ mesosEnv(workDir): _*)
 
     override val processName = "Agent"
   }
@@ -376,6 +409,16 @@ trait MesosClusterTest extends Suite with ZookeeperServerTest with MesosTest wit
   abstract override def afterAll(): Unit = {
     localMesosUrl.fold(mesosCluster.close())(_ => ())
     super.afterAll()
+  }
+}
+
+object MesosTest {
+  import sys.process._
+  lazy val isLinux: Boolean =
+    Seq("uname").!!.trim.startsWith("Linux")
+  trait AgentLike {
+    def ip: String
+    def port: Int
   }
 }
 


### PR DESCRIPTION
Backport of e05e976 / #7109

In this change, we modify the expunge-after logic to evaluate in the same event cycle as the unreachable-inactive logic, allowing expungeAfterSeconds: 0 to expunge an instance immediately when it becomes unreachable.

This improves the evaluation of group-by and unique constraints.

JIRA issues: MARATHON-8719