### PR TITLE
Allow underscores in path ids

### DIFF
--- a/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
+++ b/docs/docs/rest-api/public/api/v2/types/stringTypes.raml
@@ -22,13 +22,14 @@ types:
       validation has historically been lax.
   PathId:
     type: string
-    pattern: ^(\/?((\.\.)|(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9]))?($|\/))+$
+    pattern: ^(\/?((\.\.)|(([a-z0-9]|[a-z0-9][a-z0-9\-_]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-_]*[a-z0-9]))?($|\/))+$
     minLength: 1
     example: /ops/audit
     description: |
-      Unique identifier for the pod consisting of a series of names separated by slashes.
-      Each name must be at least 1 character and may only contain digits (`0-9`), dashes
-      (`-`), dots (`.`), and lowercase letters (`a-z`). The name may not begin or end with a dash.
+      Unique identifier for the pod consisting of a series of names separated by
+      slashes.  Each name must be at least 1 character and may only contain
+      digits (`0-9`), dashes (`-`), underscores (`_`), dots (`.`), and lowercase
+      letters (`a-z`). The name may not begin or end with a dash.
   Uri:
     type: string
     minLength: 1

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -151,7 +151,7 @@ object Dependency {
     val JUnitBenchmarks = "0.7.2"
     val Mockito = "1.10.19"
     val ScalaTest = "3.0.8"
-    val UsiTestUtil = "0.1.38"
+    val UsiTestUtil = "0.1.39"
   }
 
   val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty")

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -202,8 +202,7 @@ object PathId {
     *
     * To change it, update  `PathId` in stringTypes.raml; also, notify the maintainers of the DCOS CLI.
     */
-  private[state] val ID_PATH_SEGMENT_PATTERN =
-    App.ConstraintIdPattern
+  val ID_PATH_SEGMENT_PATTERN = App.ConstraintIdPattern
 
   private val validPathChars = isTrue[PathId](s"must fully match regular expression '${ID_PATH_SEGMENT_PATTERN.pattern.pattern()}'") { id =>
     id.path.forall(part => ID_PATH_SEGMENT_PATTERN.pattern.matcher(part).matches())

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.StrictLogging
 import com.wix.accord._
 import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation.isTrue
+import mesosphere.marathon.raml.App
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Seq
@@ -199,11 +200,10 @@ object PathId {
   /**
     * This regular expression is used to validate each path segment of an ID.
     *
-    * If you change this, please also change `PathId` in stringTypes.raml, and
-    * notify the maintainers of the DCOS CLI.
+    * To change it, update  `PathId` in stringTypes.raml; also, notify the maintainers of the DCOS CLI.
     */
   private[this] val ID_PATH_SEGMENT_PATTERN =
-    "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$".r
+    App.ConstraintIdPattern
 
   private val validPathChars = isTrue[PathId](s"must fully match regular expression '${ID_PATH_SEGMENT_PATTERN.pattern.pattern()}'") { id =>
     id.path.forall(part => ID_PATH_SEGMENT_PATTERN.pattern.matcher(part).matches())

--- a/src/main/scala/mesosphere/marathon/state/PathId.scala
+++ b/src/main/scala/mesosphere/marathon/state/PathId.scala
@@ -202,7 +202,7 @@ object PathId {
     *
     * To change it, update  `PathId` in stringTypes.raml; also, notify the maintainers of the DCOS CLI.
     */
-  private[this] val ID_PATH_SEGMENT_PATTERN =
+  private[state] val ID_PATH_SEGMENT_PATTERN =
     App.ConstraintIdPattern
 
   private val validPathChars = isTrue[PathId](s"must fully match regular expression '${ID_PATH_SEGMENT_PATTERN.pattern.pattern()}'") { id =>

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionTest.scala
@@ -38,7 +38,7 @@ class AppDefinitionTest extends UnitTest with ValidationTestLike {
   "AppDefinition" should {
     "Validation" in {
       var app = AppDefinition(id = "a b".toAbsolutePath, role = "*")
-      val idError = "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'"
+      val idError = s"must fully match regular expression '${PathId.ID_PATH_SEGMENT_PATTERN}'"
       validator(app) should haveViolations("/id" -> idError)
 
       app = app.copy(id = "a#$%^&*b".toAbsolutePath)

--- a/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/AppDefinitionValidationTest.scala
@@ -49,7 +49,7 @@ class AppDefinitionValidationTest extends UnitTest with ValidationTestLike {
         )
 
         validator(app) should haveViolations(
-          "/dependencies(0)" -> """must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])|(\.|\.\.)$'""")
+          "/dependencies(0)" -> s"must fully match regular expression '${PathId.ID_PATH_SEGMENT_PATTERN}'")
       }
     }
 

--- a/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/validation/RunSpecValidatorTest.scala
@@ -91,6 +91,10 @@ class RunSpecValidatorTest extends UnitTest with ValidationTestLike {
       testValidId("/trailing/")
     }
 
+    "id '/slave_public/with_underscores' is valid" in {
+      testValidId("/slave_public/with_underscores'")
+    }
+
     "single dots in id '/test/.' fails in validation" in {
       val app = App(
         id = "/test/.",

--- a/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/PathIdTest.scala
@@ -208,7 +208,7 @@ class PathIdTest extends UnitTest with ValidationTestLike {
       "be invalid" in {
         val path = AbsolutePathId("/@§\'foobar-0")
         pathIdValidator(path) should haveViolations(
-          "/" -> "must fully match regular expression '^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])|(\\.|\\.\\.)$'")
+          "/" -> s"must fully match regular expression '${PathId.ID_PATH_SEGMENT_PATTERN}'")
       }
     }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MultiRoleIntegrationTest.scala
@@ -127,6 +127,19 @@ class MultiRoleIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathon
       waitForTasks(AbsolutePathId(appInDev.id), 1) //make sure the app has really started
     }
 
+    "Marathon should launch an app under as slave_public" in {
+      Given("an app in role slave_public")
+      val appInDev = appProxy(AbsolutePathId("/slave_public/app-with-role"), "v1", instances = 1, role = Some("slave_public"))
+
+      When("The app is deployed")
+      val resultInDev = marathon.createAppV2(appInDev)
+
+      Then("The apps are created")
+      resultInDev should be(Created)
+      waitForDeployment(resultInDev)
+      waitForTasks(AbsolutePathId(appInDev.id), 1) //make sure the app has really started
+    }
+
   }
 
 }

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/RemoteRegionOffersIntegrationTest.scala
@@ -123,7 +123,7 @@ class RemoteRegionOffersIntegrationTest extends AkkaIntegrationTest with Embedde
       When("an agent in the remote region with running tasks becomes unreachable")
       val Some(agent) = mesosCluster.agents.filter { agent =>
         (originalAgentIds contains mesosCluster.agentIdFor(agent)) &&
-          agent.extraArgs.exists(_.contains("remote_region"))
+          agent.mesosFaultDomainAgentCmdOption.exists(_.contains("remote_region"))
       }.headOption
 
       agent.stop()


### PR DESCRIPTION
The group-role convention is that the top-level group corresponds to the
role used by the service. However, underscores are not allowed in paths,
and this prevents a common role in DC/OS from being used: slave_public.

JIRA Issues: MARATHON-8740
