### PR TITLE
Bump jekyll dependencies

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,9 +1,9 @@
-FROM buildpack-deps:stretch-curl
+FROM buildpack-deps:buster-curl
 
 COPY Gemfile Gemfile.lock /jekyll/
 
 RUN apt-get update && \
-  curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
   apt-get install -y gcc g++ git libxml2 zlib1g-dev libxml2-dev ruby ruby-dev make autoconf nodejs python python-dev && \
   gem install bundler && \
   cd /jekyll && bundle install && \

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby_dep (1.5.0)
-    rubyzip (1.2.4)
+    rubyzip (2.2.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)


### PR DESCRIPTION
Bump to Debian Buster for modern Ruby so we can install Rubyzip 2.2.0
and avoid CVE
