### PR TITLE
Add resource limits to apps and pods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,7 @@ lazy val commonSettings = Seq(
       "Mesosphere Public Repo" at "https://downloads.mesosphere.com/maven",
       "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/",
       "Apache Shapshots" at "https://repository.apache.org/content/repositories/snapshots/",
+      "Temporary Mesos releases" at "https://greg-artifacts.s3-us-west-2.amazonaws.com/", // this is needed until an Mesos 1.10 RC release is available in Maven central
       Resolver.JCenterRepository
     ) ++ resolvers.value
   },

--- a/ci/provision.sc
+++ b/ci/provision.sc
@@ -20,6 +20,7 @@ val maybeVersion =
 def installMesos(): Unit = {
   // Install Mesos
   def install_mesos(version: String): Unit = {
+    %%('sudo, "apt-get", "update")
     %%('sudo, "apt-get", "install", "-y", "--force-yes", "--no-install-recommends", s"mesos=$version.debian9")
   }
 

--- a/docs/docs/metrics.md
+++ b/docs/docs/metrics.md
@@ -157,6 +157,13 @@ forwarded as gauges.
 * `marathon.mesos.task-updates.<task-state>.counter` — the count of task
   status updates received per each task state (`task-running`,
   `task-failed` and so on).
+* `marathon.mesos.task.oom.memory-limit-unfulfillable` - The count of
+  tasks OOM-killed because, while the container stayed within its
+  specified memory limit, the agent was too memory constrained to
+  support it.
+* `marathon.mesos.task.oom.memory-limit-exceeded` - The count of tasks
+  OOM-killed because it exceeded the specified memory limit (or,
+  request, if limit was not specified).
 
 ### HTTP-specific metrics
 

--- a/docs/docs/rest-api/public/api/v2/types/app.raml
+++ b/docs/docs/rest-api/public/api/v2/types/app.raml
@@ -278,6 +278,11 @@ types:
         type: AppResidency
         description:
           This property is deprecated and it has no effect.
+      resourceLimits?:
+        type: resources.ResourceLimits
+        description: |
+          Specify optional resource limits for a container, allowing the task to consume more cpu and memory resources
+          than requested, if available.
       requirePorts?:
         type: boolean
         description: |

--- a/docs/docs/rest-api/public/api/v2/types/pod.raml
+++ b/docs/docs/rest-api/public/api/v2/types/pod.raml
@@ -171,3 +171,9 @@ types:
           The role to use. If not specified, uses the role of the enclosing group, or the default role.
           At the moment, only the default role or the group role are allowed
       linuxInfo?: linux.LinuxInfo
+      legacySharedCgroups?:
+        type: boolean
+        description: |
+          Indicates that containers inside of the pod should be launched inside the same cgroup. This is legacy behavior
+          and this flag exists to make it so pods deployed before sub-cgroup support in Mesos don't suddenly fail as a
+          result of relying on this behavior.

--- a/docs/docs/rest-api/public/api/v2/types/podContainer.raml
+++ b/docs/docs/rest-api/public/api/v2/types/podContainer.raml
@@ -81,6 +81,7 @@ types:
       resources:
         type: resources.Resources
         description: The resources to allocate to the container.
+      resourceLimits?: resources.ResourceLimits
       endpoints?:
         type: network.Endpoint[]
         (pragma.omitEmpty):

--- a/docs/docs/rest-api/public/api/v2/types/resources.raml
+++ b/docs/docs/rest-api/public/api/v2/types/resources.raml
@@ -5,7 +5,7 @@ types:
     description: Resource Allocations
     properties:
       cpus:
-        displayName: cpu shares
+        displayName: CPU shares
         description: The number of CPU shares this pod needs per instance. This number does not have to be integer, but can be a fraction.
         type: number
         minimum: 0.001
@@ -42,7 +42,7 @@ types:
     description: Executor Resource Allocations. Same as Resources but reserved for the pod executor.
     properties:
       cpus?:
-        displayName: cpu shares
+        displayName: CPU shares
         description: The number of CPU shares this pod needs per instance for its executor. This number does not have to be integer, but can be a fraction.
         type: number
         minimum: 0.1
@@ -65,3 +65,22 @@ types:
         description: How much disk space is needed for for the executor. This number does not have to be an integer, but can be a fraction.
         example: 50
         default: 10.0
+  ResourceLimit: ResourceLimitUnlimited | ResourceLimitNumber
+  ResourceLimitUnlimited:
+    type: string
+    enum: [ unlimited ]
+  ResourceLimitNumber:
+    type: number
+    format: double
+  ResourceLimits:
+    type: object
+    description: Specify resource limits in addition to the requested resources, allowing containers / tasks to consume more CPU or memory than requested.
+    properties:
+      cpus?:
+        displayName: CPU shares limit
+        description: The total number of CPU shares this task / container can consume. If not specified, then the task / container is constrained to use only the CPUs requested. A value of "unlimited" means the task / container should be allowed to use as many spare CPU cycles as are available on the box. This setting has no effect on nodes with CFS disabled.
+        type: ResourceLimit
+      mem?:
+        displayName: memory
+        description: The total amount of memory that this task / container can consume. If not specified, then the task / container is constrained to use only the memory requested. A value of "unlimited" means the task / container should be allowed as much memory as is free on the agent. Note that when a task goes over its requested memory limit it has a higher chance of being OOM-killed in the case of resource contention on a node.
+        type: ResourceLimit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -130,7 +130,7 @@ object Dependency {
     val Logstash = "4.9"
     val MarathonApiConsole = "3.0.8-accept"
     val MarathonUI = "1.3.2"
-    val Mesos = "1.9.0"
+    val Mesos = "1.10.0"
     val Mustache = "0.9.0"
     val PlayJson = "2.8.1"
     val Raven = "8.0.3"
@@ -152,7 +152,7 @@ object Dependency {
     val JUnitBenchmarks = "0.7.2"
     val Mockito = "1.10.19"
     val ScalaTest = "3.0.8"
-    val UsiTestUtil = "0.1.35-450120f-SNAPSHOT"
+    val UsiTestUtil = "0.1.38"
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -144,8 +144,7 @@ object Dependency {
     val WixAccord = "0.7.6"
 
     // Version of Mesos to use when building docker image or testing packages
-    val MesosDebian = "1.9.0-2.0.1"
-
+    val MesosDebian = "1.10.0-0.1.1225.pre.20200327gitbeaf0cd84"
 
     // test deps versions
     val JMH = "1.19"

--- a/src/main/protobuf/marathon.proto
+++ b/src/main/protobuf/marathon.proto
@@ -168,6 +168,7 @@ message ServiceDefinition {
   repeated mesos.Resource executorResources = 36;
   optional CheckDefinition check = 37;
   optional string role = 38;
+  optional ResourceLimits resourceLimits = 39;
 }
 
 enum KillSelection {
@@ -179,6 +180,11 @@ message UnreachableStrategy {
   // UnreachableDisabled is represented by both of these fields missing
   optional uint64 inactiveAfterSeconds = 1 [default = 900 ]; // 15 minutes
   optional uint64 expungeAfterSeconds = 2 [default = 604800 ]; // 7 days
+}
+
+message ResourceLimits {
+  optional double cpus = 1;
+  optional double mem = 2;
 }
 
 // we serialize PodDefinition and Instances as json, only required for legacy content

--- a/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/PodsResource.scala
@@ -93,7 +93,7 @@ class PodsResource @Inject() (
 
       val roleSettings = RoleSettings.forService(config, PathId(podRaml.id).canonicalPath(PathId.root), groupManager.rootGroup(), false)
       implicit val normalizer: Normalization[Pod] = PodNormalization(PodNormalization.Configuration(config, roleSettings))
-      implicit val podValidator: Validator[Pod] = PodsValidation.podValidator(config, scheduler.mesosMasterVersion(), roleSettings)
+      implicit val podValidator: Validator[Pod] = PodsValidation.podValidator(config, scheduler.mesosMasterVersion())
       implicit val podDefValidator: Validator[PodDefinition] = PodsValidation.podDefValidator(pluginManager, roleSettings)
 
       validateOrThrow(podRaml)
@@ -128,7 +128,7 @@ class PodsResource @Inject() (
 
       val roleSettings = RoleSettings.forService(config, podId, groupManager.rootGroup(), force)
       implicit val normalizer: Normalization[Pod] = PodNormalization(PodNormalization.Configuration(config, roleSettings))
-      implicit val podValidator: Validator[Pod] = PodsValidation.podValidator(config, scheduler.mesosMasterVersion(), roleSettings)
+      implicit val podValidator: Validator[Pod] = PodsValidation.podValidator(config, scheduler.mesosMasterVersion())
       implicit val podDefValidator: Validator[PodDefinition] = PodsValidation.podDefValidator(pluginManager, roleSettings)
 
       validateOrThrow(podRaml)

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/AppValidation.scala
@@ -324,6 +324,25 @@ trait AppValidation {
       .flatMap(_.portMappings).orElse(app.portDefinitions).getOrElse(Nil).indices
   }
 
+  def validResourceLimit(requestResource: Double): Validator[ResourceLimit] = new Validator[ResourceLimit] {
+    override def apply(resourceLimit: ResourceLimit): Result = {
+      resourceLimit match {
+        case ResourceLimitUnlimited(_) => Success
+        case ResourceLimitNumber(value) =>
+          if (value < requestResource)
+            Failure(Set(RuleViolation(value, s"resource limit must be greater than or equal to requested resource (${requestResource})")))
+          else
+            Success
+      }
+    }
+  }
+
+  def validResourceLimits(requestCpus: Double, requestMem: Double): Validator[ResourceLimits] = validator[ResourceLimits] { resourceLimits =>
+    resourceLimits.cpus is optional(validResourceLimit(requestCpus))
+    resourceLimits.mem is
+      optional(validResourceLimit(requestMem))
+  }
+
   /** validate most canonical API fields */
   private def validBasicAppDefinition(enabledFeatures: Set[String], validRoles: Set[String]): Validator[App] = validator[App] { app =>
     app.container is optional(validContainer(enabledFeatures, app.networks, app.secrets))
@@ -333,6 +352,7 @@ trait AppValidation {
     app.healthChecks is every(complyWithIpProtocolRules(app.container))
     app must haveAtMostOneMesosHealthCheck
     app.fetch is every(valid)
+    app.resourceLimits is optional(validResourceLimits(app.cpus, app.mem))
     app.secrets is { secrets: Map[String, SecretDef] =>
       secrets.nonEmpty
     } -> (featureEnabled(enabledFeatures, Features.SECRETS))

--- a/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/validation/PodsValidation.scala
@@ -150,6 +150,7 @@ trait PodsValidation extends GeneralPurposeCombinators {
     validator[PodContainer] { container =>
       container.name is notEqualTo(Task.Id.Names.anonymousContainer)
       container.resources is resourceValidator
+      container.resourceLimits is optional(AppValidation.validResourceLimits(container.resources.cpus, container.resources.mem))
       container.endpoints is every(endpointValidator(pod.networks))
       container.image is optional(imageValidator(enabledFeatures, pod.secrets))
       container.environment is envValidator(strictNameValidation = false, pod.secrets, enabledFeatures)
@@ -157,6 +158,11 @@ trait PodsValidation extends GeneralPurposeCombinators {
       container.volumeMounts is every(volumeMountValidator(pod.volumes))
       container.artifacts is every(artifactValidator)
       container.linuxInfo is optional(state.LinuxInfo.validLinuxInfoForContainerRaml)
+      if (pod.legacySharedCgroups.exists(identity)) {
+        container.resourceLimits is isTrue("resourceLimits cannot be defined if legacySharedCgroups is enabled") { limits =>
+          limits.isEmpty
+        }
+      }
     }
 
   private def volumeValidator(containers: Seq[PodContainer]): Validator[PodVolume] =
@@ -212,10 +218,10 @@ trait PodsValidation extends GeneralPurposeCombinators {
     (podAcceptedResourceRoles(pod) as "acceptedResourceRoles" is empty or valid(ResourceRole.validAcceptedResourceRoles("pod", podPersistentVolumes(pod).nonEmpty)))
   }
 
-  def podValidator(config: MarathonConf, mesosMasterVersion: Option[SemanticVersion] = Some(SemanticVersion.zero), roleSettings: RoleSettings): Validator[Pod] =
-    podValidator(config.availableFeatures, mesosMasterVersion.getOrElse(SemanticVersion.zero), config.defaultNetworkName.toOption, roleSettings)
+  def podValidator(config: MarathonConf, mesosMasterVersion: Option[SemanticVersion] = Some(SemanticVersion.zero)): Validator[Pod] =
+    podValidator(config.availableFeatures, mesosMasterVersion.getOrElse(SemanticVersion.zero), config.defaultNetworkName.toOption)
 
-  def podValidator(enabledFeatures: Set[String], mesosMasterVersion: SemanticVersion, defaultNetworkName: Option[String], roleSettings: RoleSettings): Validator[Pod] = validator[Pod] { pod =>
+  def podValidator(enabledFeatures: Set[String], mesosMasterVersion: SemanticVersion, defaultNetworkName: Option[String]): Validator[Pod] = validator[Pod] { pod =>
     PathId(pod.id) as "id" is valid and PathId.absolutePathValidator and PathId.nonEmptyPath
     pod.user is optional(notEmpty)
     pod.environment is envValidator(strictNameValidation = false, pod.secrets, enabledFeatures)

--- a/src/main/scala/mesosphere/marathon/core/pod/MesosContainer.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/MesosContainer.scala
@@ -3,7 +3,7 @@ package core.pod
 
 import mesosphere.marathon.plugin.ContainerSpec
 import mesosphere.marathon.raml.{Artifact, Endpoint, Image, Lifecycle, MesosExec, Resources}
-import mesosphere.marathon.state.{LinuxInfo, VolumeMount}
+import mesosphere.marathon.state.{LinuxInfo, ResourceLimits, VolumeMount}
 
 import scala.collection.immutable.Map
 
@@ -21,4 +21,5 @@ case class MesosContainer(
     labels: Map[String, String] = Map.empty,
     lifecycle: Option[Lifecycle] = None,
     tty: Option[Boolean] = None,
-    linuxInfo: Option[LinuxInfo] = None) extends ContainerSpec
+    linuxInfo: Option[LinuxInfo] = None,
+    resourceLimits: Option[ResourceLimits] = None) extends ContainerSpec

--- a/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/core/pod/PodDefinition.scala
@@ -34,7 +34,8 @@ case class PodDefinition(
     override val volumes: Seq[Volume] = PodDefinition.DefaultVolumes,
     override val unreachableStrategy: UnreachableStrategy = PodDefinition.DefaultUnreachableStrategy,
     override val killSelection: KillSelection = KillSelection.DefaultKillSelection,
-    role: Role
+    role: Role,
+    legacySharedCgroups: Option[Boolean] = None
 ) extends RunSpec with plugin.PodSpec with MarathonState[Protos.Json, PodDefinition] {
 
   /**

--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -37,11 +37,15 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     metrics.timer("debug.publishing-task-status-update-duration")
   private[this] val killUnknownTaskTimeMetric: Timer =
     metrics.timer("debug.killing-unknown-task-duration")
+  private[this] val oomKilledTasksWithinLimits: Counter =
+    metrics.counter("mesos.task.oom.memory-limit-unfulfillable")
+  private[this] val oomKilledTasksExceededLimits: Counter =
+    metrics.counter("mesos.task.oom.memory-limit-exceeded")
 
   private[this] val taskStateCounterMetrics: collection.concurrent.Map[Int, Counter] =
     new java.util.concurrent.ConcurrentHashMap[Int, Counter]().asScala
 
-  private[this] def getTaskStateCounterMetric(taskState: MesosProtos.TaskState): Counter = {
+  private[this] def getTaskStateCounterMetric(taskState: MesosProtos.TaskState): Counter = synchronized {
     def createCounter() = {
       val stateName = taskState.name().toLowerCase(Locale.US).replace('_', '-')
       val metricName = s"mesos.task-updates.$stateName"
@@ -55,6 +59,14 @@ class TaskStatusUpdateProcessorImpl @Inject() (
   override def publish(status: MesosProtos.TaskStatus): Future[Unit] = publishTimeMetric {
     logger.debug(s"Received status update\n$status")
     getTaskStateCounterMetric(status.getState).increment()
+
+    (status.getReason) match {
+      case MesosProtos.TaskStatus.Reason.REASON_CONTAINER_LIMITATION_MEMORY =>
+        oomKilledTasksExceededLimits.increment()
+      case MesosProtos.TaskStatus.Reason.REASON_CONTAINER_MEMORY_REQUEST_EXCEEDED =>
+        oomKilledTasksWithinLimits.increment()
+      case _ =>
+    }
 
     import TaskStatusUpdateProcessorImpl._
 

--- a/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/AppConversion.scala
@@ -11,7 +11,7 @@ import scala.jdk.CollectionConverters._
 
 trait AppConversion extends DefaultConversions with CheckConversion with ConstraintConversion with EnvVarConversion with HealthCheckConversion
   with NetworkConversion with ReadinessConversions with SecretConversion with VolumeConversion
-  with UnreachableStrategyConversion with KillSelectionConversion {
+  with UnreachableStrategyConversion with KillSelectionConversion with ResourceLimitsConversion {
 
   import AppConversion._
 
@@ -83,7 +83,8 @@ trait AppConversion extends DefaultConversions with CheckConversion with Constra
       killSelection = app.killSelection.toRaml,
       tty = app.tty,
       executorResources = app.executorResources.toRaml,
-      role = Option(app.role)
+      role = Option(app.role),
+      resourceLimits = app.resourceLimits.map(_.toRaml)
     )
   }
 
@@ -171,7 +172,8 @@ trait AppConversion extends DefaultConversions with CheckConversion with Constra
       killSelection = app.killSelection.fromRaml,
       tty = app.tty,
       executorResources = app.executorResources.map(_.fromRaml),
-      role = role
+      role = role,
+      resourceLimits = app.resourceLimits.map(_.fromRaml)
     )
     result
   }
@@ -222,7 +224,8 @@ trait AppConversion extends DefaultConversions with CheckConversion with Constra
       killSelection = update.killSelection.getOrElse(app.killSelection),
       tty = update.tty.orElse(app.tty),
       executorResources = update.executorResources,
-      role = update.role.orElse(app.role)
+      role = update.role.orElse(app.role),
+      resourceLimits = update.resourceLimits
     )
   }
 
@@ -369,7 +372,8 @@ trait AppConversion extends DefaultConversions with CheckConversion with Constra
       killSelection = service.whenOrElse(_.hasKillSelection, _.getKillSelection.toRaml, App.DefaultKillSelection),
       unreachableStrategy = unreachableStrategy,
       tty = service.when(_.hasTty, _.getTty: Boolean).orElse(App.DefaultTty),
-      role = service.when(_.hasRole, _.getRole).orElse(App.DefaultRole)
+      role = service.when(_.hasRole, _.getRole).orElse(App.DefaultRole),
+      resourceLimits = service.when(_.hasResourceLimits, _.getResourceLimits.toRaml)
     )
     // special ports normalization when converting from protobuf, because the protos don't allow us to distinguish
     // between "I specified an empty set of ports" and "I specified a null set of ports" (for definitions and mappings).
@@ -431,7 +435,8 @@ trait AppConversion extends DefaultConversions with CheckConversion with Constra
       ports = app.ports,
       uris = app.uris,
       tty = app.tty,
-      role = app.role
+      role = app.role,
+      resourceLimits = app.resourceLimits
     )
   }
 }

--- a/src/main/scala/mesosphere/marathon/raml/ContainerConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/ContainerConversion.scala
@@ -7,13 +7,14 @@ import mesosphere.mesos.protos.Implicits._
 import org.apache.mesos.{Protos => Mesos}
 import scala.jdk.CollectionConverters._
 
-trait ContainerConversion extends HealthCheckConversion with VolumeConversion with NetworkConversion with LinuxInfoConversion {
+trait ContainerConversion extends HealthCheckConversion with VolumeConversion with NetworkConversion with LinuxInfoConversion with ResourceLimitsConversion {
 
   implicit val containerRamlWrites: Writes[MesosContainer, PodContainer] = Writes { c =>
     PodContainer(
       name = c.name,
       exec = c.exec,
       resources = c.resources,
+      resourceLimits = c.resourceLimits.map(_.toRaml),
       endpoints = c.endpoints,
       image = c.image,
       environment = Raml.toRaml(c.env),
@@ -33,6 +34,7 @@ trait ContainerConversion extends HealthCheckConversion with VolumeConversion wi
       name = c.name,
       exec = c.exec,
       resources = c.resources,
+      resourceLimits = c.resourceLimits.map(_.fromRaml),
       endpoints = c.endpoints,
       image = c.image,
       env = Raml.fromRaml(c.environment),

--- a/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/PodConversion.scala
@@ -66,6 +66,7 @@ trait PodConversion extends NetworkConversion with ConstraintConversion with Con
       linuxInfo = linuxInfo.map(Raml.fromRaml(_)),
       unreachableStrategy = unreachableStrategy,
       killSelection = killSelection,
+      legacySharedCgroups = podd.legacySharedCgroups.filter(identity),
       role = role
     )
   }
@@ -107,7 +108,8 @@ trait PodConversion extends NetworkConversion with ConstraintConversion with Con
       networks = podDef.networks.map(Raml.toRaml(_)),
       executorResources = Some(podDef.executorResources.toRaml),
       role = Some(podDef.role),
-      linuxInfo = Raml.toRaml(podDef.linuxInfo)
+      linuxInfo = Raml.toRaml(podDef.linuxInfo),
+      legacySharedCgroups = podDef.legacySharedCgroups.filter(identity)
     )
   }
 

--- a/src/main/scala/mesosphere/marathon/raml/ResourceLimitsConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/ResourceLimitsConversion.scala
@@ -1,0 +1,45 @@
+package mesosphere.marathon
+package raml
+
+trait ResourceLimitsConversion {
+
+  import ResourceLimitsConversion.{resourceLimitFromDouble, resourceLimitToDouble}
+  implicit val ramlResourceLimitsRead = Reads[ResourceLimits, state.ResourceLimits] { resourceLimits =>
+    state.ResourceLimits(
+      cpus = resourceLimits.cpus.map(resourceLimitToDouble),
+      mem = resourceLimits.mem.map(resourceLimitToDouble)
+    )
+  }
+
+  implicit val ramlResourceLimitsWrite = Writes[state.ResourceLimits, ResourceLimits]{ resourceLimits =>
+    ResourceLimits(
+      cpus = resourceLimits.cpus.map(resourceLimitFromDouble),
+      mem = resourceLimits.mem.map(resourceLimitFromDouble)
+    )
+  }
+
+  implicit val resourceLimitsProtoRamlWrites = Writes[Protos.ResourceLimits, ResourceLimits]{ proto =>
+    ResourceLimits(
+      cpus = if (proto.hasCpus) Some(resourceLimitFromDouble(proto.getCpus)) else None,
+      mem = if (proto.hasMem) Some(resourceLimitFromDouble(proto.getMem)) else None)
+  }
+}
+
+object ResourceLimitsConversion {
+  def resourceLimitToDouble(resourceLimit: ResourceLimit): Double =
+    resourceLimit match {
+      case ResourceLimitUnlimited("unlimited") =>
+        // This value is understood by protobuf as infinity, and Mesos consequently also understands it
+        Double.PositiveInfinity
+      case ResourceLimitUnlimited(text) =>
+        throw new IllegalStateException(s"ResourceLimitUnlimited(${text}) encountered, should be ResourceLimitUnlimited(unlimited)") // we should never get here
+      case ResourceLimitNumber(value) =>
+        value
+    }
+
+  def resourceLimitFromDouble(limit: Double): ResourceLimit =
+    if (limit == Double.PositiveInfinity)
+      ResourceLimitUnlimited("unlimited")
+    else
+      ResourceLimitNumber(limit)
+}

--- a/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
+++ b/src/main/scala/mesosphere/marathon/state/AppDefinition.scala
@@ -88,7 +88,9 @@ case class AppDefinition(
 
     tty: Option[Boolean] = AppDefinition.DefaultTTY,
 
-    role: Role) extends RunSpec
+    role: Role,
+
+    resourceLimits: Option[ResourceLimits] = None) extends RunSpec
   with plugin.ApplicationSpec with MarathonState[Protos.ServiceDefinition, AppDefinition] {
 
   /**
@@ -192,6 +194,9 @@ case class AppDefinition(
       .setKillSelection(killSelection.toProto)
       .setRole(role)
 
+    resourceLimits.foreach { limits =>
+      builder.setResourceLimits(ResourceLimits.resourceLimitsToProto(limits))
+    }
     check.foreach { c => builder.setCheck(c.toProto) }
 
     executorResources.foreach(r => {

--- a/src/main/scala/mesosphere/marathon/state/ResourceLimits.scala
+++ b/src/main/scala/mesosphere/marathon/state/ResourceLimits.scala
@@ -1,0 +1,20 @@
+package mesosphere.marathon
+package state
+
+case class ResourceLimits(cpus: Option[Double], mem: Option[Double])
+
+object ResourceLimits {
+  def resourceLimitsToProto(limits: ResourceLimits): Protos.ResourceLimits = {
+    val b = Protos.ResourceLimits.newBuilder()
+    limits.cpus.foreach(b.setCpus)
+    limits.mem.foreach(b.setMem)
+    b.build
+  }
+
+  def resourceLimitsFromProto(proto: Protos.ResourceLimits): ResourceLimits = {
+    ResourceLimits(
+      cpus = if (proto.hasCpus) Some(proto.getCpus) else None,
+      mem = if (proto.hasMem) Some(proto.getMem) else None
+    )
+  }
+}

--- a/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/Migration.scala
@@ -217,7 +217,8 @@ object Migration {
       StorageVersions(18, 200) -> { (migration) => new MigrationTo18200(migration.instanceRepo, migration.persistenceStore) },
       StorageVersions(19, 100) -> { (migration) => new MigrationTo19100(migration.defaultMesosRole, migration.persistenceStore) },
       StorageVersions(19, 200) -> { (migration) => new MigrationTo19200(migration.defaultMesosRole, migration.instanceRepo, migration.persistenceStore) },
-      StorageVersions(19, 300) -> { (migration) => new MigrationTo19300(migration.persistenceStore) }
+      StorageVersions(19, 300) -> { (migration) => new MigrationTo19300(migration.persistenceStore) },
+      StorageVersions(110, 100) -> { (migration) => new MigrationTo110000(migration.persistenceStore) }
     )
 }
 

--- a/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo110000.scala
+++ b/src/main/scala/mesosphere/marathon/storage/migration/MigrationTo110000.scala
@@ -1,0 +1,46 @@
+package mesosphere.marathon
+package storage.migration
+
+import java.time.OffsetDateTime
+
+import akka.Done
+import akka.stream.Materializer
+import akka.stream.scaladsl.Flow
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.storage.store.PersistenceStore
+import mesosphere.marathon.core.storage.store.impl.zk.{ZkId, ZkSerialized}
+
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future}
+
+class MigrationTo110000(
+    persistenceStore: PersistenceStore[ZkId, String, ZkSerialized]) extends MigrationStep with StrictLogging {
+
+  override def migrate()(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = async {
+    logger.info("Starting migration to 1.10.000")
+    await(MigrationTo110000.migratePods(persistenceStore))
+  }
+
+}
+
+object MigrationTo110000 {
+  val migrationVersion = StorageVersions(110, 0)
+
+  private[migration] val podMigratingFlow = Flow[(raml.Pod, Option[OffsetDateTime])].map {
+    case (podRaml, version) =>
+      val migratedPod = podRaml.copy(legacySharedCgroups = Some(true))
+
+      migratedPod -> version
+  }
+
+  /**
+    * Loads all pod definitions from store and sets the boolean "legacySharedCgroups" to true
+    *
+    * @param persistenceStore The ZooKeeper storage.
+    * @return Successful future when done.
+    */
+  def migratePods(persistenceStore: PersistenceStore[ZkId, String, ZkSerialized])(implicit ctx: ExecutionContext, mat: Materializer): Future[Done] = {
+    ServiceMigration.migratePodVersions(migrationVersion, persistenceStore, podMigratingFlow)
+  }
+
+}

--- a/src/main/scala/mesosphere/mesos/TaskBuilder.scala
+++ b/src/main/scala/mesosphere/mesos/TaskBuilder.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.state.Container.Docker
 import mesosphere.marathon.state._
 import mesosphere.mesos.ResourceMatcher.ResourceMatch
 import mesosphere.mesos.protos.Implicits._
-import mesosphere.mesos.protos.ScalarResource
+import mesosphere.mesos.protos.{Resource, ScalarResource}
 import org.apache.mesos.Protos.Environment._
 import org.apache.mesos.Protos._
 
@@ -44,6 +44,7 @@ class TaskBuilder(
       .setTaskId(taskId.mesosTaskId)
       .setSlaveId(offer.getSlaveId)
       .addAllResources(resourceMatch.resources.asJava)
+      .putAllLimits(TaskBuilder.limitsAsJavaMap(runSpec.resourceLimits))
 
     builder.setDiscovery(computeDiscoveryInfo(runSpec, resourceMatch.hostPorts))
 
@@ -198,6 +199,16 @@ class TaskBuilder(
 }
 
 object TaskBuilder {
+  def limitsAsJavaMap(maybeLimits: Option[ResourceLimits]): java.util.Map[String, Value.Scalar] = {
+    maybeLimits.iterator.flatMap { limits =>
+      limits.cpus.iterator.map { cpus =>
+        Resource.CPUS -> Value.Scalar.newBuilder().setValue(cpus).build
+      } ++
+        limits.mem.iterator.map { mem =>
+          Resource.MEM -> Value.Scalar.newBuilder().setValue(mem).build
+        }
+    }.toMap.asJava
+  }
 
   def commandInfo(
     runSpec: AppDefinition,

--- a/src/test/scala/mesosphere/UnitTest.scala
+++ b/src/test/scala/mesosphere/UnitTest.scala
@@ -7,6 +7,7 @@ import akka.actor.{ActorSystem, Scheduler}
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.{TestActor, TestActorRef, TestKitBase}
 import akka.util.Timeout
+import com.mesosphere.utils.mesos.MesosTest
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.api.v2.json.Formats
@@ -32,6 +33,13 @@ case class KnownIssue(jira: String) extends Tag(s"mesosphere.marathon.KnownIssue
   * }}}
   */
 case class WhenEnvSet(envVarName: String, default: String = "false") extends Tag(if (sys.env.getOrElse(envVarName, default) == "true") "" else classOf[Ignore].getName)
+
+/**
+  * Tag that will conditionally enable a specific test case if the operating system is Linux
+  *
+  * Used to skip tests when running on platforms where the test is known to fail due to capabilities unsupported by the OS
+  */
+case object WhenLinux extends Tag(if (MesosTest.isLinux) "" else classOf[Ignore].getName)
 
 trait CancelFailedTestWithKnownIssue extends TestSuite {
 

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/PodsValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/PodsValidationTest.scala
@@ -2,9 +2,8 @@ package mesosphere.marathon
 package api.v2.validation
 
 import com.wix.accord.{Failure, Result, Validator}
-import mesosphere.marathon.api.v2.ValidationHelper
 import mesosphere.marathon.core.plugin.PluginManager
-import mesosphere.marathon.raml.{Constraint, ConstraintOperator, DockerPullConfig, Endpoint, EnvVarSecret, Image, ImageType, Network, NetworkMode, PersistentVolumeInfo, Pod, PodContainer, PodEphemeralVolume, PodPersistentVolume, PodPlacementPolicy, PodSchedulingPolicy, PodSecretVolume, PodUpgradeStrategy, Resources, SecretDef, UnreachableDisabled, UnreachableEnabled, VolumeMount}
+import mesosphere.marathon.raml.{Constraint, ConstraintOperator, DockerPullConfig, Endpoint, EnvVarSecret, Image, ImageType, Network, NetworkMode, PersistentVolumeInfo, Pod, PodContainer, PodEphemeralVolume, PodPersistentVolume, PodPlacementPolicy, PodSchedulingPolicy, PodSecretVolume, PodUpgradeStrategy, ResourceLimitNumber, ResourceLimitUnlimited, ResourceLimits, Resources, SecretDef, UnreachableDisabled, UnreachableEnabled, VolumeMount}
 import mesosphere.marathon.state.PersistentVolume
 import mesosphere.marathon.util.{RoleSettings, SemanticVersion}
 import mesosphere.{UnitTest, ValidationTestLike}
@@ -275,7 +274,7 @@ class PodsValidationTest extends UnitTest with ValidationTestLike with PodsValid
         unreachableStrategy = Some(UnreachableDisabled()))))
 
     val features: Set[String] = if (validateSecrets) Set(Features.SECRETS) else Set.empty
-    implicit val validator: Validator[Pod] = podValidator(features, SemanticVersion.zero, None, ValidationHelper.roleSettings())
+    implicit val validator: Validator[Pod] = podValidator(features, SemanticVersion.zero, None)
 
     val pluginManager: PluginManager = PluginManager.None
 
@@ -285,7 +284,7 @@ class PodsValidationTest extends UnitTest with ValidationTestLike with PodsValid
 
   "network validation" when {
     implicit val validator: Validator[Pod] =
-      podValidator(Set.empty, SemanticVersion.zero, Some("default-network-name"), ValidationHelper.roleSettings())
+      podValidator(Set.empty, SemanticVersion.zero, Some("default-network-name"))
 
     def podContainer(name: String = "ct1", resources: Resources = Resources(), endpoints: Seq[Endpoint]) =
       PodContainer(
@@ -454,6 +453,43 @@ class PodsValidationTest extends UnitTest with ValidationTestLike with PodsValid
       validator(networkedPod(Seq(
         podContainer(endpoints = Seq(Endpoint("ep")))
       ), hostNetwork)) should be(aSuccess)
+    }
+  }
+
+  "resourceLimits validation" should {
+    def withResourceLimits(pod: Pod, cpus: Option[Double] = None, mem: Option[Double] = None): Pod = {
+      def doubleToResourceLimit(d: Double) = if (d.isInfinite()) {
+        ResourceLimitUnlimited("unlimited")
+      } else {
+        ResourceLimitNumber(d)
+      }
+
+      pod.copy(containers = pod.containers.map { container =>
+        container.copy(resourceLimits = Some(ResourceLimits(cpus = cpus.map(doubleToResourceLimit), mem = mem.map(doubleToResourceLimit))))
+      })
+    }
+
+    "succeed when resource limits are >= requested resources" in new Fixture {
+      validator(withResourceLimits(validPod, mem = Some(256.0))) should be(aSuccess)
+      validator(withResourceLimits(validPod, mem = Some(300.0))) should be(aSuccess)
+      validator(withResourceLimits(validPod, mem = Some(Double.PositiveInfinity))) should be(aSuccess)
+
+      validator(withResourceLimits(validPod, cpus = Some(2.0))) should be(aSuccess)
+      validator(withResourceLimits(validPod, cpus = Some(10.0))) should be(aSuccess)
+      validator(withResourceLimits(validPod, cpus = Some(Double.PositiveInfinity))) should be(aSuccess)
+    }
+
+    "fail when resource limits are less than requested resources" in new Fixture {
+      validator(withResourceLimits(validPod, mem = Some(100))) should haveViolations(
+        "/containers(0)/resourceLimits/mem" -> "resource limit must be greater than or equal to requested resource (128.0)")
+      validator(withResourceLimits(validPod, cpus = Some(0.5))) should haveViolations(
+        "/containers(0)/resourceLimits/cpus" -> "resource limit must be greater than or equal to requested resource (1.0)")
+    }
+
+    "fail when resource limits are specified and sharedCgroups is enabled" in new Fixture {
+      val podWithSharedCgroups = validPod.copy(legacySharedCgroups = Some(true))
+      validator(withResourceLimits(podWithSharedCgroups, cpus = Some(Double.PositiveInfinity))) should haveViolations(
+        "/containers(0)/resourceLimits" -> "resourceLimits cannot be defined if legacySharedCgroups is enabled")
     }
   }
 }

--- a/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/AppConversionTest.scala
@@ -41,7 +41,8 @@ class AppConversionTest extends UnitTest with ValidationTestLike {
       acceptedResourceRoles = Set("*"),
       killSelection = state.KillSelection.OldestFirst,
       secrets = Map("secret0" -> state.Secret("/path/to/secret")),
-      role = "*"
+      role = "*",
+      resourceLimits = Some(state.ResourceLimits(cpus = Some(Double.PositiveInfinity), mem = Some(4096)))
     )
   }
   private lazy val hostApp = AppDefinition(

--- a/src/test/scala/mesosphere/marathon/raml/PodConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodConversionTest.scala
@@ -1,0 +1,79 @@
+package mesosphere.marathon
+package raml
+
+import mesosphere.UnitTest
+import mesosphere.marathon.core.health.{MesosHttpHealthCheck, PortReference}
+import mesosphere.marathon.core.pod.{ContainerNetwork, MesosContainer, PodDefinition}
+import mesosphere.marathon.raml.PodStatusConversionTest.containerResources
+import mesosphere.marathon.state.AbsolutePathId
+
+class PodConversionTest extends UnitTest {
+
+  import PodConversionTest._
+
+  "PodConversion" should {
+    val pod = basicOneContainerPod.copy(linuxInfo = Some(state.LinuxInfo(seccomp = None, ipcInfo = Some(state.IPCInfo(ipcMode = state.IpcMode.Private, shmSize = Some(32))))))
+
+    "converting raml to internal model" should {
+      "keep linux info on executor" in {
+        val ramlPod = pod.toRaml
+        val ramlLinuxInfo = Some(LinuxInfo(seccomp = None, ipcInfo = Some(IPCInfo(mode = IPCMode.Private, shmSize = Some(32)))))
+        ramlPod.linuxInfo should be(ramlLinuxInfo)
+      }
+
+      "keeps legacySharedCgroups when it is set to true, but drops it when set to false" in {
+        val ramlPod = pod.toRaml
+        ramlPod.copy(legacySharedCgroups = Some(false)).fromRaml.legacySharedCgroups shouldBe None
+        ramlPod.copy(legacySharedCgroups = Some(true)).fromRaml.legacySharedCgroups shouldBe Some(true)
+      }
+    }
+
+    "converting internal model to raml" should {
+      "keeps legacySharedCgroups when it is set to true, but drops it when set to false" in {
+        pod.copy(legacySharedCgroups = Some(false)).toRaml.legacySharedCgroups shouldBe None
+        pod.copy(legacySharedCgroups = Some(true)).toRaml.legacySharedCgroups shouldBe Some(true)
+      }
+    }
+    behave like convertToRamlAndBack(pod)
+  }
+
+  def convertToRamlAndBack(pod: PodDefinition): Unit = {
+    s"pod ${pod.id.toString} is written to json and can be read again via formats" in {
+      Given("An pod")
+      val ramlPod = pod.toRaml[Pod]
+
+      When("The pod is translated to json and read back from formats")
+      val readPod: PodDefinition = withValidationClue {
+        Raml.fromRaml(ramlPod)
+      }
+      Then("The pod is identical")
+      readPod should be(pod)
+    }
+  }
+
+  def withValidationClue[T](f: => T): T = scala.util.Try { f }.recover {
+    // handle RAML validation errors
+    case vfe: ValidationFailedException => fail(vfe.failure.violations.toString())
+    case th => throw th
+  }.get
+}
+
+object PodConversionTest {
+  val basicOneContainerPod = PodDefinition(
+    id = AbsolutePathId("/foo"),
+    role = "*",
+    containers = Seq(
+      MesosContainer(
+        name = "ct1",
+        resources = containerResources,
+        image = Some(Image(kind = ImageType.Docker, id = "busybox")),
+        endpoints = Seq(
+          Endpoint(name = "web", containerPort = Some(80)),
+          Endpoint(name = "admin", containerPort = Some(90), hostPort = Some(0))
+        ),
+        healthCheck = Some(MesosHttpHealthCheck(portIndex = Some(PortReference("web")), path = Some("/ping")))
+      )
+    ),
+    networks = Seq(ContainerNetwork(name = "dcos"), ContainerNetwork("bigdog"))
+  )
+}

--- a/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
+++ b/src/test/scala/mesosphere/marathon/raml/PodStatusConversionTest.scala
@@ -17,39 +17,6 @@ class PodStatusConversionTest extends UnitTest {
 
   import PodStatusConversionTest._
 
-  "PodConversion" should {
-    val pod = basicOneContainerPod.copy(linuxInfo = Some(state.LinuxInfo(seccomp = None, ipcInfo = Some(state.IPCInfo(ipcMode = state.IpcMode.Private, shmSize = Some(32))))))
-
-    "keep linux info on executor" in {
-      val ramlPod = pod.toRaml
-      val ramlLinuxInfo = Some(LinuxInfo(seccomp = None, ipcInfo = Some(IPCInfo(mode = IPCMode.Private, shmSize = Some(32)))))
-      ramlPod.linuxInfo should be(ramlLinuxInfo)
-    }
-
-    behave like convertToRamlAndBack(pod)
-
-  }
-
-  def convertToRamlAndBack(pod: PodDefinition): Unit = {
-    s"pod ${pod.id.toString} is written to json and can be read again via formats" in {
-      Given("An pod")
-      val ramlPod = pod.toRaml[Pod]
-
-      When("The pod is translated to json and read back from formats")
-      val readPod: PodDefinition = withValidationClue {
-        Raml.fromRaml(ramlPod)
-      }
-      Then("The pod is identical")
-      readPod should be(pod)
-    }
-  }
-
-  def withValidationClue[T](f: => T): T = scala.util.Try { f }.recover {
-    // handle RAML validation errors
-    case vfe: ValidationFailedException => fail(vfe.failure.violations.toString())
-    case th => throw th
-  }.get
-
   "PodStatusConversion" should {
     "multiple tasks with multiple container networks convert to proper network status" in {
 
@@ -460,6 +427,7 @@ class PodStatusConversionTest extends UnitTest {
 object PodStatusConversionTest {
 
   val containerResources = Resources(cpus = 0.01, mem = 100)
+  val containerResourceLimits = state.ResourceLimits(cpus = Some(Double.MaxValue), mem = Some(4096))
 
   val basicOneContainerPod = PodDefinition(
     id = AbsolutePathId("/foo"),
@@ -468,6 +436,7 @@ object PodStatusConversionTest {
       MesosContainer(
         name = "ct1",
         resources = containerResources,
+        resourceLimits = Some(containerResourceLimits),
         image = Some(Image(kind = ImageType.Docker, id = "busybox")),
         endpoints = Seq(
           Endpoint(name = "web", containerPort = Some(80)),

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -1156,7 +1156,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
       val container = MesosContainer(name = "withTTY", resources = Resources())
       val pod = PodDefinition(id = AbsolutePathId("/notty"), role = "*", containers = Seq(container))
       val containerInfo = TaskGroupBuilder.computeContainerInfo(pod, container)
-      containerInfo should be(empty)
+      containerInfo.get.hasTtyInfo shouldBe false
     }
 
     "IpcConfig defined on a pod renders to executor info" in {

--- a/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
+++ b/src/test/scala/mesosphere/mesos/TaskGroupBuilderTest.scala
@@ -9,12 +9,13 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.plugin.task.RunSpecTaskProcessor
 import mesosphere.marathon.plugin.{ApplicationSpec, PodSpec}
 import mesosphere.marathon.raml
-import mesosphere.marathon.raml.{Endpoint, Resources, Lifecycle}
+import mesosphere.marathon.raml.{Endpoint, Lifecycle, Resources}
 import mesosphere.marathon.state._
 import mesosphere.marathon.state
 import scala.jdk.CollectionConverters._
 import mesosphere.marathon.test.{MarathonTestHelper, SettableClock}
 import mesosphere.marathon.AllConf
+import mesosphere.mesos.protos.Resource
 import org.apache.mesos.Protos.{ExecutorInfo, TaskGroupInfo, TaskInfo}
 import org.apache.mesos.{Protos => mesos}
 import org.scalatest.Inside
@@ -1158,7 +1159,7 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
       containerInfo should be(empty)
     }
 
-    "IpcConfig defined on a pod renderes to executor info" in {
+    "IpcConfig defined on a pod renders to executor info" in {
       val ipcShmSize = 64
       val ipcMode = IpcMode.Private
 
@@ -1166,41 +1167,38 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
       val ipcShmSizeContainer = 32
 
       val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0, disk = 10.0, beginPort = 8000, endPort = 9000).build
-      val container = MesosContainer(name = "dummy", resources = Resources(), linuxInfo = Some(LinuxInfo(seccomp = None, ipcInfo = Some(IPCInfo(ipcMode = ipcModeContainer, shmSize = Some(ipcShmSizeContainer))))))
+      val containerLinuxInfo = LinuxInfo(seccomp = None, ipcInfo = Some(IPCInfo(ipcMode = ipcModeContainer, shmSize = Some(ipcShmSizeContainer))))
+      val podLinuxInfo = LinuxInfo(seccomp = None, ipcInfo = Some(IPCInfo(ipcMode = ipcMode, shmSize = Some(ipcShmSize))))
 
-      val podSpec = PodDefinition(id = AbsolutePathId("/ipcConfig"), containers = Seq(container), linuxInfo = Some(LinuxInfo(seccomp = None, ipcInfo = Some(IPCInfo(ipcMode = ipcMode, shmSize = Some(ipcShmSize))))), role = "*")
-      val instanceId = Instance.Id.forRunSpec(podSpec.id)
-      val taskIds = podSpec.containers.map(c => Task.Id(instanceId, Some(c)))
-      val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Nil,
-        defaultBuilderConfig.acceptedResourceRoles, config, Nil)
+      new FixtureWithMatchedOffer(containerLinuxInfo = Some(containerLinuxInfo), podLinuxInfo = Some(podLinuxInfo)) {
+        val (executorInfo, taskGroup, _) = TaskGroupBuilder.build(
+          podSpec,
+          offer,
+          instanceId,
+          taskIds,
+          defaultBuilderConfig,
+          RunSpecTaskProcessor.empty,
+          resourceMatch.asInstanceOf[ResourceMatchResponse.Match].resourceMatch,
+          None,
+          true
+        )
 
-      val (executorInfo, taskGroup, _) = TaskGroupBuilder.build(
-        podSpec,
-        offer,
-        instanceId,
-        taskIds,
-        defaultBuilderConfig,
-        RunSpecTaskProcessor.empty,
-        resourceMatch.asInstanceOf[ResourceMatchResponse.Match].resourceMatch,
-        None,
-        true
-      )
+        executorInfo.hasContainer should be(true)
+        executorInfo.getContainer.hasLinuxInfo should be(true)
+        executorInfo.getContainer.getLinuxInfo.hasIpcMode should be(true)
+        executorInfo.getContainer.getLinuxInfo.getIpcMode should be(mesos.LinuxInfo.IpcMode.PRIVATE)
+        executorInfo.getContainer.getLinuxInfo.hasShmSize should be(true)
+        executorInfo.getContainer.getLinuxInfo.getShmSize should be(ipcShmSize)
 
-      executorInfo.hasContainer should be(true)
-      executorInfo.getContainer.hasLinuxInfo should be(true)
-      executorInfo.getContainer.getLinuxInfo.hasIpcMode should be(true)
-      executorInfo.getContainer.getLinuxInfo.getIpcMode should be(mesos.LinuxInfo.IpcMode.PRIVATE)
-      executorInfo.getContainer.getLinuxInfo.hasShmSize should be(true)
-      executorInfo.getContainer.getLinuxInfo.getShmSize should be(ipcShmSize)
-
-      taskGroup.getTasksCount should be(1)
-      val task = taskGroup.getTasksList.get(0)
-      task.hasContainer should be(true)
-      task.getContainer.hasLinuxInfo should be(true)
-      task.getContainer.getLinuxInfo.hasIpcMode should be(true)
-      task.getContainer.getLinuxInfo.getIpcMode should be(mesos.LinuxInfo.IpcMode.SHARE_PARENT)
-      task.getContainer.getLinuxInfo.hasShmSize should be(true)
-      task.getContainer.getLinuxInfo.getShmSize should be(ipcShmSizeContainer)
+        taskGroup.getTasksCount should be(1)
+        val task = taskGroup.getTasksList.get(0)
+        task.hasContainer should be(true)
+        task.getContainer.hasLinuxInfo should be(true)
+        task.getContainer.getLinuxInfo.hasIpcMode should be(true)
+        task.getContainer.getLinuxInfo.getIpcMode should be(mesos.LinuxInfo.IpcMode.SHARE_PARENT)
+        task.getContainer.getLinuxInfo.hasShmSize should be(true)
+        task.getContainer.getLinuxInfo.getShmSize should be(ipcShmSizeContainer)
+      }
 
     }
 
@@ -1232,5 +1230,55 @@ class TaskGroupBuilderTest extends UnitTest with Inside {
 
       taskGroupInfo.getTasks(0).getKillPolicy.getGracePeriod.getNanoseconds shouldBe (killDuration.toNanos)
     }
+
+    "legacySharedCgroups is propagated to the executorInfo container properly" in new FixtureWithMatchedOffer(legacySharedCgroups = Some(true)) {
+      val (executorInfo, taskGroup, _) = TaskGroupBuilder.build(
+        podSpec,
+        offer,
+        instanceId,
+        taskIds,
+        defaultBuilderConfig,
+        RunSpecTaskProcessor.empty,
+        resourceMatch.asInstanceOf[ResourceMatchResponse.Match].resourceMatch,
+        None,
+        true
+      )
+
+      executorInfo.getContainer.getLinuxInfo.getShareCgroups shouldBe true
+    }
+
+    "resource limits are propagated for a container" in {
+      new FixtureWithMatchedOffer(legacySharedCgroups = Some(false), resourceLimits = Some(ResourceLimits(cpus = Some(Double.PositiveInfinity), mem = Some(1024.0)))) {
+        val (executorInfo, taskGroup, _) = TaskGroupBuilder.build(
+          podSpec,
+          offer,
+          instanceId,
+          taskIds,
+          defaultBuilderConfig,
+          RunSpecTaskProcessor.empty,
+          resourceMatch.asInstanceOf[ResourceMatchResponse.Match].resourceMatch,
+          None,
+          true
+        )
+
+        executorInfo.getContainer.getLinuxInfo.getShareCgroups shouldBe false
+        val limits = taskGroup.getTasks(0).getLimitsMap.asScala
+        limits.keySet shouldBe Set(Resource.CPUS, Resource.MEM)
+
+        limits(Resource.CPUS).getValue shouldBe Double.PositiveInfinity
+        limits(Resource.MEM).getValue shouldBe 1024.0
+      }
+    }
+  }
+
+  class FixtureWithMatchedOffer(podLinuxInfo: Option[LinuxInfo] = None, containerLinuxInfo: Option[LinuxInfo] = None, resourceLimits: Option[ResourceLimits] = None, legacySharedCgroups: Option[Boolean] = None) {
+    val offer = MarathonTestHelper.makeBasicOffer(cpus = 3.1, mem = 416.0, disk = 10.0, beginPort = 8000, endPort = 9000).build
+    val container = MesosContainer(name = "dummy", resources = Resources(), resourceLimits = resourceLimits, linuxInfo = containerLinuxInfo)
+
+    val podSpec = PodDefinition(id = AbsolutePathId("/ipcConfig"), legacySharedCgroups = legacySharedCgroups, containers = Seq(container), linuxInfo = podLinuxInfo, role = "*")
+    val instanceId = Instance.Id.forRunSpec(podSpec.id)
+    val taskIds = podSpec.containers.map(c => Task.Id(instanceId, Some(c)))
+    val resourceMatch = RunSpecOfferMatcher.matchOffer(podSpec, offer, Nil,
+      defaultBuilderConfig.acceptedResourceRoles, config, Nil)
   }
 }

--- a/tests/integration/src/test/resources/python/app_mock.py
+++ b/tests/integration/src/test/resources/python/app_mock.py
@@ -8,6 +8,7 @@ import socket
 import sys
 import subprocess
 import re
+import json
 
 # Ensure compatibility with Python 2 and 3.
 # See https://github.com/JioCloud/python-six/blob/master/six.py for details.
@@ -35,6 +36,38 @@ else:
     def response_status(response):
         return response.getcode()
 
+
+def cgroup_name(resource_type):
+    logging.info("Looking for my cgroup for resource type %s", resource_type)
+    with open("/proc/self/cgroup", "r") as file:
+        lines = file.readlines()
+        for line in lines:
+            logging.info("/proc/self/cgroup: %s", line)
+            [idx, resource_types, cgroup_name] = line.strip().split(":")
+            for t in resource_types.split(","):
+                if t == resource_type:
+                    logging.info("My cgroup: %s", cgroup_name)
+                    return cgroup_name
+                
+
+        
+# reads all the files in a folder that are readable, return them in a map of filename: contents
+def read_cgroup_values(resource_type):
+    name = cgroup_name(resource_type)
+    if name is None:
+        return {}
+    folder = os.path.join("/sys/fs/cgroup", resource_type) + name
+    result = {}
+    for filename in os.listdir(folder):
+        path = os.path.join(folder, filename)
+        print(path)
+        with open(path, 'r') as file:
+            try:
+                result[filename] = file.read().strip()
+            except IOError:
+                ()
+                # ignore
+    return result
 
 def make_handler(app_id, version, task_id, base_url):
     """
@@ -129,6 +162,20 @@ def make_handler(app_id, version, task_id, base_url):
             logging.debug("Done reporting IPC ns info.")
             return
 
+        def handle_cgroup_info(self):
+            cgroup_info = {
+                "memory": read_cgroup_values("memory"),
+                "cpu": read_cgroup_values("cpu")
+            }
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+
+            self.wfile.write(json.dumps(cgroup_info))
+
+            logging.debug("Done reporting cgroup info.")
+            return
+
         def handle_suicide(self):
 
             logging.info("Received a suicide request. Sending a SIGTERM to myself.")
@@ -152,6 +199,8 @@ def make_handler(app_id, version, task_id, base_url):
                     return self.handle_ipc_shm_info()
                 elif self.path == '/ipcns':
                     return self.handle_ipc_ns_info()
+                elif self.path == "/cgroup":
+                    return self.handle_cgroup_info()
                 else:
                     return SimpleHTTPRequestHandler.do_GET(self)
             except Exception:

--- a/tests/integration/src/test/resources/python/app_mock.py
+++ b/tests/integration/src/test/resources/python/app_mock.py
@@ -48,9 +48,8 @@ def cgroup_name(resource_type):
                 if t == resource_type:
                     logging.info("My cgroup: %s", cgroup_name)
                     return cgroup_name
-                
 
-        
+
 # reads all the files in a folder that are readable, return them in a map of filename: contents
 def read_cgroup_values(resource_type):
     name = cgroup_name(resource_type)
@@ -68,6 +67,7 @@ def read_cgroup_values(resource_type):
                 ()
                 # ignore
     return result
+
 
 def make_handler(app_id, version, task_id, base_url):
     """

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/LimitsIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/LimitsIntegrationTest.scala
@@ -1,0 +1,246 @@
+package mesosphere.marathon.integration
+
+import java.io.File
+
+import com.mesosphere.utils.mesos.MesosAgentConfig
+import mesosphere.marathon.integration.facades.AppMockFacade
+import mesosphere.marathon.integration.setup.EmbeddedMarathonTest
+import mesosphere.marathon.raml
+import mesosphere.marathon.state.AbsolutePathId
+import mesosphere.{AkkaIntegrationTest, WhenLinux}
+import org.apache.commons.io.FileUtils
+import org.scalatest.Inside
+import play.api.libs.json.Json
+
+class LimitsIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
+
+  case class CgroupInfo(memory: Map[String, String], cpu: Map[String, String])
+  implicit val cgroupInfoFormat = Json.format[CgroupInfo]
+  val projectDir: String = sys.props.getOrElse("user.dir", ".")
+  override lazy val agentConfig = MesosAgentConfig(
+    launcher = "linux",
+    containerizers = "mesos",
+    isolation = Some("filesystem/linux,cgroups/cpu,cgroups/mem"),
+    cgroupsEnableCfs = true,
+  )
+
+  override def afterEach(): Unit = {
+    marathon.deleteRoot(true)
+    super.afterEach()
+  }
+
+  def deployApp(app: raml.App): CallbackEvent = {
+    val createResult = marathon.createAppV2(app)
+    createResult should be(Created)
+    waitForDeployment(createResult)
+  }
+
+  def deployPod(pod: raml.Pod) = {
+    val createResult = marathon.createPodV2(pod)
+    createResult should be(Created)
+    waitForDeployment(createResult)
+  }
+
+  def getPodInstanceCgroupInfo(podId: AbsolutePathId): CgroupInfo = {
+    eventually {
+      marathon.status(podId) should be(Stable)
+      val status = marathon.status(podId).value
+      val host = inside(status.instances.flatMap(_.agentHostname)) {
+        case Seq(host) => host
+      }
+      val port = inside(status.instances.flatMap(_.containers.flatMap(_.endpoints.flatMap(_.allocatedHostPort)))) {
+        case Seq(port) => port
+      }
+
+      val facade = AppMockFacade(host, port)
+
+      val groupJson = facade.get("/cgroup").futureValue.entityString
+      Json.parse(groupJson).as[CgroupInfo]
+    }
+  }
+
+  def getTaskCgroupInfo(appId: AbsolutePathId): CgroupInfo = {
+    eventually {
+      val tasks = marathon.tasks(appId).value
+      tasks.length shouldBe 1
+      val task = tasks.head
+      task.state shouldBe "TASK_RUNNING"
+      val host = task.host
+      val port = task.ports.get.head
+
+      val facade = AppMockFacade(host, port)
+
+      val groupJson = facade.get("/cgroup").futureValue.entityString
+      Json.parse(groupJson).as[CgroupInfo]
+    }
+  }
+
+  def logCgroupInfo(desc: String, cgroupInfo: CgroupInfo) = {
+    val all = (cgroupInfo.cpu.map { case (k,v) => s"cpu:${k}" -> v} ++ cgroupInfo.memory.map { case (k,v) => s"mem:${k}" -> v})
+
+    all.toSeq.sorted.foreach { case (k, v) =>
+      println(s"${desc}\t${k}\t${v.split("\n").headOption.getOrElse("")}")
+    }
+  }
+
+  lazy val totalCpuShares: Int = {
+    FileUtils.readFileToString(new File("/sys/fs/cgroup/cpu/cpu.shares"), java.nio.charset.StandardCharsets.US_ASCII).trim.toInt
+  }
+
+  "launch apps with and without limits specified for memory and cpus" taggedAs WhenLinux in {
+    val unlimitedAppId = testBasePath / "unlimited-app"
+    val limitedAppId = testBasePath / "limited-app"
+    val limitsUnsetAppId = testBasePath / "limits-unset-app"
+
+    val unlimitedApp = raml.App(
+      id = unlimitedAppId.toString,
+      container = Some(raml.Container(`type` = raml.EngineType.Mesos)),
+      cmd = Some(appMockCmd(unlimitedAppId, "1")),
+      cpus = 0.1,
+      mem = 32,
+      executorResources = Some(raml.ExecutorResources(
+        cpus = 0.1,
+        mem = 32)),
+      resourceLimits = Some(raml.ResourceLimits(
+        cpus = Some(raml.ResourceLimitUnlimited("unlimited")),
+        mem = Some(raml.ResourceLimitUnlimited("unlimited")))))
+
+    val limitedApp = raml.App(
+      id = limitedAppId.toString,
+      container = Some(raml.Container(`type` = raml.EngineType.Mesos)),
+      cmd = Some(appMockCmd(unlimitedAppId, "1")),
+      cpus = 0.1,
+      mem = 32,
+      executorResources = Some(raml.ExecutorResources(
+        cpus = 0.1,
+        mem = 32)),
+      resourceLimits = Some(raml.ResourceLimits(
+        cpus = Some(raml.ResourceLimitNumber(1)),
+        mem = Some(raml.ResourceLimitNumber(128)))))
+
+    val limitsUnsetApp = raml.App(
+      id = limitsUnsetAppId.toString,
+      container = Some(raml.Container(`type` = raml.EngineType.Mesos)),
+      cmd = Some(appMockCmd(unlimitedAppId, "1")),
+      cpus = 0.1,
+      mem = 32,
+      executorResources = Some(raml.ExecutorResources(
+        cpus = 0.1,
+        mem = 32)),
+      resourceLimits = None)
+
+    deployApp(unlimitedApp)
+    deployApp(limitsUnsetApp)
+    deployApp(limitedApp)
+
+    val unlimitedCgroupInfo = getTaskCgroupInfo(unlimitedAppId)
+    val limitedCgroupInfo = getTaskCgroupInfo(limitedAppId)
+    val limitsUnsetCgroupInfo = getTaskCgroupInfo(limitsUnsetAppId)
+
+    logCgroupInfo("app unlimitedCgroupInfo", unlimitedCgroupInfo)
+    logCgroupInfo("app limitedCgroupInfo", limitedCgroupInfo)
+    logCgroupInfo("app limitsUnsetCgroupInfo", limitsUnsetCgroupInfo)
+
+    // assert cpu shares are set the same for all apps
+    Then("the unlimited app should have no quota defined for CPU")
+    unlimitedCgroupInfo.cpu("cpu.cfs_quota_us").toInt shouldBe -1
+
+    And("the quota for the app with limits set is greater than the quota with the default limits")
+    limitedCgroupInfo.cpu("cpu.cfs_quota_us").toInt shouldBe > (limitsUnsetCgroupInfo.cpu("cpu.cfs_quota_us").toInt)
+
+    And("the unlimited app should have a substantially higher memory limit than the app with limits specified")
+    unlimitedCgroupInfo.memory("memory.limit_in_bytes").toLong shouldBe > (limitedCgroupInfo.memory("memory.limit_in_bytes").toLong)
+
+    And("the app with limits specified should have a a higher memory limit than the app with limits unspecified")
+    limitedCgroupInfo.memory("memory.limit_in_bytes").toLong shouldBe > (limitsUnsetCgroupInfo.memory("memory.limit_in_bytes").toLong)
+  }
+
+  "launch pods with and without limits specified for memory and cpus" taggedAs WhenLinux in {
+    val unlimitedPodId = testBasePath / "unlimited-pod"
+    val limitedPodId = testBasePath / "limited-pod"
+    val limitsUnsetPodId = testBasePath / "limits-unset-pod"
+
+    val unlimitedPod = raml.Pod(
+      id = unlimitedPodId.toString,
+      networks = Seq(raml.Network(mode = raml.NetworkMode.Host)),
+      executorResources = Some(raml.ExecutorResources(
+        cpus = 0.1,
+        mem = 32)),
+      containers = Seq(raml.PodContainer(
+        name = "primary",
+        exec = Some(raml.MesosExec(
+          command = raml.ShellCommand(appMockCmd(unlimitedPodId, port = "$ENDPOINT_HTTP", versionId = "1"))
+        )),
+        resources = raml.Resources(
+          cpus = 0.1,
+          mem = 32,
+        ),
+        endpoints = Seq(raml.Endpoint(name = "http", hostPort = Some(0))),
+        resourceLimits = Some(raml.ResourceLimits(
+          cpus = Some(raml.ResourceLimitUnlimited("unlimited")),
+          mem = Some(raml.ResourceLimitUnlimited("unlimited")))))))
+
+    val limitedPod = raml.Pod(
+      id = limitedPodId.toString,
+      networks = Seq(raml.Network(mode = raml.NetworkMode.Host)),
+      executorResources = Some(raml.ExecutorResources(
+        cpus = 0.1,
+        mem = 32)),
+      containers = Seq(raml.PodContainer(
+        name = "primary",
+        exec = Some(raml.MesosExec(
+          command = raml.ShellCommand(appMockCmd(unlimitedPodId, port = "$ENDPOINT_HTTP", versionId = "1"))
+        )),
+        resources = raml.Resources(
+          cpus = 0.1,
+          mem = 32,
+        ),
+        endpoints = Seq(raml.Endpoint(name = "http", hostPort = Some(0))),
+        resourceLimits = Some(raml.ResourceLimits(
+          cpus = Some(raml.ResourceLimitNumber(1)),
+          mem = Some(raml.ResourceLimitNumber(128)))))))
+
+    val limitsUnsetPod = raml.Pod(
+      id = limitsUnsetPodId.toString,
+      networks = Seq(raml.Network(mode = raml.NetworkMode.Host)),
+      executorResources = Some(raml.ExecutorResources(
+        cpus = 0.1,
+        mem = 32)),
+      containers = Seq(raml.PodContainer(
+        name = "primary",
+        exec = Some(raml.MesosExec(
+          command = raml.ShellCommand(appMockCmd(unlimitedPodId, port = "$ENDPOINT_HTTP", versionId = "1"))
+        )),
+        resources = raml.Resources(
+          cpus = 0.1,
+          mem = 32,
+        ),
+        endpoints = Seq(raml.Endpoint(name = "http", hostPort = Some(0))),
+        resourceLimits = None)))
+
+    deployPod(unlimitedPod)
+    deployPod(limitsUnsetPod)
+    deployPod(limitedPod)
+
+    val unlimitedCgroupInfo = getPodInstanceCgroupInfo(unlimitedPodId)
+    val limitedCgroupInfo = getPodInstanceCgroupInfo(limitedPodId)
+    val limitsUnsetCgroupInfo = getPodInstanceCgroupInfo(limitsUnsetPodId)
+
+    logCgroupInfo("pod - unlimitedCgroupInfo", unlimitedCgroupInfo)
+    logCgroupInfo("pod - limitedCgroupInfo", limitedCgroupInfo)
+    logCgroupInfo("pod - limitsUnsetCgroupInfo", limitsUnsetCgroupInfo)
+
+    // assert cpu shares are set the same for all pods
+    Then("the unlimited pod should have no quota defined for CPU")
+    unlimitedCgroupInfo.cpu("cpu.cfs_quota_us").toInt shouldBe -1
+
+    And("the quota for the pod with limits set is greater than the quota with the default limits")
+    limitedCgroupInfo.cpu("cpu.cfs_quota_us").toInt shouldBe > (limitsUnsetCgroupInfo.cpu("cpu.cfs_quota_us").toInt)
+
+    And("the unlimited pod should have a substantially higher memory limit than the pod with limits specified")
+    unlimitedCgroupInfo.memory("memory.limit_in_bytes").toLong shouldBe > (limitedCgroupInfo.memory("memory.limit_in_bytes").toLong)
+
+    And("the pod with limits specified should have a a higher memory limit than the pod with limits unspecified")
+    limitedCgroupInfo.memory("memory.limit_in_bytes").toLong shouldBe > (limitsUnsetCgroupInfo.memory("memory.limit_in_bytes").toLong)
+  }
+}

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/facades/MarathonFacade.scala
@@ -279,10 +279,14 @@ class MarathonFacade(
 
   def podTasksIds(podId: AbsolutePathId): Seq[String] = status(podId).value.instances.flatMap(_.containers.flatMap(_.containerId))
 
-  def createPodV2(pod: PodDefinition): RestResult[PodDefinition] = {
-    requireInBaseGroup(pod.id)
-    val res = result(requestFor[Pod](Post(s"$url/v2/pods", Raml.toRaml(pod))), waitTime)
+  def createPodV2(pod: Pod): RestResult[PodDefinition] = {
+    requireInBaseGroup(pod.id.toPath)
+    val res = result(requestFor[Pod](Post(s"$url/v2/pods", pod)), waitTime)
     res.map(Raml.fromRaml(_))
+  }
+
+  def createPodV2(pod: PodDefinition): RestResult[PodDefinition] = {
+    createPodV2(Raml.toRaml(pod))
   }
 
   def deletePod(id: AbsolutePathId, force: Boolean = false): RestResult[HttpResponse] = {

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -371,14 +371,14 @@ trait MarathonAppFixtures {
     s"http://$$HOST:$healthCheckPort/$encodedAppId/$versionId"
   }
 
-  def appMockCmd(appId: PathId, versionId: String): String = {
+  def appMockCmd(appId: PathId, versionId: String, port: String = "$PORT0"): String = {
     val projectDir = sys.props.getOrElse("user.dir", ".")
     val appMock: File = MarathonTestHelper.resourcePath("python/app_mock.py")
     if (!appMock.exists()) {
       throw new IllegalStateException("Failed to locate app_mock.py (" + appMock.getAbsolutePath + ")")
     }
     s"""echo APP PROXY $$MESOS_TASK_ID RUNNING; ${appMock.getAbsolutePath} """ +
-      s"""$$PORT0 $appId $versionId ${healthEndpointFor(appId, versionId)}"""
+      s"""${port} $appId $versionId ${healthEndpointFor(appId, versionId)}"""
   }
 
   def appProxyHealthCheck(

--- a/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/RamlTypeGenerator.scala
@@ -4,7 +4,7 @@ import treehugger.forest._
 import definitions._
 import mesosphere.raml.backend._
 import mesosphere.raml.backend.treehugger.{GeneratedFile, GeneratedObject, Visitor}
-import mesosphere.raml.ir.{ConstraintT, EnumT, FieldT, GeneratedClass, ObjectT, StringT, UnionT}
+import mesosphere.raml.ir.{ConstraintT, EnumT, FieldT, GeneratedClass, ObjectT, StringT, NumberT, UnionT}
 import org.raml.v2.api.RamlModelResult
 import org.raml.v2.api.model.v10.api.Library
 import org.raml.v2.api.model.v10.datamodel._
@@ -252,6 +252,8 @@ object RamlTypeGenerator {
                     ObjectT(name, fields, parent, comment(o), discriminator = Option(o.discriminator()), discriminatorValue = Option(o.discriminatorValue()), serializeOnly = pragmaSerializeOnly(o))
                   case s: StringTypeDeclaration =>
                     StringT(s.name, Option(s.defaultValue()))
+                  case n: NumberTypeDeclaration =>
+                    NumberT(n.name, Option(n.defaultValue()).map(_.toDouble))
                   case t =>
                     sys.error(s"Unable to generate union types of non-object/string subtypes: ${u.name()} ${t.name()} ${t.`type`()}")
                 }

--- a/type-generator/src/main/scala/mesosphere/raml/backend/package.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/backend/package.scala
@@ -61,6 +61,7 @@ package object backend {
   val PlayJson = RootClass.newClass("play.api.libs.json.Json")
   val PlayJsValue = RootClass.newClass("play.api.libs.json.JsValue")
   val PlayJsString = RootClass.newClass("play.api.libs.json.JsString")
+  val PlayJsNumber = RootClass.newClass("play.api.libs.json.JsNumber")
   val PlayJsObject = RootClass.newClass("play.api.libs.json.JsObject")
   val PlayJsArray = RootClass.newClass("play.api.libs.json.JsArray")
   val PlayValidationError = RootClass.newClass("play.api.libs.json.JsonValidationError")

--- a/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/UnionVisitor.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/backend/treehugger/UnionVisitor.scala
@@ -1,8 +1,8 @@
 package mesosphere.raml.backend.treehugger
 
-import mesosphere.raml.backend.{PlayJson, PlayJsValue, PlayJsString, PLAY_JSON_FORMAT, PLAY_JSON_RESULT}
+import mesosphere.raml.backend.{PlayJson, PlayJsNumber, PlayJsValue, PlayJsString, PLAY_JSON_FORMAT, PLAY_JSON_RESULT}
 
-import mesosphere.raml.ir.{StringT, UnionT}
+import mesosphere.raml.ir.{StringT, UnionT, NumberT}
 import treehugger.forest._
 import definitions._
 import treehuggerDSL._
@@ -31,6 +31,40 @@ object UnionVisitor {
       )
     )
     val children:Seq[GeneratedObject] = childTypes.flatMap {
+      case s: NumberT => {
+        val caseClass =
+          CASECLASSDEF(s.name) withParents name withParams s.defaultValue.fold(PARAM("value", DoubleClass).tree){ defaultValue =>
+            PARAM("value", DoubleClass) := LIT(defaultValue.toDouble)
+          }
+
+        val objectDef =
+          OBJECTDEF(s.name) := BLOCK(
+            Seq(OBJECTDEF("playJsonFormat") withParents PLAY_JSON_FORMAT(s.name) withFlags Flags.IMPLICIT := BLOCK(
+              DEF("reads", PLAY_JSON_RESULT(s.name)) withParams PARAM("json", PlayJsValue) := BLOCK(
+                REF("json") DOT "validate" APPLYTYPE DoubleClass DOT "map" APPLY (REF(s.name) DOT "apply")
+              ),
+              DEF("writes", PlayJsValue) withParams PARAM("o", s.name) := BLOCK(
+                REF(PlayJsNumber) APPLY (REF("o") DOT "value")
+              )
+            )) ++ s.defaultValue.map{ defaultValue =>
+              VAL("DefaultValue") withType(s.name) := REF(s.name) APPLY()
+            }
+          )
+
+        val jacksonSerializerSym = RootClass.newClass(s.name + "Serializer")
+
+        val jacksonSerializer = OBJECTDEF(jacksonSerializerSym).withParents("com.fasterxml.jackson.databind.ser.std.StdSerializer[" + s.name + "](classOf[" + s.name + "])") := BLOCK(
+          DEF("serialize", UnitClass) withFlags Flags.OVERRIDE withParams(
+            PARAM("value", s.name),
+            PARAM("gen", "com.fasterxml.jackson.core.JsonGenerator"),
+            PARAM("provider", "com.fasterxml.jackson.databind.SerializerProvider")) := BLOCK(
+
+            (REF("gen") DOT "writeNumber" APPLY(REF("value") DOT "value"))
+          )
+        )
+
+        Seq(GeneratedObject( s.name, Seq( caseClass, objectDef, jacksonSerializer), Some(jacksonSerializerSym)))
+      }
       case s: StringT => {
         val caseClass =
           CASECLASSDEF(s.name) withParents name withParams s.defaultValue.fold(PARAM("value", StringClass).tree){ defaultValue =>

--- a/type-generator/src/main/scala/mesosphere/raml/ir/NumberT.scala
+++ b/type-generator/src/main/scala/mesosphere/raml/ir/NumberT.scala
@@ -1,0 +1,4 @@
+package mesosphere.raml.ir
+
+case class NumberT(name: String, defaultValue: Option[Double]) extends GeneratedClass {
+}


### PR DESCRIPTION
 We add support for Mesos resource limits. New pods are launched such
that they do not share resources any longer; existing pods will continue
to have containers show resources by setting the flag
"legacySharedCgroups" to true.

JIRA Issues: D2IQ-61131, D2IQ-61130