### PR TITLE
Do not upgrade Marathon EE

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -257,7 +257,6 @@ def buildStorageTool(): String = {
 @main
 def updateDcosImage(version: SemVer, artifactUrl: String, sha1: String): Unit = utils.stage("Patch DC/OS Branch") {
   upgrade.updateMarathon(artifactUrl, sha1, s"Update Marathon to $version")
-  upgrade.updateMarathonEE(artifactUrl, sha1, s"Update Marathon to $version")
 }
 
 /*******************************************************************************

--- a/ci/upgrade.sc
+++ b/ci/upgrade.sc
@@ -308,17 +308,3 @@ def updateDcosServiceEE(url: String, sha1: String, message: String, serviceName:
     push(git, commitRev, destination = s"refs/heads/$branchName")
   }
 }
-
-
-/**
-  * Checks out a DC/OS Enterprise repository and updates the Marathon package ee.buildinfo.json
-  * to the passed url and sha1.
-  *
-  * @param url The URL to the new Marathon artifact.
-  * @param sha1 The sha1 checksum of the Marathon artifact.
-  * @param message The commit message for the change.
-  */
-@main
-def updateMarathonEE(url: String, sha1: String, message: String): Unit = {
-  updateDcosServiceEE(url, sha1, message, "Marathon", "mergebot/dcos/master/1739")
-}


### PR DESCRIPTION
Summary:
The Marathon package does not exist in EE anymore. We don't have to
update it since the open bump will do so.