### PR TITLE
Increase log format detection window to 1000

### DIFF
--- a/tools/elk/lib/main.sc
+++ b/tools/elk/lib/main.sc
@@ -91,12 +91,12 @@ def detectLogFormat(logFiles: Seq[Path])(implicit mat: Materializer): Option[Log
         val linesSample = await(
           FileIO.fromPath(input.toNIO)
             .via(warningLineSplitter(input, 128000))
-            .take(100)
+            .take(1000)
             .map(_.utf8String)
             .runWith(Sink.seq))
 
         val maybeFormat = (for {
-          line <- linesSample.take(100)
+          line <- linesSample.take(1000)
           format <- LogFormat.tryMatch(line)
         } yield format).headOption
 


### PR DESCRIPTION
I ran in to a case where the first 100 lines or so for all log bundles
were filled with log messages generated by bootstrapping logic, and not
for Marathon.

Increasing the window to 1000 allows the tool a better chance to find a
log message emitted by Marathon
