### PR TITLE
Always release lock after scale check.

### DIFF
--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -196,7 +196,7 @@ class MarathonSchedulerActor private (
       case DeploymentFailed(plan, reason) =>
         deploymentFailed(plan, reason)
 
-      case RunSpecScaled(id) =>
+      case RunSpecScaled(id) => () // The lock is released via RemoveLocks.
       case msg => logger.warn(s"Received unexpected message from ${sender()}: $msg")
     }
 

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -237,7 +237,7 @@ class MarathonSchedulerActor private (
     // Only remove if we are at the latest lock version. Eg let's say we have two scale events for
     // app /foo after another. The first scale check locks with version 1. The seconds will lock
     // with version 2 after the lock for v1 was released. This check will then prevent that a delayed
-    // duplicated lock release for v1 will not release v2.
+    // duplicated lock release for v1 will release v2.
     if (lockedRunSpecs.get(runSpecId).contains(lockVersion)) {
       lockedRunSpecs.remove(runSpecId)
       logger.debug(

--- a/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
+++ b/src/main/scala/mesosphere/marathon/MarathonSchedulerActor.scala
@@ -197,7 +197,6 @@ class MarathonSchedulerActor private (
         deploymentFailed(plan, reason)
 
       case RunSpecScaled(id) =>
-
       case msg => logger.warn(s"Received unexpected message from ${sender()}: $msg")
     }
 
@@ -231,9 +230,10 @@ class MarathonSchedulerActor private (
     conflicts.isEmpty
   }
 
-  def removeLocks(runSpecIds: Iterable[AbsolutePathId], lockVersion: Long): Unit = runSpecIds.foreach { runSpecId => removeLock(runSpecId, lockVersion)}
+  def removeLocks(runSpecIds: Iterable[AbsolutePathId], lockVersion: Long): Unit =
+    runSpecIds.foreach { runSpecId => removeLock(runSpecId, lockVersion) }
   def removeLock(runSpecId: AbsolutePathId, lockVersion: Long): Unit = {
-    if (lockedRunSpecs.get(runSpecId).exists( _ == lockVersion)) {
+    if (lockedRunSpecs.get(runSpecId).exists(_ == lockVersion)) {
       val locks = lockedRunSpecs - runSpecId
       logger.debug(s"Removed lock for run spec: id=$runSpecId locks=$locks lockedRunSpec=$lockedRunSpecs")
     }


### PR DESCRIPTION
Summary:
`MarathonScheuduleActor` would not release the lock on a run spec if the
scale check for the lock run spec failed.

A scale attempt can fail when the instance of a run spec is removed
before we try to set its goal.

JIRA issues: MARATHON-8758