### PR TITLE
Fix grace period after kill for health check failure

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/health/Health.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/Health.scala
@@ -20,13 +20,13 @@ case class Health(
 
   def update(result: HealthResult): Health =
     result match {
-      case Healthy(_, _, time, _) =>
+      case Healthy(_, _, _, time, _) =>
         copy(
           firstSuccess = firstSuccess.orElse(Some(time)),
           lastSuccess = Some(time),
           consecutiveFailures = 0
         )
-      case Unhealthy(_, _, cause, time, _) =>
+      case Unhealthy(_, _, _, cause, time, _) =>
         copy(
           lastFailure = Some(time),
           lastFailureCause = Some(cause),

--- a/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
+++ b/src/main/scala/mesosphere/marathon/core/health/HealthResult.scala
@@ -2,20 +2,23 @@ package mesosphere.marathon
 package core.health
 
 import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.state.Timestamp
 
 sealed trait HealthResult {
   def instanceId: Instance.Id
+  def taskId: Task.Id
   def version: Timestamp
   def time: Timestamp
   def publishEvent: Boolean
 }
 
-case class Healthy(instanceId: Instance.Id, version: Timestamp, time: Timestamp = Timestamp.now(), publishEvent: Boolean = true)
+case class Healthy(instanceId: Instance.Id, taskId: Task.Id, version: Timestamp, time: Timestamp = Timestamp.now(), publishEvent: Boolean = true)
     extends HealthResult
 
 case class Unhealthy(
     instanceId: Instance.Id,
+    taskId: Task.Id,
     version: Timestamp,
     cause: String,
     time: Timestamp = Timestamp.now(),
@@ -26,5 +29,5 @@ case class Unhealthy(
   * Representing an ignored HTTP response code (see [[MarathonHttpHealthCheck.ignoreHttp1xx]]. Will not update the
   * health check state and not be published.
   */
-case class Ignored(instanceId: Instance.Id, version: Timestamp, time: Timestamp = Timestamp.now(), publishEvent: Boolean = false)
+case class Ignored(instanceId: Instance.Id, taskId: Task.Id, version: Timestamp, time: Timestamp = Timestamp.now(), publishEvent: Boolean = false)
     extends HealthResult

--- a/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/health/impl/HealthCheckActorTest.scala
@@ -45,7 +45,7 @@ class HealthCheckActorTest extends AkkaUnitTest {
     val healthCheckWorkerHub: Sink[(AppDefinition, Instance, MarathonHealthCheck, ActorRef), NotUsed] =
       MergeHub
         .source[(AppDefinition, Instance, MarathonHealthCheck, ActorRef)](1)
-        .map { case (_, instance, _, ref) => ref ! Healthy(instance.instanceId, Timestamp.now()) }
+        .map { case (_, instance, _, ref) => ref ! Healthy(instance.instanceId, instance.appTask.taskId, Timestamp.now()) }
         .to(Sink.ignore)
         .run()
 


### PR DESCRIPTION
Following the [change of task id / instance id format](https://jira.d2iq.com/browse/MARATHON-8140), task health status
was not properly tracked because bound to the same instance id after
successive kills for health check failure. This fix propose to address
the issue by tracking health status by task id to ensure it to cleaned
each time a task is terminated, whatever the reason.

JIRA Issues: [MARATHON-8745](https://jira.d2iq.com/browse/MARATHON-8745)

[MARATHON-8745]: https://d2iq.atlassian.net/browse/MARATHON-8745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ