### PR TITLE
Remove `REASON_CONTAINER_MEMORY_REQUEST_EXCEEDED`.

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
+++ b/src/main/scala/mesosphere/marathon/core/task/update/impl/TaskStatusUpdateProcessorImpl.scala
@@ -63,8 +63,6 @@ class TaskStatusUpdateProcessorImpl @Inject() (
     (status.getReason) match {
       case MesosProtos.TaskStatus.Reason.REASON_CONTAINER_LIMITATION_MEMORY =>
         oomKilledTasksExceededLimits.increment()
-      case MesosProtos.TaskStatus.Reason.REASON_CONTAINER_MEMORY_REQUEST_EXCEEDED =>
-        oomKilledTasksWithinLimits.increment()
       case _ =>
     }
 


### PR DESCRIPTION
Summary:
`REASON_CONTAINER_MEMORY_REQUEST_EXCEEDED` was removed before the
actually Mesos 1.10.0 release. Marathon was depending on a snapshot
release.
