### PR TITLE
Define special exit code for invalid CLI flag.

### DIFF
--- a/docs/docs/exit-codes.md
+++ b/docs/docs/exit-codes.md
@@ -22,6 +22,7 @@ help you figure out why the Marathon process stopped.
 |109        | `IncompatibleLibMesos` Provided LibMesos version is incompatible                                     |
 |110        | `FrameworkHasBeenRemoved` Framework has been removed via Mesos teardown call                         |
 |111        | `BindingError` Marathon could not bind to the address provided by `--http_address` and `--http_port` |
+|112        | `InvalidCommandLineFlag` Marathon was started with an invalid command line flag. Check the error message for deprecated options. |
 |137        | Killed by an external process or uncaught exception                                                  |
 
 ## Troubleshooting Exit Codes

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -43,12 +43,13 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
     System.exit(CrashStrategy.IncompatibleLibMesos.code)
   }
 
-  val cliConf = try {
+  val cliConf: AllConf = try {
     new AllConf(args)
   } catch {
     case e: Throwable =>
       logger.error("Invalid command line flag", e)
       Runtime.getRuntime.exit(CrashStrategy.InvalidCommandLineFlag.code)
+      ???
   }
 
   val actorSystem = ActorSystem("marathon")

--- a/src/main/scala/mesosphere/marathon/Main.scala
+++ b/src/main/scala/mesosphere/marathon/Main.scala
@@ -43,7 +43,14 @@ class MarathonApp(args: Seq[String]) extends AutoCloseable with StrictLogging {
     System.exit(CrashStrategy.IncompatibleLibMesos.code)
   }
 
-  val cliConf = new AllConf(args)
+  val cliConf = try {
+    new AllConf(args)
+  } catch {
+    case e: Throwable =>
+      logger.error("Invalid command line flag", e)
+      Runtime.getRuntime.exit(CrashStrategy.InvalidCommandLineFlag.code)
+  }
+
   val actorSystem = ActorSystem("marathon")
 
   val marathonRestModule = new MarathonRestModule()

--- a/src/main/scala/mesosphere/marathon/MarathonConf.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonConf.scala
@@ -154,7 +154,7 @@ trait MarathonConf
     str.split(',').map(_.trim).toSet
 
   private[this] def validateDefaultAcceptedResourceRoles(str: String): Boolean = {
-    require(BuildInfo.version.minor < 10, "This flag has been removed in Marathon 1.10.0; use --accepted_resource_roles_default_behavior, instead.")
+    require(BuildInfo.version.minor < 10, "The flag '--default_accepted_resource_roles' has been removed in Marathon 1.10.0; use --accepted_resource_roles_default_behavior, instead.")
     false
   }
 

--- a/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
+++ b/src/main/scala/mesosphere/marathon/core/base/CrashStrategy.scala
@@ -25,6 +25,7 @@ object CrashStrategy {
   case object IncompatibleLibMesos extends Reason { override val code: Int = 109 }
   case object FrameworkHasBeenRemoved extends Reason { override val code: Int = 110 }
   case object BindingError extends Reason { override val code: Int = 111 }
+  case object InvalidCommandLineFlag extends Reason { override val code: Int = 112 }
 }
 
 case object JvmExitsCrashStrategy extends CrashStrategy {


### PR DESCRIPTION
Summary:
This let's Marathon crash immediately with a special exit code if a
command line flag is invalid.