### PR TITLE
Don't authenticate irrelevant apps with kill-and-scale

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -243,7 +243,7 @@ lazy val ammonite = (project in file("./tools/repl-server"))
   .settings(formatSettings: _*)
   .settings(
     mainClass in Compile := Some("ammoniterepl.Main"),
-    libraryDependencies += "com.lihaoyi" % "ammonite-sshd" % "1.5.0" cross CrossVersion.full
+    libraryDependencies += "com.lihaoyi" % "ammonite-sshd" % "2.0.4" cross CrossVersion.full
   )
   .dependsOn(marathon)
 

--- a/src/main/scala/mesosphere/marathon/api/RestResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/RestResource.scala
@@ -21,7 +21,6 @@ import scala.util.{Failure, Success}
 
 trait RestResource extends JaxResource {
   implicit val executionContext: ExecutionContext
-  protected val config: MarathonConf
   case class FailureResponse(response: Response) extends Throwable
 
   /**

--- a/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
+++ b/src/main/scala/mesosphere/marathon/api/TaskKiller.scala
@@ -22,7 +22,6 @@ import scala.util.control.NonFatal
 class TaskKiller @Inject() (
     instanceTracker: InstanceTracker,
     groupManager: GroupManager,
-    val config: MarathonConf,
     val authenticator: Authenticator,
     val authorizer: Authorizer,
     killService: KillService)(implicit val executionContext: ExecutionContext, implicit val materializer: Materializer) extends AuthResource with StrictLogging {
@@ -94,8 +93,8 @@ class TaskKiller @Inject() (
     appInstances: Map[PathId, Seq[Instance]],
     force: Boolean)(implicit identity: Identity): Future[DeploymentPlan] = {
     def scaleApp(app: AppDefinition): AppDefinition = {
-      checkAuthorization(UpdateRunSpec, app)
       appInstances.get(app.id).fold(app) { instances =>
+        checkAuthorization(UpdateRunSpec, app)
         // only count active instances that did not already receive a kill request.
         val toKillCount = instances.count(i => i.isActive && !i.isKilling)
         // make sure we never scale below zero instances.

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTrackerModule.scala
@@ -5,7 +5,7 @@ import java.time.Clock
 
 import akka.stream.Materializer
 import mesosphere.marathon.core.base.CrashStrategy
-import mesosphere.marathon.core.instance.update.{InstanceChangeHandler, InstanceUpdateOpResolver}
+import mesosphere.marathon.core.instance.update.InstanceChangeHandler
 import mesosphere.marathon.core.leadership.LeadershipModule
 import mesosphere.marathon.core.task.tracker.impl._
 import mesosphere.marathon.metrics.Metrics
@@ -28,11 +28,13 @@ class InstanceTrackerModule(
   lazy val instanceTrackerUpdateStepProcessor: InstanceTrackerUpdateStepProcessor =
     new InstanceTrackerUpdateStepProcessorImpl(metrics, updateSteps)
 
-  private[this] lazy val updateOpResolver: InstanceUpdateOpResolver = new InstanceUpdateOpResolver(clock)
-  private[this] lazy val instancesLoader = new InstancesLoaderImpl(InstanceView(instanceRepository, groupRepository), config)
-  private[this] lazy val instanceTrackerMetrics = new InstanceTrackerActor.ActorMetrics(metrics)
   private[this] lazy val instanceTrackerActorProps = InstanceTrackerActor.props(
-    instanceTrackerMetrics, instancesLoader, instanceTrackerUpdateStepProcessor, updateOpResolver, InstanceView(instanceRepository, groupRepository), clock, crashStrategy)
+    metrics = metrics,
+    config = config,
+    steps = updateSteps,
+    repository = InstanceView(instanceRepository, groupRepository),
+    clock = clock,
+    crashStrategy = crashStrategy)
   protected lazy val instanceTrackerActorName = "instanceTracker"
   private[this] lazy val instanceTrackerActorRef = leadershipModule.startWhenLeader(
     instanceTrackerActorProps, instanceTrackerActorName

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -9,14 +9,15 @@ import akka.actor.SupervisorStrategy.Escalate
 import akka.actor._
 import akka.event.LoggingReceive
 import akka.pattern.pipe
+import akka.stream.Materializer
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.appinfo.TaskCounts
 import mesosphere.marathon.core.base.CrashStrategy
 import mesosphere.marathon.core.instance.Instance
-import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation, InstanceUpdated, InstancesSnapshot}
+import mesosphere.marathon.core.instance.update.{InstanceChange, InstanceChangeHandler, InstanceDeleted, InstanceUpdateEffect, InstanceUpdateOpResolver, InstanceUpdateOperation, InstanceUpdated, InstancesSnapshot}
 import mesosphere.marathon.core.leadership.LeaderDeferrable
 import mesosphere.marathon.core.task.tracker.impl.InstanceTrackerActor.{RepositoryStateUpdated, UpdateContext}
-import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerUpdateStepProcessor}
+import mesosphere.marathon.core.task.tracker.{InstanceTracker, InstanceTrackerConfig, InstanceTrackerUpdateStepProcessor}
 import mesosphere.marathon.metrics.{Metrics, SettableGauge}
 import mesosphere.marathon.state.{PathId, Timestamp}
 import mesosphere.marathon.storage.repository.InstanceView
@@ -27,14 +28,17 @@ import scala.util.{Failure, Success}
 
 object InstanceTrackerActor {
   def props(
-    metrics: ActorMetrics,
-    taskLoader: InstancesLoader,
-    updateStepProcessor: InstanceTrackerUpdateStepProcessor,
-    stateOpResolver: InstanceUpdateOpResolver,
+    metrics: Metrics,
+    config: InstanceTrackerConfig,
+    steps: Seq[InstanceChangeHandler],
     repository: InstanceView,
     clock: Clock,
-    crashStrategy: CrashStrategy): Props = {
-    Props(new InstanceTrackerActor(metrics, taskLoader, updateStepProcessor, stateOpResolver, repository, clock, crashStrategy))
+    crashStrategy: CrashStrategy)(implicit mat: Materializer): Props = {
+    val instancesLoader = new InstancesLoaderImpl(repository, config)(mat)
+    val updateStepProcessor = new InstanceTrackerUpdateStepProcessorImpl(metrics, steps)
+    val stateOpResolver: InstanceUpdateOpResolver = new InstanceUpdateOpResolver(clock)
+
+    Props(new InstanceTrackerActor(new ActorMetrics(metrics), instancesLoader, updateStepProcessor, stateOpResolver, repository, clock, crashStrategy))
   }
 
   /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]]. */

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -29,7 +29,7 @@ import scala.util.{Failure, Success}
   * This is used for the "global" InstanceTracker trait and it is also
   * is used internally in this package to communicate with the InstanceTracker.
   */
-private[tracker] class InstanceTrackerDelegate(
+private[marathon] class InstanceTrackerDelegate(
     metrics: Metrics,
     clock: Clock,
     config: InstanceTrackerConfig,

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -120,6 +120,9 @@ class Group(
 
     s"Group($id, apps = $summarizedApps, pods = $summarizedPods, groups = $summarizedGroups, dependencies = $summarizedDependencies, version = $version)"
   }
+
+  def withDependencies(dependencies: Set[PathId]): Group =
+    new Group(this.id, this.apps, this.pods, this.groupsById, dependencies, this.version)
 }
 
 object Group extends StrictLogging {

--- a/src/main/scala/mesosphere/marathon/state/RootGroup.scala
+++ b/src/main/scala/mesosphere/marathon/state/RootGroup.scala
@@ -208,15 +208,7 @@ class RootGroup(
     val oldGroup = group(groupId).getOrElse(Group.empty(groupId))
     val oldDependencies = oldGroup.dependencies
     val newDependencies = dependencies(oldDependencies)
-    val newGroup = Group(
-      id = oldGroup.id,
-      apps = oldGroup.apps,
-      pods = oldGroup.pods,
-      groupsById = oldGroup.groupsById,
-      dependencies = newDependencies,
-      version = version
-    )
-    putGroup(newGroup, version)
+    putGroup(oldGroup.withDependencies(newDependencies), version)
   }
 
   /**
@@ -287,6 +279,21 @@ class RootGroup(
       dependencies = oldGroup.dependencies,
       version = version)
     putGroup(newGroup, version)
+  }
+
+  /**
+    * Update a group with the specified group id by applying the update function.
+    *
+    * It has the same semantics as [[updateApp()]] and [[updatePod()]]. If the group does not exist
+    * it will be created. The update does *not* change the group version.
+    *
+    * @param groupId the if od the group to be updated.
+    * @param fn      the update function.
+    * @return the new root group with the update group.
+    */
+  def updateGroup(groupId: PathId, fn: Option[Group] => Group): RootGroup = {
+    val updatedGroup = fn(group(groupId))
+    putGroup(updatedGroup, updatedGroup.version)
   }
 
   private def updateVersion(group: Group, version: Timestamp): Group = {

--- a/src/test/scala/mesosphere/marathon/Builders.scala
+++ b/src/test/scala/mesosphere/marathon/Builders.scala
@@ -1,0 +1,117 @@
+package mesosphere.marathon
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import mesosphere.marathon.Protos.Constraint
+import mesosphere.marathon.core.check.Check
+import mesosphere.marathon.core.health.HealthCheck
+import mesosphere.marathon.core.pod.{Network, PodDefinition}
+import mesosphere.marathon.core.readiness.ReadinessCheck
+import mesosphere.marathon.raml.{App, Apps, Resources}
+import mesosphere.marathon.state.{PathId, AppDefinition, BackoffStrategy, EnvVarValue, Group, KillSelection, PortDefinition, RootGroup, Secret, Timestamp, UnreachableStrategy, UpgradeStrategy, VersionInfo}
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Home for constructors of common test fixtures.
+  *
+  * Convention: new{EntityType}.{variant}, where variant describes some recipe for creating different variations of standard fixtures; for example, a command app definition.
+  *
+  * For the standard variant, `apply` is used.
+  *
+  * All builders return valid objects with the least amount of information required (IE - where empty list or None is valid, this is used as a default)
+  */
+object Builders {
+
+  object newRootGroup {
+    /**
+      * Construct a new rootGroup containing the specified pods and apps. Interim groups are automatically created.
+      * @param apps Apps to include, in any nested path structure.
+      * @param pods Pods to include, in any nested path structure.
+      * @return Root group containing the apps and pods specified
+      */
+    def apply( apps: Seq[AppDefinition] = Nil,
+               pods: Seq[PodDefinition] = Nil,
+               groupDependencies: Map[PathId, Set[PathId]] = Map.empty,
+               groupIds: Seq[PathId] = Nil,
+               version: Timestamp = Group.defaultVersion,
+             ): RootGroup = {
+      val initialGroup = RootGroup(
+        version = version)
+      val withEmptyGroups = groupIds.foldLeft(initialGroup) { (rootGroup, groupId) =>
+        rootGroup.updateGroup(groupId, _.getOrElse { new Group(groupId, version = version) })
+      }
+      val groupWithApps = apps.foldLeft(withEmptyGroups) { (rootGroup, app) =>
+        rootGroup.updateApp(app.id, _ => app, version = version)
+      }
+      val groupWithPods = pods.foldLeft(groupWithApps) { (rootGroup, pod) =>
+        rootGroup.updatePod(pod.id, _ => pod, version = version)
+      }
+      groupDependencies.foldLeft(groupWithPods) { case (rootGroup, (groupId, dependencies)) =>
+        rootGroup.updateGroup(groupId, {
+          case Some(group) => group.withDependencies(dependencies)
+          case None => new Group(groupId, version = version)
+        })
+      }
+    }
+  }
+
+  object newAppDefinition {
+    val appIdIncrementor = new AtomicInteger()
+
+    /** Return a valid command app definition (using command executor, not using UCR or Docker). */
+    def command(
+      id: PathId = PathId(s"/app-${appIdIncrementor.incrementAndGet()}"),
+      cmd: Option[String] = Some("sleep 3600"),
+      args: Seq[String] = App.DefaultArgs,
+      user: Option[String] = App.DefaultUser,
+      env: Map[String, EnvVarValue] = AppDefinition.DefaultEnv,
+      instances: Int = 1,
+      resources: Resources = Apps.DefaultResources,
+      constraints: Set[Constraint] = AppDefinition.DefaultConstraints,
+      portDefinitions: Seq[PortDefinition] = AppDefinition.DefaultPortDefinitions,
+      requirePorts: Boolean = App.DefaultRequirePorts,
+      backoffStrategy: BackoffStrategy = AppDefinition.DefaultBackoffStrategy,
+      healthChecks: Set[HealthCheck] = AppDefinition.DefaultHealthChecks,
+      check: Option[Check] = AppDefinition.DefaultCheck,
+      readinessChecks: Seq[ReadinessCheck] = AppDefinition.DefaultReadinessChecks,
+      taskKillGracePeriod: Option[FiniteDuration] = AppDefinition.DefaultTaskKillGracePeriod,
+      upgradeStrategy: UpgradeStrategy = AppDefinition.DefaultUpgradeStrategy,
+      labels: Map[String, String] = AppDefinition.DefaultLabels,
+      acceptedResourceRoles: Set[String] = Set("*"),
+      networks: Seq[Network] = AppDefinition.DefaultNetworks,
+      versionInfo: VersionInfo = VersionInfo.OnlyVersion(Timestamp.now()),
+      secrets: Map[String, Secret] = AppDefinition.DefaultSecrets,
+      unreachableStrategy: UnreachableStrategy = AppDefinition.DefaultUnreachableStrategy,
+      killSelection: KillSelection = KillSelection.DefaultKillSelection,
+      tty: Option[Boolean] = AppDefinition.DefaultTTY): AppDefinition = {
+      AppDefinition(
+        id = id,
+        cmd = cmd,
+        user = user,
+        env = env,
+        args = args,
+        container = None,
+        resources = resources,
+        instances = instances,
+        portDefinitions = portDefinitions,
+        executor = "//cmd",
+        acceptedResourceRoles = acceptedResourceRoles,
+        constraints = constraints,
+        requirePorts = requirePorts,
+        backoffStrategy = backoffStrategy,
+        healthChecks = healthChecks,
+        check = check,
+        readinessChecks = readinessChecks,
+        taskKillGracePeriod = taskKillGracePeriod,
+        upgradeStrategy = upgradeStrategy,
+        labels = labels,
+        networks = networks,
+        versionInfo = versionInfo,
+        secrets = secrets,
+        unreachableStrategy = unreachableStrategy,
+        killSelection = killSelection,
+        tty = tty)
+    }
+  }
+}

--- a/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/TaskKillerTest.scala
@@ -5,31 +5,27 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
-import mesosphere.UnitTest
 import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.core.group.GroupManager
-import mesosphere.marathon.core.instance.update.InstancesSnapshot
+import mesosphere.marathon.core.instance.update.{InstanceUpdateOperation, InstancesSnapshot}
 import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
 import mesosphere.marathon.core.task.termination.{KillReason, KillService}
-import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.core.task.tracker.InstanceTracker.InstancesBySpec
+import mesosphere.marathon.core.task.tracker.InstanceTracker
+import mesosphere.marathon.plugin.auth.Identity
 import mesosphere.marathon.state._
+import mesosphere.AkkaUnitTest
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.concurrent.duration._
 
-class TaskKillerTest extends UnitTest {
-
-  val auth: TestAuthFixture = new TestAuthFixture
-  implicit val identity = auth.identity
-
+class TaskKillerTest extends AkkaUnitTest {
   "TaskKiller" should {
     //regression for #3251
     "No tasks to kill should return with an empty array" in {
       val f = new Fixture
+      import f.auth.identity
       val appId = PathId("invalid")
       when(f.tracker.specInstances(appId)).thenReturn(Future.successful(Seq.empty))
       when(f.groupManager.runSpec(appId)).thenReturn(Some(AppDefinition(appId)))
@@ -40,6 +36,7 @@ class TaskKillerTest extends UnitTest {
 
     "AppNotFound" in {
       val f = new Fixture
+      import f.auth.identity
       val appId = PathId("invalid")
       when(f.tracker.specInstances(appId)).thenReturn(Future.successful(Seq.empty))
       when(f.groupManager.runSpec(appId)).thenReturn(None)
@@ -50,6 +47,7 @@ class TaskKillerTest extends UnitTest {
 
     "AppNotFound with scaling" in {
       val f = new Fixture
+      import f.auth.identity
       val appId = PathId("invalid")
       when(f.tracker.instancesBySpec()).thenReturn(Future.successful(InstancesBySpec.empty))
       when(f.tracker.specInstances(appId)).thenReturn(Future.successful(Seq.empty))
@@ -60,6 +58,7 @@ class TaskKillerTest extends UnitTest {
 
     "KillRequested with scaling" in {
       val f = new Fixture
+      import f.auth.identity
       val appId = PathId(List("app"))
       val instance1 = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
       val instance2 = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
@@ -89,6 +88,7 @@ class TaskKillerTest extends UnitTest {
 
     "KillRequested without scaling" in {
       val f = new Fixture
+      import f.auth.identity
       val appId = PathId(List("my", "app"))
       val instance = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
       val tasksToKill = Seq(instance)
@@ -106,6 +106,7 @@ class TaskKillerTest extends UnitTest {
 
     "Kill and scale w/o force should fail if there is a deployment" in {
       val f = new Fixture
+      import f.auth.identity
       val appId = PathId(List("my", "app"))
       val instance1 = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
       val instance2 = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
@@ -131,6 +132,7 @@ class TaskKillerTest extends UnitTest {
 
     "kill with wipe will kill running and expunge all" in {
       val f = new Fixture
+      import f.auth.identity
       val appId = PathId(List("my", "app"))
       val app = AppDefinition(appId)
       val runningInstance: Instance = TestInstanceBuilder.newBuilder(appId).addTaskRunning().getInstance()
@@ -151,23 +153,58 @@ class TaskKillerTest extends UnitTest {
       verify(f.tracker, atLeastOnce).forceExpunge(runningInstance.instanceId)
       verify(f.tracker).forceExpunge(reservedInstance.instanceId)
     }
+
+    "allows kill and scale for an app for which a user specifically has access" in {
+      // Regression test for MARATHON-8731
+      val business = Builders.newAppDefinition.command(id = PathId("/business"))
+      val devBackend = Builders.newAppDefinition.command(id = PathId("/dev/backend"))
+      val initialRoot = Builders.newRootGroup(apps = Seq(business, devBackend))
+      val businessInstance = TestInstanceBuilder.newBuilderForRunSpec(business).addTaskRunning().instance
+      val devBackendInstance = TestInstanceBuilder.newBuilderForRunSpec(devBackend).addTaskRunning().instance
+      val authFn: Any => Boolean = {
+        case app: AppDefinition =>
+          (app.id == devBackend.id)
+        case _ =>
+          ???
+      }
+      new FixtureWithRealInstanceTracker(initialRoot, authFn) {
+        instanceTracker.process(InstanceUpdateOperation.Schedule(businessInstance)).futureValue
+        instanceTracker.process(InstanceUpdateOperation.Schedule(devBackendInstance)).futureValue
+
+        val deployment = taskKiller.killAndScale(Map(devBackendInstance.runSpecId -> Seq(devBackendInstance)), force = false).futureValue
+        deployment.affectedRunSpecIds shouldBe Set(devBackend.id)
+      }
+    }
+  }
+
+  class FixtureWithRealInstanceTracker(
+      initialRoot: RootGroup = RootGroup.empty,
+      authFn: Any => Boolean = _ => true) {
+    val testInstanceTrackerFixture = new TestInstanceTrackerFixture(initialRoot, authFn = authFn)
+    val instanceTracker = testInstanceTrackerFixture.instanceTracker
+    val killService: KillService = mock[KillService]
+    val auth = testInstanceTrackerFixture.authFixture.auth
+    implicit val identity: Identity = testInstanceTrackerFixture.authFixture.identity
+
+    testInstanceTrackerFixture.service.deploy(any, any).returns(Future(Done))
+    val taskKiller: TaskKiller = new TaskKiller(
+      instanceTracker, testInstanceTrackerFixture.groupManager, testInstanceTrackerFixture.authFixture.auth, testInstanceTrackerFixture.authFixture.auth, killService)
   }
 
   class Fixture {
+    val auth: TestAuthFixture = new TestAuthFixture
     val tracker: InstanceTracker = mock[InstanceTracker]
     tracker.setGoal(any, any, any).returns(Future.successful(Done))
     tracker.instanceUpdates.returns(Source.single(InstancesSnapshot(Nil) -> Source.empty))
     val killService: KillService = mock[KillService]
     val groupManager: GroupManager = mock[GroupManager]
 
-    val config: MarathonConf = mock[MarathonConf]
-    when(config.zkTimeoutDuration).thenReturn(1.second)
-
     implicit val system = ActorSystem("test")
+
     def materializerSettings = ActorMaterializerSettings(system)
+
     implicit val mat = ActorMaterializer(materializerSettings)
     val taskKiller: TaskKiller = new TaskKiller(
-      tracker, groupManager, config, auth.auth, auth.auth, killService)
+      tracker, groupManager, auth.auth, auth.auth, killService)
   }
-
 }

--- a/src/test/scala/mesosphere/marathon/api/TestAuthFixture.scala
+++ b/src/test/scala/mesosphere/marathon/api/TestAuthFixture.scala
@@ -14,7 +14,7 @@ class TestAuthFixture() extends Mockito {
 
   type Auth = Authenticator with Authorizer
 
-  var identity: Identity = new Identity {}
+  implicit var identity: Identity = new Identity {}
 
   @volatile var authenticated: Boolean = true
   @volatile var authorized: Boolean = true

--- a/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
+++ b/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.core.group.GroupManagerModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.state.RootGroup
-import mesosphere.marathon.storage.repository.{AppRepository, GroupRepository, PodRepository}
+import mesosphere.marathon.storage.repository.{AppRepository, GroupRepository, InstanceRepository, PodRepository}
 import mesosphere.marathon.test.Mockito
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
+++ b/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
@@ -11,7 +11,7 @@ import mesosphere.marathon.core.group.GroupManagerModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.state.RootGroup
-import mesosphere.marathon.storage.repository.{AppRepository, GroupRepository, InstanceRepository, PodRepository}
+import mesosphere.marathon.storage.repository.{AppRepository, GroupRepository, PodRepository}
 import mesosphere.marathon.test.Mockito
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/test/scala/mesosphere/marathon/api/TestInstanceTrackerFixture.scala
+++ b/src/test/scala/mesosphere/marathon/api/TestInstanceTrackerFixture.scala
@@ -1,0 +1,40 @@
+package mesosphere.marathon
+package api
+
+import java.time.Clock
+
+import akka.actor.ActorSystem
+import mesosphere.marathon.core.task.tracker.impl.{InstanceTrackerActor, InstanceTrackerDelegate}
+import mesosphere.marathon.state.RootGroup
+import mesosphere.marathon.storage.repository.{InstanceRepository, InstanceView}
+import mesosphere.marathon.test.TestCrashStrategy
+
+import scala.concurrent.ExecutionContext
+
+class TestInstanceTrackerFixture(
+    initialRoot: RootGroup = RootGroup.empty,
+    authenticated: Boolean = true,
+    authorized: Boolean = true,
+    authFn: Any => Boolean = _ => true,
+    val clock: Clock = Clock.systemUTC())(implicit as: ActorSystem, ec: ExecutionContext) extends TestGroupManagerFixture(
+  initialRoot,
+  authenticated = authenticated,
+  authorized = authorized,
+  authFn = authFn) {
+
+  val crashStrategy = new TestCrashStrategy
+  val instanceRepository = InstanceRepository.inMemRepository(store)
+  val instanceView = InstanceView(instanceRepository, groupRepository)
+  val instanceTrackerActor = as.actorOf(InstanceTrackerActor.props(
+    metrics = metrics,
+    config = config,
+    steps = Nil,
+    repository = instanceView,
+    clock = clock,
+    crashStrategy = crashStrategy))
+  val instanceTracker = new InstanceTrackerDelegate(
+    metrics = metrics,
+    clock = clock,
+    config = config,
+    instanceTrackerActor)
+}

--- a/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/SpecInstancesResourceTest.scala
@@ -59,7 +59,7 @@ class SpecInstancesResourceTest extends UnitTest with GroupCreation with JerseyT
     def materializerSettings = ActorMaterializerSettings(system)
     implicit val mat = ActorMaterializer(materializerSettings)
     val taskKiller = new TaskKiller(
-      instanceTracker, groupManager, config, auth.auth, auth.auth, killService)
+      instanceTracker, groupManager, auth.auth, auth.auth, killService)
     val appsTaskResource = new AppTasksResource(
       instanceTracker,
       taskKiller,

--- a/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/TasksResourceTest.scala
@@ -375,7 +375,7 @@ class TasksResourceTest extends UnitTest with GroupCreation with JerseyTest with
       def materializerSettings = ActorMaterializerSettings(system)
       implicit val mat = ActorMaterializer(materializerSettings)
       override val taskKiller = new TaskKiller(
-        instanceTracker, groupManager, config, auth.auth, auth.auth, killService)
+        instanceTracker, groupManager, auth.auth, auth.auth, killService)
       override val taskResource = new TasksResource(
         instanceTracker,
         taskKiller,

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -76,7 +76,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
     "should not dispatch health checks for staging tasks" in new Fixture {
       instanceTracker.specInstances(any, anyBoolean)(any) returns Future.successful(Seq(instance))
 
-      val actor = healthCheckActor()
+      healthCheckActor()
 
       appHealthCheckActor.expectMsgAllClassOf(classOf[PurgeHealthCheckStatuses])
     }
@@ -84,7 +84,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
     "should not dispatch health checks for lost tasks" in new Fixture {
       instanceTracker.specInstances(any, anyBoolean)(any) returns Future.successful(Seq(lostInstance))
 
-      val actor = healthCheckActor()
+      healthCheckActor()
 
       appHealthCheckActor.expectMsgAllClassOf(classOf[PurgeHealthCheckStatuses])
     }
@@ -92,7 +92,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
     "should not dispatch health checks for unreachable tasks" in new Fixture {
       instanceTracker.specInstances(any, anyBoolean)(any) returns Future.successful(Seq(unreachableInstance))
 
-      val actor = healthCheckActor()
+      healthCheckActor()
 
       appHealthCheckActor.expectMsgAllClassOf(classOf[PurgeHealthCheckStatuses])
     }

--- a/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/MarathonHealthCheckManagerTest.scala
@@ -213,14 +213,6 @@ class MarathonHealthCheckManagerTest extends AkkaUnitTest with Eventually {
     }
 
     "reconcile" in new Fixture {
-      def taskStatus(instance: Instance, state: mesos.TaskState = mesos.TaskState.TASK_RUNNING) =
-        mesos.TaskStatus.newBuilder
-          .setTaskId(mesos.TaskID.newBuilder()
-            .setValue(instance.tasksMap.keys.head.idString)
-            .build)
-          .setState(state)
-          .setHealthy(true)
-          .build
 
       val healthChecks = List(0, 1, 2).map { i =>
         (0 until i).map { j =>

--- a/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActorTest.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package core.task.tracker.impl
 
 import akka.Done
-import akka.actor.{Status, Terminated}
+import akka.actor.{Props, Status, Terminated}
 import akka.testkit.{TestActorRef, TestProbe}
 import com.typesafe.config.ConfigFactory
 import mesosphere.AkkaUnitTest
@@ -342,7 +342,7 @@ class InstanceTrackerActorTest extends AkkaUnitTest with Eventually {
 
       stepProcessor.process(any)(any[ExecutionContext]) returns Future.successful(Done)
 
-      lazy val instanceTrackerActor = TestActorRef[InstanceTrackerActor](InstanceTrackerActor.props(actorMetrics, instancesLoader, stepProcessor, updateResolver, repository, clock, crashStrategy))
+      lazy val instanceTrackerActor = TestActorRef[InstanceTrackerActor](Props(new InstanceTrackerActor(actorMetrics, instancesLoader, stepProcessor, updateResolver, repository, clock, crashStrategy)))
 
       def verifyNoMoreInteractions(): Unit = {
         noMoreInteractions(instancesLoader)

--- a/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
+++ b/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
@@ -6,6 +6,7 @@ import mesosphere.marathon.state._
 import com.wix.accord
 
 trait GroupCreation {
+  @deprecated("Prefer Builders.newRootGroup instead", since = "1.9")
   def createRootGroup(
     apps: Map[AppDefinition.AppKey, AppDefinition] = Group.defaultApps,
     pods: Map[PathId, PodDefinition] = Group.defaultPods,


### PR DESCRIPTION
Backport of 87482273 / #7149

Marathon would check access for all app definitions in the entire
root-group before permitting a kill-and-scale for a single app.

Fixes MARATHON-8731
