### PR TITLE
Remove blocking calls from instance tracker.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/InstanceTracker.scala
@@ -69,7 +69,6 @@ trait InstanceTracker extends StrictLogging {
 
   def countActiveSpecInstances(appId: AbsolutePathId): Future[Int]
 
-  def hasSpecInstancesSync(appId: AbsolutePathId): Boolean
   def hasSpecInstances(appId: AbsolutePathId)(implicit ec: ExecutionContext): Future[Boolean]
 
   /** Process an InstanceUpdateOperation and propagate its result. */

--- a/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/tracker/impl/InstanceTrackerDelegate.scala
@@ -58,7 +58,6 @@ private[marathon] class InstanceTrackerDelegate(
     specInstances(appId).map(_.count(instance => instance.isActive))
   }
 
-  override def hasSpecInstancesSync(appId: AbsolutePathId): Boolean = specInstancesSync(appId).nonEmpty
   override def hasSpecInstances(appId: AbsolutePathId)(implicit ec: ExecutionContext): Future[Boolean] =
     specInstances(appId).map(_.nonEmpty)
 

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceTrackerImplTest.scala
@@ -106,10 +106,6 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
       testAppInstances should have size (3)
     }
 
-    "Contains" in new Fixture {
-      testContains(_.hasSpecInstancesSync(_))
-    }
-
     "Contains Async" in new Fixture {
       testContains(_.hasSpecInstances(_).futureValue)
     }
@@ -159,7 +155,7 @@ class InstanceTrackerImplTest extends AkkaUnitTest {
       state.ids().runWith(EnrichedSink.set).futureValue should not contain (sampleInstance.instanceId)
 
       // APP SHUTDOWN
-      assert(!instanceTracker.hasSpecInstancesSync(TEST_APP_NAME), "App was not removed")
+      assert(!instanceTracker.hasSpecInstances(TEST_APP_NAME).futureValue, "App was not removed")
 
       // ERRONEOUS MESSAGE, TASK DOES NOT EXIST ANYMORE
       val lostStatus = makeTaskStatus(sampleInstance, TaskState.TASK_LOST)


### PR DESCRIPTION
Summary:
Blocking calls can cause thread starvation in actors. We want to
discourage this behavior by remove the last blocking calls from the
instance tracker.

Outstanding Calls
- [ ] `specInstancesSync`
- [ ] `instancesBySpecSync` 