### PR TITLE
Don't set the readonly property for CSI volumes

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/CSIProvider.scala
+++ b/src/main/scala/mesosphere/marathon/core/externalvolume/impl/providers/CSIProvider.scala
@@ -27,7 +27,6 @@ private[externalvolume] case object CSIProvider extends ExternalVolumeProvider {
           val staticProvisioning = CSIVolume.StaticProvisioning
             .newBuilder()
             .setVolumeId(info.name)
-            .setReadonly(mount.readOnly)
             .setVolumeCapability(ExternalVolumeInfoSerializer.toProtoVolumeCapability(info))
             .putAllNodeStageSecrets(info.nodeStageSecret.view.mapValues(SecretSerializer.toSecretReference).toMap.asJava)
             .putAllNodePublishSecrets(info.nodePublishSecret.view.mapValues(SecretSerializer.toSecretReference).toMap.asJava)

--- a/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/CSIProviderVolumeToUnifiedMesosVolumeTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/externalvolume/impl/providers/CSIProviderVolumeToUnifiedMesosVolumeTest.scala
@@ -29,8 +29,6 @@ class CSIProviderVolumeToUnifiedMesosVolumeTest extends UnitTest {
     csiProto.getPluginName shouldBe volInfo.pluginName
     csiProto.getStaticProvisioning.getVolumeId shouldBe volInfo.name
 
-    csiProto.getStaticProvisioning.getReadonly shouldBe true withClue ("readonly-ness should be set by Volume mount mode")
-
     val capability = csiProto.getStaticProvisioning.getVolumeCapability
     capability.getAccessMode.getMode shouldBe MesosCSIVolume.VolumeCapability.AccessMode.Mode.SINGLE_NODE_WRITER
 


### PR DESCRIPTION
This field was redundant and is removed from the Mesos API