### PR TITLE
Allow GROUP_BY to preemptively scale up

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
+++ b/src/main/scala/mesosphere/marathon/core/instance/Instance.scala
@@ -12,7 +12,6 @@ import mesosphere.marathon.state.Role
 import mesosphere.marathon.state.{PathId, Timestamp, UnreachableDisabled, UnreachableEnabled, UnreachableStrategy, _}
 import scala.jdk.CollectionConverters._
 import mesosphere.marathon.tasks.OfferUtil
-import mesosphere.mesos.Placed
 import org.apache._
 import org.apache.mesos.Protos.Attribute
 import play.api.libs.functional.syntax._
@@ -44,7 +43,7 @@ case class Instance(
     runSpec: RunSpec,
     reservation: Option[Reservation],
     role: Role
-) extends Placed {
+) {
 
   def runSpecId: AbsolutePathId = runSpec.id
 
@@ -76,13 +75,13 @@ case class Instance(
 
   def hasReservation: Boolean = reservation.isDefined
 
-  override def hostname: Option[String] = agentInfo.map(_.host)
+  def hostname: Option[String] = agentInfo.map(_.host)
 
-  override def attributes: Seq[Attribute] = agentInfo.map(_.attributes).getOrElse(Seq.empty)
+  def attributes: Seq[Attribute] = agentInfo.map(_.attributes).getOrElse(Seq.empty)
 
-  override def zone: Option[String] = agentInfo.flatMap(_.zone)
+  def zone: Option[String] = agentInfo.flatMap(_.zone)
 
-  override def region: Option[String] = agentInfo.flatMap(_.region)
+  def region: Option[String] = agentInfo.flatMap(_.region)
 
   /**
     * Factory method for creating provisioned instance from Scheduled instance

--- a/tools/elk/lib/dependencies.sc
+++ b/tools/elk/lib/dependencies.sc
@@ -1,1 +1,1 @@
-import $ivy.`com.typesafe.akka::akka-stream:2.5.7`
+import $ivy.`com.typesafe.akka::akka-stream:2.6.3`


### PR DESCRIPTION
Previously, GROUP_BY would evenly assign instances to each group, keeping the groups within 1 instance count from each other. When placing 10 instances across three groups, Marathon would require 1 instance to placed in each group A, B and C before placing the 2nd instance, and so-on. With the change, Marathon will allow placing 4 instances in group A, even if no instances have been placed in B or C. This helps prevent prevent rolling deployments from becoming blocked when resources are used to near capacity, as the kill-order will not kill instances evenly across groups.

JIRA Issues: MARATHON-8752