### PR TITLE
Reject sanitization that would result in an empty array

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,10 @@
-## Changes from 1.9.100 to 1.9.xxx
 ## Changes from to 1.10.17 to 1.10.xxx
 
 ### Fixed issues
 
 * [MARATHON-8762](https://jira.d2iq.com/browse/MARATHON-8762) - Marathon allows migrations to be re-applied if they did not previously complete.
 
-## Changes from 1.9.136 to 1.10.17
+## Changes from 1.9.139 to 1.10.17
 
 ### Vertical container bursting support and shared cgroups
 
@@ -28,7 +27,6 @@ Also, newly created pods will no longer allow containers to steal resources from
 
 For more information, see [resource-limits.md](https://github.com/mesosphere/marathon/blob/master/docs/docs/resource-limits.md)
 
-## Changes from 1.9.100 to 1.9.136
 ## Changes from 1.9.139 to 1.9.xxx
 
 ### Compatibility breaking changes

--- a/changelog.md
+++ b/changelog.md
@@ -1,33 +1,8 @@
-## Changes from to 1.10.17 to 1.10.xxx
+## Changes from 1.9.139 to 1.9.xxx
 
 ### Fixed issues
 
 * [MARATHON-8762](https://jira.d2iq.com/browse/MARATHON-8762) - Marathon allows migrations to be re-applied if they did not previously complete.
-
-## Changes from 1.9.139 to 1.10.17
-
-### Vertical container bursting support and shared cgroups
-
-Marathon 1.10 brings support for Mesos resource-limits, allowing containers to formally allocate and consume more CPU or memory than are consumed from an offer. For example, the following app definition would allow a Marathon app to consume as many CPU cycles are available, and also consume more than the 4gb of memory requested.
-
-```
-{
-  "id": "/dev/bigbusiness",
-  "cpus": 1,
-  "mem": 4096,
-  "resourceLimits": {
-    "cpus": "unlimited",
-    "mem": 8192
-  },
-  ...
-}
-```
-
-Also, newly created pods will no longer allow containers to steal resources from eachother. Previously, if a container in a pod was configured with less memory than it actually needs, the pod would still run successfully if the container could borrow steal the amount needed from another container. Pods created prior to upgrading Marathon to 1.10 will automatically have the flag `legacySharedCgroups` set to allow them to continue to run with the same configuration as they were initially launched. Pods cannot specify resource limits when `legacySharedCgroups` is enabled.
-
-For more information, see [resource-limits.md](https://github.com/mesosphere/marathon/blob/master/docs/docs/resource-limits.md)
-
-## Changes from 1.9.139 to 1.9.xxx
 
 ### Compatibility breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 
 ### Compatibility breaking changes
 
-* [MARATHON-8748] - Marathon now returns an error if a completely invalid `acceptedResourceRoles` is specified, rather than sanitizing it and using `["*"]`. This is intended to address a situation where users were attempting to deploy an app on a DC/OS public node, but weren't using the service role `slave_public`.
+* [MARATHON-8748] - Marathon now returns an error if a completely invalid `acceptedResourceRoles` is specified, rather than sanitizing it and using `["*"]`. This helps users remember to use the service role `slave_public` when deploying an app on a DC/OS public node.
 
 ## Changes from 1.9.100 to 1.9.139
 

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,13 @@ Also, newly created pods will no longer allow containers to steal resources from
 For more information, see [resource-limits.md](https://github.com/mesosphere/marathon/blob/master/docs/docs/resource-limits.md)
 
 ## Changes from 1.9.100 to 1.9.136
+## Changes from 1.9.139 to 1.9.xxx
+
+### Compatibility breaking changes
+
+* [MARATHON-8748] - Marathon now returns an error if a completely invalid `acceptedResourceRoles` is specified, rather than sanitizing it and using `["*"]`. This is intended to address a situation where users were attempting to deploy an app on a DC/OS public node, but weren't using the service role `slave_public`.
+
+## Changes from 1.9.100 to 1.9.139
 
 ### Fixed issues
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -2,7 +2,7 @@ package mesosphere.marathon
 package api.v2
 
 import mesosphere.marathon.raml._
-import mesosphere.marathon.state.{AbsolutePathId, FetchUri, PathId, ResourceRole}
+import mesosphere.marathon.state.{AbsolutePathId, FetchUri, PathId}
 import mesosphere.marathon.stream.Implicits._
 import mesosphere.mesos.ResourceMatcher.Role
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -212,8 +212,10 @@ object AppNormalization {
       // This method is only called when [[DeprecatedFeatures.sanitizeAcceptedResourceRoles]] is ON. In this
       // case we not only filter out invalid roles, but also fallback to the default (*) one. Note that acceptedResourceRoles
       // is about reservations and NOT allocation, so the default one is (*) and not (--mesos_role)
-      if (sanitized.isEmpty) Set(ResourceRole.Unreserved)
-      else sanitized
+      if (sanitized.isEmpty)
+        throw NormalizationException(s"acceptedResourceRoles is invalid. Specify either '*', '${effectiveRole}' (the service role), or both.")
+      else
+        sanitized
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -213,7 +213,9 @@ object AppNormalization {
       // case we not only filter out invalid roles, but also fallback to the default (*) one. Note that acceptedResourceRoles
       // is about reservations and NOT allocation, so the default one is (*) and not (--mesos_role)
       if (sanitized.isEmpty)
-        throw NormalizationException(s"acceptedResourceRoles is invalid. Valid values are ${validAcceptedResourceRoleValues(effectiveRole)}.")
+        throw NormalizationException(
+          s"acceptedResourceRoles is invalid. Valid values are ${validAcceptedResourceRoleValues(effectiveRole)}."
+        )
       else
         sanitized
     }

--- a/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
+++ b/src/main/scala/mesosphere/marathon/api/v2/AppNormalization.scala
@@ -213,10 +213,17 @@ object AppNormalization {
       // case we not only filter out invalid roles, but also fallback to the default (*) one. Note that acceptedResourceRoles
       // is about reservations and NOT allocation, so the default one is (*) and not (--mesos_role)
       if (sanitized.isEmpty)
-        throw NormalizationException(s"acceptedResourceRoles is invalid. Specify either '*', '${effectiveRole}' (the service role), or both.")
+        throw NormalizationException(s"acceptedResourceRoles is invalid. Valid values are ${validAcceptedResourceRoleValues(effectiveRole)}.")
       else
         sanitized
     }
+  }
+
+  def validAcceptedResourceRoleValues(serviceRole: String) = {
+    if (serviceRole == "*")
+      """["*"]"""
+    else
+      s"""["*"], ["${serviceRole}"], or ["*", "${serviceRole}"]"""
   }
 
   def maybeDropPortMappings(c: Container, networks: Seq[Network]): Container =

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2616,10 +2616,7 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
     ) {
 
       Given("An app with an unknown acceptedResourceRole")
-      val app = App(
-        id = "/app-with-accepted-unknown-mesos-role",
-        cmd = Some("cmd"),
-        acceptedResourceRoles = Some(Set("customMesosRole")))
+      val app = App(id = "/app-with-accepted-unknown-mesos-role", cmd = Some("cmd"), acceptedResourceRoles = Some(Set("*", "customMesosRole")))
 
       val (body, _) = prepareApp(app, groupManager, validate = false)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -2611,12 +2611,15 @@ class AppsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest {
       }
     }
 
-    "Create an app in root with acceptedResourceRoles = customMesosRole and sanitizeAcceptedResourceRoles = true" in new Fixture(
+    "Create an app in root with acceptedResourceRoles = *,customMesosRole and sanitizeAcceptedResourceRoles = true" in new Fixture(
       configArgs = Seq("--deprecated_features", "sanitize_accepted_resource_roles")
     ) {
 
       Given("An app with an unknown acceptedResourceRole")
-      val app = App(id = "/app-with-accepted-unknown-mesos-role", cmd = Some("cmd"), acceptedResourceRoles = Some(Set("customMesosRole")))
+      val app = App(
+        id = "/app-with-accepted-unknown-mesos-role",
+        cmd = Some("cmd"),
+        acceptedResourceRoles = Some(Set("customMesosRole")))
 
       val (body, _) = prepareApp(app, groupManager, validate = false)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -213,8 +213,8 @@ class AppDefinitionFormatsTest extends UnitTest with HealthCheckFormats with Mat
       appDef.acceptedResourceRoles should equal(Set(ResourceRole.Unreserved))
     }
 
-    "FromJSON should is sanitized when 'acceptedResourceRoles' is defined but empty" in {
-      val json = Json.parse(""" { "id": "test", "cmd": "foo", "acceptedResourceRoles": [] }""")
+    "FromJSON should is sanitized when 'acceptedResourceRoles' is defined but contains an invalid role" in {
+      val json = Json.parse(""" { "id": "test", "cmd": "foo", "acceptedResourceRoles": ["*", "invalid"] }""")
       val appDef = normalizeAndConvert(json.as[raml.App])
       appDef.acceptedResourceRoles should equal(Set(ResourceRole.Unreserved))
     }

--- a/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/AppDefinitionFormatsTest.scala
@@ -213,7 +213,7 @@ class AppDefinitionFormatsTest extends UnitTest with HealthCheckFormats with Mat
       appDef.acceptedResourceRoles should equal(Set(ResourceRole.Unreserved))
     }
 
-    "FromJSON should is sanitized when 'acceptedResourceRoles' is defined but contains an invalid role" in {
+    "FromJSON should be sanitized when 'acceptedResourceRoles' is defined but contains an invalid role" in {
       val json = Json.parse(""" { "id": "test", "cmd": "foo", "acceptedResourceRoles": ["*", "invalid"] }""")
       val appDef = normalizeAndConvert(json.as[raml.App])
       appDef.acceptedResourceRoles should equal(Set(ResourceRole.Unreserved))

--- a/src/test/scala/mesosphere/marathon/api/v2/normalization/AppNormalizationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/normalization/AppNormalizationTest.scala
@@ -730,7 +730,7 @@ class AppNormalizationTest extends UnitTest with Inside {
           `without-*-role`.normalize(configuredNormalizer).acceptedResourceRoles.value should be(Set("*"))
         })) {
           case Failure(ex: NormalizationException) =>
-            ex.msg shouldBe "acceptedResourceRoles is invalid. Specify either '*', 'default_role' (the service role), or both."
+            ex.msg shouldBe """acceptedResourceRoles is invalid. Valid values are ["*"], ["default_role"], or ["*", "default_role"]."""
         }
       }
 


### PR DESCRIPTION
In this change, we reject an acceptedResourceRoles value that would
result in an empty array, rather than substitute it with a default
value. This will reduce confusion when a user unknowingly is creating a
service as the group role and tries to launch the service in a
statically reserved reservation.

JIRA Issues: MARATHON-8748
