### PR TITLE
Warm up docker to ensure integration test success

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -168,6 +168,10 @@ def provisionHost(): Unit = utils.stage("Provision") {
   // Set port range for random port 0 allocation.
   %('sudo, "ci/set_port_range.sh")
 
+  // First call to `docker --version` can take up to 30s. This sometimes leads to Mesos agent
+  // failing to start when checking for the docker version. So we do it here (successive calls will be faster).
+  %('sudo, "docker", "--version")
+
   provision.killStaleTestProcesses()
   provision.installMesos()
   provision.installDcosCli()

--- a/tests/package/centos6/Dockerfile
+++ b/tests/package/centos6/Dockerfile
@@ -11,8 +11,7 @@ RUN rpm -Uvh http://repos.mesosphere.com/el/6/noarch/RPMS/mesosphere-el-repo-6-2
   ln -svT /usr/lib/jvm/java-1.8.0-openjdk-* /docker-java-home && \
 
   # Install Python, Pip and dcrpm
-  yum install -y epel-release git && yum install -y python34 python34-devel gcc gcc-c++ && \
-  curl -O https://bootstrap.pypa.io/get-pip.py && /usr/bin/python3.4 get-pip.py && \
+  yum install -y epel-release git && yum install -y python34 python34-devel python34-pip gcc gcc-c++ && \
   pip3 install git+https://github.com/facebookincubator/dcrpm.git@v0.2.0 &&  \
 
   # Clean


### PR DESCRIPTION
Calling `docker --version` can take longer that 5 seconds to respond, initially. If the first invocation of docker is done by starting a Mesos agent, then that agent can fail to start.

By calling `docker --version` in the provision script, we ensure that docker is ready to go.