### PR TITLE
Defer loading of instances.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerActor.scala
@@ -42,7 +42,7 @@ object InstanceTrackerActor {
   }
 
   /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]]. */
-  private[impl] case object List
+  @LeaderDeferrable private[impl] case object List
 
   /** Query the current [[InstanceTracker.SpecInstances]] from the [[InstanceTrackerActor]] by RunSpec [[PathId]]. */
   private[impl] case class ListBySpec(appId: PathId)


### PR DESCRIPTION
Backport of 4303d385 / #7159

The loading of instance in `LaunchQueueActor` can be deferred until the
`TaskInstanceTracker` is ready.

JIRA Issues: MARATHON-8741
