### PR TITLE
Publish Docker images.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,15 +35,14 @@ ansiColor('xterm') {
     }
 
     stage('Release MoM EE Docker Image') {
-      //if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME ==~ /releases\/.*/) { Always run for testing.
-        //env['DOCKER_VERSION'] = sh(script: "./version docker", returnStdout: true).trim()
+      if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME ==~ /releases\/.*/) {
         version = sh(script: "./version docker", returnStdout: true).trim()
         build(
              job: '/marathon-dcos-plugins/release-mom-ee-docker-image/master',
              parameters: [string(name: 'from_image_tag', value: version)],
              propagate: true
         )
-      //}
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,13 +35,14 @@ ansiColor('xterm') {
     }
 
     stage('Release unstable MoM EE Docker Image') {
-      if (env.BRANCH_NAME == 'master') {
+      //if (env.BRANCH_NAME == 'master') { Always run for testing.
+        env['DOCKER_VERSION'] = sh(script: "./version docker")
         build(
              job: '/marathon-dcos-plugins/release-mom-ee-docker-image/master',
-             parameters: [string(name: 'from_image_tag', value: 'unstable'), string(name: 'target_tag', value: 'unstable')],
+             parameters: [string(name: 'from_image_tag', value: env.DOCKER_VERISON)],
              propagate: true
         )
-      }
+      //}
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,12 +34,13 @@ ansiColor('xterm') {
       }
     }
 
-    stage('Release unstable MoM EE Docker Image') {
-      //if (env.BRANCH_NAME == 'master') { Always run for testing.
-        env['DOCKER_VERSION'] = sh(script: "./version docker")
+    stage('Release MoM EE Docker Image') {
+      //if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME ==~ /releases\/.*/) { Always run for testing.
+        //env['DOCKER_VERSION'] = sh(script: "./version docker", returnStdout: true).trim()
+        version = sh(script: "./version docker", returnStdout: true).trim()
         build(
              job: '/marathon-dcos-plugins/release-mom-ee-docker-image/master',
-             parameters: [string(name: 'from_image_tag', value: env.DOCKER_VERISON)],
+             parameters: [string(name: 'from_image_tag', value: version)],
              propagate: true
         )
       //}

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -285,9 +285,9 @@ def buildMaster(): Unit = {
     updateDcosImage(version, artifact.downloadUrl, artifact.sha1)
   }
 
-  // Publish Docker image as `unstable`
-  %('docker, "tag", s"mesosphere/marathon:${dockerTag}", "mesosphere/marathon:unstable")
-  %('docker, "push", "mesosphere/marathon:unstable")
+  // Publish Docker image
+  %('docker, "tag", s"mesosphere/marathon:${dockerTag}")
+  %('docker, "push", s"mesosphere/marathon:${dockerTag}")
 }
 
 /**


### PR DESCRIPTION
Summary:
This change will publish the Docker images with a proper version tag instead
of the `unstable` tag.