### PR TITLE
Add aventer to the list of companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Across all installations Marathon is managing applications on more than 100,000 
 * [Artirix](http://www.artirix.com/)
 * [Arukas](https://arukas.io/)
 * [Avast](https://www.avast.com/)
+* [AVENTER](https://www.aventer.biz/)
 * [bol.com](https://www.bol.com/)
 * [Brand24](https://brand24.com/)
 * [Branding Brand](http://www.brandingbrand.com/)


### PR DESCRIPTION
Add new company who is using marathon and mesos in production.