### PR TITLE
Enable Scalafix.

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  RemoveUnused
+]

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ resolvers ++= loadM2Resolvers(sLog.value)
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.17")
+addCompilerPlugin(scalafixSemanticdb)
 
 val silencerVersion = "1.1"
 addCompilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion)
@@ -78,7 +79,7 @@ val pbSettings = ProtobufPlugin.projectSettings ++ Seq(
 lazy val commonSettings = Seq(
   autoCompilerPlugins := true,
   organization := "mesosphere.marathon",
-  scalaVersion := "2.12.7",
+  scalaVersion := "2.12.10",
   crossScalaVersions := Seq(scalaVersion.value),
   scalacOptions in Compile ++= Seq(
     "-encoding", "UTF-8",
@@ -91,13 +92,14 @@ lazy val commonSettings = Seq(
     //FIXME: CORE-977 and MESOS-7368 are filed and need to be resolved to re-enable this
     // "-Xfatal-warnings",
     "-Yno-adapted-args",
+    "-Yrangepos",
     "-Ywarn-numeric-widen",
     //"-Ywarn-dead-code", We should turn this one on soon
     "-Ywarn-inaccessible",
     "-Ywarn-infer-any",
     "-Ywarn-nullary-override",
     "-Ywarn-nullary-unit",
-    //"-Ywarn-unused", We should turn this one on soon
+    "-Ywarn-unused-import",
     "-Ywarn-unused:-locals,imports",
     //"-Ywarn-value-discard", We should turn this one on soon.
   ),

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -31,6 +31,8 @@ import utils.BranchType._
 val PACKAGE_DIR: Path = pwd / 'target / 'universal
 val PACKAGE_DOCS_DIR: Path = pwd / 'target / "universal-docs"
 
+final case class ScalafixException(message: String, cause: Throwable) extends Exception(message, cause)
+
 
 /**
  * Compile Marathon and run unit, integration tests.
@@ -48,8 +50,6 @@ def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") 
 
   run("sbt", "clean", "integration/clean", "compile", "test:compile", "integration/test:compile")
 
-  checkUnusedImports(logFileName)
-
   run("sbt", "test", "integration/test")
 
   // Check leaked processes after integration tests
@@ -62,6 +62,8 @@ def compileAndTest(logFileName: String): Unit = utils.stage("Compile and Test") 
 
   // Check system integration tests.
   checkSystemIntegrationTests(logFileName)
+
+  checkScalafix()
 }
 
 /**
@@ -74,12 +76,13 @@ def checkLeakedProcesses(): Unit = {
 }
 
 @main
-def checkUnusedImports(logFileName: String): Unit = {
-  val logs = read! pwd / logFileName
-  val unusedImportMatch = """.*\.scala:\d+:\d+: Unused import.*\n.*import.*\n.*\^""".r
-  val unusedImports = unusedImportMatch.findAllIn(logs).toVector
-
-  assert(unusedImports.isEmpty, s"Found unused imports:\n${unusedImports.mkString("\n")}")
+def checkScalafix(): Unit = {
+  try {
+    %('sbt, "compile:scalafix --check")
+  } catch {
+    case e: InteractiveShelloutException =>
+      throw ScalafixException("Scalafix failed. Run sbt compile:scalafix before checking in.", e)
+  }
 }
 
 @main

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,12 +6,13 @@ resolvers ++= Seq(
   Resolver.jcenterRepo // needed for sbt-s3-resolver
 )
 
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 addSbtPlugin("ohnosequences" % "sbt-s3-resolver" % "0.19.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.9")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")


### PR DESCRIPTION
Summary:
This change enables scalafix and replace our crude unused import check.
Simply run `sbt 'compile:scalafix'` as a pre-commit hook to let scalafix
apply all changes before checkin.