### PR TITLE
Update preferential-gpu-scheduling.md

### DIFF
--- a/docs/docs/preferential-gpu-scheduling.md
+++ b/docs/docs/preferential-gpu-scheduling.md
@@ -24,7 +24,7 @@ Marathon:
 - `--enable_features gpu_resources` - Tell Mesos that Marathon should be offered GPU resources. (See the [command-line docs](./command-line-flags.html)).
 - `--gpu_scheduling_behavior` - Defines how offered GPU resources should be treated. Possible settings:
     - `unrestricted` - non-GPU tasks are launched irrespective of offers containing GPUs.
-    - `restricted` (Default) - non-GPU tasks will decline offers containing GPUs. A decline reason of `DeclinedScareResources` is given.
+    - `restricted` (Default) - non-GPU tasks will decline offers containing GPUs. A decline reason of `DeclinedScarceResources` is given.
 
 ## Enumeration of Different Possible Cluster Scenarios
 


### PR DESCRIPTION
Nasty typo `DeclinedScareResources` instead `DeclinedScarceResources`, so this documentation is not properly indexed on Google and did not showed up after job seeking for information being stuck thanks to the new marathon 1.8+ gpu_scheduling_behavior set to "restricted" as default.
