### PR TITLE
Do not retag Docker image.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -286,7 +286,6 @@ def buildMaster(): Unit = {
   }
 
   // Publish Docker image
-  %('docker, "tag", s"mesosphere/marathon:${dockerTag}")
   %('docker, "push", s"mesosphere/marathon:${dockerTag}")
 }
 


### PR DESCRIPTION
Summary:
The Docker image is already tagged during the build.