### PR TITLE
Set mesos offer constraints based on app constraints and instances state

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/LaunchQueueModule.scala
@@ -89,6 +89,8 @@ class LaunchQueueModule(
       initialFrameworkInfo,
       reviveConfig.mesosRole(),
       reviveConfig.minReviveOffersInterval().millis,
+      reviveConfig.useOfferConstraints(),
+      reviveConfig.minOfferConstraintsUpdateInterval().millis,
       instanceTracker.instanceUpdates,
       rateLimiterUpdates,
       driverHolder,

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
@@ -26,7 +26,8 @@ trait ReviveOffersConfig extends ScallopConf {
     "mesos_offer_constraints",
     default = Some(false),
     noshort = true,
-    descrYes = "Specify offer constraints to Mesos to avoid receiving some of unneeded offers (experimental).",
+    descrYes =
+      "Send offer constraints to Mesos to reduce the number of offers Marathon needs to decline due to placement constraints (experimental).",
     descrNo = "(Default) Mesos will send unconstrained offers to Marathon.",
     prefix = "disable_"
   )

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
@@ -21,4 +21,19 @@ trait ReviveOffersConfig extends ScallopConf {
     descrNo = "(Default) Offers will be continually declined for declineOfferDuration.",
     prefix = "disable_"
   )
+
+  lazy val useOfferConstraints = toggle(
+    "use_offer_constraints",
+    default = Some(false),
+    noshort = true,
+    descrYes = "Specify offer constraints to Mesos to avoid receiving some of unneeded offers (experimental).",
+    descrNo = "(Default) Mesos will send unconstrained offers to Marathon.",
+    prefix = "disable_"
+  )
+
+  lazy val minOfferConstraintsUpdateInterval = opt[Long](
+    "min_offer_constraints_update_interval",
+    descr = "Avoid updating Mesos offer constraints more often than this interval (ms). Has no effect without `--use_offer_constraints`.",
+    default = Some(1000)
+  )
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/ReviveOffersConfig.scala
@@ -23,7 +23,7 @@ trait ReviveOffersConfig extends ScallopConf {
   )
 
   lazy val useOfferConstraints = toggle(
-    "use_offer_constraints",
+    "mesos_offer_constraints",
     default = Some(false),
     noshort = true,
     descrYes = "Specify offer constraints to Mesos to avoid receiving some of unneeded offers (experimental).",
@@ -32,8 +32,8 @@ trait ReviveOffersConfig extends ScallopConf {
   )
 
   lazy val minOfferConstraintsUpdateInterval = opt[Long](
-    "min_offer_constraints_update_interval",
-    descr = "Avoid updating Mesos offer constraints more often than this interval (ms). Has no effect without `--use_offer_constraints`.",
+    "min_mesos_offer_constraints_update_interval",
+    descr = "Avoid updating Mesos offer constraints more often than this interval (ms). Has no effect without `--mesos_offer_constraints`.",
     default = Some(1000)
   )
 }

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/OfferConstraints.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/OfferConstraints.scala
@@ -1,0 +1,284 @@
+package mesosphere.marathon
+package core.launchqueue.impl
+
+import com.typesafe.scalalogging.StrictLogging
+import mesosphere.marathon.core.instance.update.InstancesSnapshot
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.launchqueue.impl.ReviveOffersState.Role
+import mesosphere.marathon.state.RunSpecConfigRef
+
+import mesosphere.marathon.Protos.Constraint
+import mesosphere.marathon.Protos.Constraint.Operator
+import mesosphere.mesos.Constraints
+
+import org.apache.mesos.scheduler.Protos.{OfferConstraints => MesosOfferConstraints}
+import org.apache.mesos.scheduler.Protos.{AttributeConstraint => MesosAttributeConstraint}
+
+object OfferConstraints {
+  // Intermediate representation of a Mesos attribute constraint predicate.
+  sealed trait Predicate;
+
+  case class Exists() extends Predicate
+  case class NotExists() extends Predicate
+  case class TextEquals(value: String) extends Predicate
+  case class TextNotEquals(value: String) extends Predicate
+  case class TextMatches(regex: String) extends Predicate
+  case class TextNotMatches(regex: String) extends Predicate
+
+  private def buildPredicateProto(predicate: Predicate, builder: MesosAttributeConstraint.Predicate.Builder): Unit =
+    predicate match {
+      case Exists() => builder.getExistsBuilder();
+      case NotExists() => builder.getNotExistsBuilder();
+      case TextEquals(value) => builder.getTextEqualsBuilder.setValue(value);
+      case TextNotEquals(value) => builder.getTextNotEqualsBuilder.setValue(value);
+      case TextMatches(regex) => builder.getTextMatchesBuilder.setRegex(regex);
+      case TextNotMatches(regex) => builder.getTextNotMatchesBuilder.setRegex(regex);
+    }
+
+  // Intermediate representation of a Mesos attribute constraint.
+  case class AttributeConstraint(field: String, predicate: Predicate) {
+    def buildProto(builder: MesosAttributeConstraint.Builder): Unit = {
+      Constraints.buildSelectorProto(field, builder.getSelectorBuilder());
+      buildPredicateProto(predicate, builder.getPredicateBuilder());
+    }
+  }
+
+  private def getAgnosticConstraint(constraint: Constraint): AttributeConstraint = {
+    val predicate: Predicate = constraint.getOperator match {
+      case Operator.LIKE => TextMatches(constraint.getValue)
+      case Operator.UNLIKE => TextNotMatches(constraint.getValue)
+      case Operator.UNIQUE => Exists()
+      case Operator.GROUP_BY => Exists()
+      case Operator.MAX_PER => Exists()
+      case Operator.CLUSTER => if (constraint.getValue.isEmpty) Exists() else TextEquals(constraint.getValue)
+      case Operator.IS => TextEquals(constraint.getValue)
+    }
+
+    AttributeConstraint(constraint.getField, predicate)
+  }
+
+  /*
+   * An attribute constraint that is brought to life by existence of
+   * an active instance under app's constraint, and is applied only as soon as
+   * the app has enough active instances inducing this constraint.
+   * This is used to translate GROUP_BY/UNIQUE/MAX_PER into offer constraints.
+   *
+   * Example: consider an app with a constraint "foo:MAX_PER:2".
+   * After the first launch on an agent with an attribute "foo:bar",
+   * the app has a single instance that set
+   * `Induced(AttributeConstraint("foo", TextNotEquals("bar")), 2)`
+   * which is not applied.
+   * After the second launch on an agent with an attribute "foo:bar",
+   * the app has two such instances, hence
+   * `AttributeConstraint("foo", TextNotEquals("bar"))`
+   * is applied from then onwards.
+   */
+  case class Induced(attributeConstraint: AttributeConstraint, minInstanceCountToApply: Int)
+
+  /*
+   * Returns offer constraints that should be set for further offers
+   * due to already existing Instance for the RunSpec in question.
+   */
+  private def getInducedConstraint(constraint: Constraint, placed: Instance): Option[Induced] = {
+
+    def makeInduced(predicate: Predicate, minInstanceCountToApply: Int): Some[Induced] =
+      Some(Induced(AttributeConstraint(constraint.getField, predicate), minInstanceCountToApply))
+
+    val placedValueReader = Constraints.readerForField(constraint.getField)._2
+
+    placedValueReader(placed) match {
+      case Some(value) =>
+        constraint.getOperator match {
+          case Operator.IS => None
+          case Operator.LIKE => None
+          case Operator.UNLIKE => None
+          case Operator.CLUSTER => makeInduced(TextEquals(value), 1)
+          case Operator.UNIQUE => makeInduced(TextNotEquals(value), 1)
+          case Operator.MAX_PER => makeInduced(TextNotEquals(value), constraint.getValue.toInt)
+
+          // TODO: Support induced constraints for GROUP_BY
+          case Operator.GROUP_BY => None
+
+        }
+      // This covers the case of a scheduled instance
+      case None => None
+    }
+  }
+
+  private def getInducedByInstance(instance: Instance): Set[Induced] =
+    if (!instance.isActive)
+      Set.empty
+    else
+      instance.runSpec.constraints
+        .map(getInducedConstraint(_, instance))
+        .flatMap(identity)
+        .to(Set)
+
+  case class Group(constraints: Set[AttributeConstraint]) {
+    def buildProto(builder: MesosOfferConstraints.RoleConstraints.Group.Builder): Unit = {
+      constraints.foreach { _.buildProto(builder.addAttributeConstraintsBuilder()) }
+    }
+  }
+
+  object Group { def empty = Group(Set.empty) }
+
+  case class RunSpecState(
+      role: Role,
+      constraints: Set[Constraint],
+      induced: Map[Instance.Id, Set[Induced]],
+      scheduledInstances: Set[Instance.Id],
+      instancesToUnreserve: Set[Instance.Id]
+  ) {
+
+    def isEmpty(): Boolean = induced.isEmpty && scheduledInstances.isEmpty && instancesToUnreserve.isEmpty
+
+    def willChangeOnUpdate(instance: Instance): Boolean =
+      role != instance.runSpec.role ||
+        constraints != instance.runSpec.constraints ||
+        induced.getOrElse(instance.instanceId, Set.empty) != getInducedByInstance(instance) ||
+        scheduledInstances.contains(instance.instanceId) != instance.isScheduled ||
+        instancesToUnreserve(instance.instanceId) != ReviveOffersState.shouldUnreserve(instance)
+
+    def withInstanceAddedOrUpdated(instance: Instance): RunSpecState = {
+      val id = instance.instanceId
+      val inducedByInstance = getInducedByInstance(instance)
+
+      copy(
+        role = instance.runSpec.role,
+        constraints = instance.runSpec.constraints,
+        induced = if (inducedByInstance.isEmpty) induced - id else induced + (id -> inducedByInstance),
+        scheduledInstances = if (instance.isScheduled) scheduledInstances + id else scheduledInstances - id,
+        instancesToUnreserve = if (ReviveOffersState.shouldUnreserve(instance)) instancesToUnreserve + id else instancesToUnreserve - id
+      )
+    }
+
+    def withInstanceDeleted(instance: Instance): RunSpecState = {
+      val newInduced = induced - instance.instanceId
+      val newScheduledInstances = scheduledInstances - instance.instanceId
+      val newInstancesToUnreserve = instancesToUnreserve - instance.instanceId
+      if (newInduced.isEmpty && newScheduledInstances.isEmpty && newInstancesToUnreserve.isEmpty)
+        RunSpecState.empty
+      else
+        copy(role, constraints, newInduced, newScheduledInstances, newInstancesToUnreserve)
+    }
+
+    def toGroup(): Option[Group] =
+      if (!instancesToUnreserve.isEmpty)
+        Some(Group.empty)
+      else if (scheduledInstances.isEmpty)
+        None
+      else {
+        val allInducedConstraints = induced.values.flatten
+        val effectiveInducedConstraints = allInducedConstraints
+          .groupBy(identity)
+          .valuesIterator
+          .map { (induced: Iterable[Induced]) =>
+            if (induced.size >= induced.head.minInstanceCountToApply)
+              Some(induced.head.attributeConstraint)
+            else None
+          }
+          .flatten
+
+        Some(Group((effectiveInducedConstraints ++ constraints.map(getAgnosticConstraint)).to(Set)))
+      }
+  }
+
+  object RunSpecState {
+    def empty = RunSpecState("", Set.empty, Map.empty, Set.empty, Set.empty)
+
+    def fromSnapshotInstances(instances: Iterable[Instance]): RunSpecState =
+      RunSpecState(
+        role = instances.head.runSpec.role,
+        constraints = instances.head.runSpec.constraints,
+        induced = instances.flatMap { instance =>
+          {
+            val inducedByInstance = getInducedByInstance(instance)
+            if (inducedByInstance.isEmpty) None else Some(instance.instanceId -> inducedByInstance)
+          }
+        }.to(Map),
+        scheduledInstances = instances.flatMap { instance =>
+          if (instance.isScheduled) Some(instance.instanceId) else None
+        }.to(Set),
+        instancesToUnreserve = instances.flatMap { instance =>
+          if (ReviveOffersState.shouldUnreserve(instance)) Some(instance.instanceId) else None
+        }.to(Set)
+      )
+  }
+
+  case class RoleState(groupsByRole: Map[Role, Set[Group]]) {
+    def toProto(susbcribedRoles: Set[Role]): MesosOfferConstraints = {
+      val builder = MesosOfferConstraints.newBuilder();
+
+      groupsByRole.foreach {
+        case (role, groups) =>
+          if (susbcribedRoles.contains(role)) {
+            val roleConstraintsBuilder =
+              MesosOfferConstraints.RoleConstraints.newBuilder()
+
+            groups.foreach { _.buildProto(roleConstraintsBuilder.addGroupsBuilder()) }
+            builder.putRoleConstraints(role, roleConstraintsBuilder.build())
+          } else {}
+      }
+
+      builder.build()
+    }
+  }
+
+  object RoleState { val empty = RoleState(Map.empty) }
+
+  case class State(state: Map[RunSpecConfigRef, RunSpecState]) extends StrictLogging {
+
+    def withSnapshot(snapshot: InstancesSnapshot): State =
+      State(
+        snapshot.instances
+          .groupBy(_.runSpec.configRef)
+          .view
+          .mapValues(RunSpecState.fromSnapshotInstances)
+          .toMap
+      )
+
+    def withInstanceAddedOrUpdated(instance: Instance): State = {
+      val configRef = instance.runSpec.configRef
+      val runSpecState: RunSpecState = state.getOrElse(configRef, RunSpecState.empty)
+
+      if (runSpecState.willChangeOnUpdate(instance))
+        copy(state + (configRef -> runSpecState.withInstanceAddedOrUpdated(instance)))
+      else
+        this
+    }
+
+    def withInstanceDeleted(instance: Instance): State = {
+      val configRef = instance.runSpec.configRef
+      val newRunSpecState = state
+        .getOrElse(configRef, RunSpecState.empty)
+        .withInstanceDeleted(instance)
+
+      copy(
+        if (newRunSpecState.isEmpty())
+          state - configRef
+        else
+          state + (configRef -> newRunSpecState)
+      )
+    }
+
+    lazy val roleState = RoleState({
+      val runSpecStatesByRole = state.values.groupBy(_.role)
+
+      runSpecStatesByRole.flatMap {
+        case (role: Role, runSpecStates: Iterable[RunSpecState]) => {
+          val groups: Set[Group] = runSpecStates.flatMap(_.toGroup).toSet
+          val roleShouldBeSuppressed = groups.isEmpty
+          val roleNeedsUnconstrainedOffers = groups.contains(Group.empty)
+
+          // NOTE: Decision to suppress a role is made independently by the ReviveOffersState.
+          if (roleShouldBeSuppressed || roleNeedsUnconstrainedOffers)
+            None
+          else
+            Some(role -> groups)
+        }
+      }
+    })
+  }
+
+  object State { val empty = State(Map.empty) }
+}

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/OfferConstraintsStreamLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/OfferConstraintsStreamLogic.scala
@@ -1,0 +1,76 @@
+package mesosphere.marathon
+package core.launchqueue.impl
+
+import akka.NotUsed
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Flow, Source}
+import com.typesafe.scalalogging.StrictLogging
+
+import mesosphere.marathon.core.instance.update.{InstanceChangeOrSnapshot, InstanceDeleted, InstanceUpdated, InstancesSnapshot}
+import mesosphere.marathon.core.launchqueue.impl.OfferConstraints
+import mesosphere.marathon.core.launchqueue.impl.ReviveOffersStreamLogic.{IssueRevive, RoleDirective, UpdateFramework}
+
+import mesosphere.marathon.stream.RateLimiterFlow
+
+import scala.concurrent.duration.FiniteDuration
+
+object OfferConstraintsStreamLogic extends StrictLogging {
+
+  // Generates rate-limited offer constraint updates from instance updates.
+  def offerConstraintsFlow(minUpdateInterval: FiniteDuration): Flow[InstanceChangeOrSnapshot, OfferConstraints.RoleState, NotUsed] =
+    Flow[InstanceChangeOrSnapshot]
+      .scan(OfferConstraints.State.empty) {
+        case (current, snapshot: InstancesSnapshot) => current.withSnapshot(snapshot)
+        case (current, InstanceUpdated(updated, _, _)) => current.withInstanceAddedOrUpdated(updated)
+        case (current, InstanceDeleted(deleted, _, _)) => current.withInstanceDeleted(deleted)
+      }
+      .buffer(1, OverflowStrategy.dropHead) // While we are back-pressured, we drop older interim frames
+      .via(RateLimiterFlow.apply(minUpdateInterval))
+      .map(_.roleState)
+      .sliding(2)
+      .map {
+        case Seq(previous, current) =>
+          if (previous == current) None else Some(current)
+        case _ =>
+          logger.info(s"Offer constraints flow is terminating")
+          None
+      }
+      .collect { case Some(state) => state }
+      .map { state => { logger.info(s"Changing offer constraints to: ${state}"); state } }
+
+  /**
+    * Emits each RoleDirective together with the latest offer constraints state.
+    * Empty constraints are used if no constraints have been generated yet.
+    *
+    * On offer constraints update, RE-EMITS the latest UpdateFramework directive
+    * with the new constraints. Before the first UpdateFramework, doesn't emit
+    * anything on constraints updates.
+    *
+   * @param minUpdateInterval - The maximum rate at which we allow offer constraint updates to be emitted.
+    */
+  def offerConstraintsInjectionFlow(
+      offerConstraintsSource: Source[OfferConstraints.RoleState, NotUsed]
+  ): Flow[RoleDirective, (RoleDirective, OfferConstraints.RoleState), NotUsed] = {
+
+    case class Latest(updateFramework: Option[UpdateFramework], constraints: OfferConstraints.RoleState, directive: Option[RoleDirective]) {
+
+      def withDirectiveOrConstraints(directiveOrConstraints: Either[RoleDirective, OfferConstraints.RoleState]): Latest =
+        directiveOrConstraints match {
+          case Left(issueRevive: IssueRevive) =>
+            copy(directive = Some(issueRevive))
+          case Left(newUpdateFramework: UpdateFramework) =>
+            copy(updateFramework = Some(newUpdateFramework), directive = Some(newUpdateFramework))
+          case Right(constraints) =>
+            copy(constraints = constraints, directive = updateFramework)
+        }
+    }
+
+    object Latest { def empty = Latest(None, OfferConstraints.RoleState.empty, None) }
+
+    Flow[RoleDirective]
+      .map(Left(_))
+      .merge(offerConstraintsSource.map(Right(_)))
+      .scan(Latest.empty) { (current, element) => current.withDirectiveOrConstraints(element) }
+      .collect { case Latest(_, constraints, Some(directive)) => (directive, constraints) }
+  }
+}

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
@@ -13,6 +13,7 @@ import mesosphere.marathon.core.launchqueue.impl.ReviveOffersStreamLogic.{IssueR
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.metrics.{Counter, Metrics}
 import org.apache.mesos.Protos.FrameworkInfo
+import org.apache.mesos.scheduler.Protos.OfferConstraints
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -87,7 +88,10 @@ class ReviveOffersActor(
             driverHolder.driver.foreach { d =>
               val newInfo = frameworkInfoWithRoles(frameworkInfo, roleState.keys)
               val suppressedRoles = roleState.iterator.collect { case (role, OffersNotWanted) => role }.toSeq
-              d.updateFramework(newInfo, suppressedRoles.asJava)
+              d.updateFramework(
+                  newInfo,
+                  suppressedRoles.asJava,
+                  OfferConstraints.getDefaultInstance())
             }
 
           case IssueRevive(roles) =>

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActor.scala
@@ -89,7 +89,7 @@ class ReviveOffersActor(
             .via(offerConstraintsFlow(minOfferConstraintsUpdateInterval))
         )
       else
-        Flow[RoleDirective].map { (_, OfferConstraints.RoleState.empty) }
+        Flow[RoleDirective].map { (_, OfferConstraints.RoleConstraintState.empty) }
 
     val done: Future[Done] = initialFrameworkInfo.flatMap { frameworkInfo =>
       flattenedInstanceUpdates
@@ -103,7 +103,7 @@ class ReviveOffersActor(
             driverHolder.driver.foreach { d =>
               val newInfo = frameworkInfoWithRoles(frameworkInfo, roleState.keys)
               val suppressedRoles = roleState.iterator.collect { case (role, OffersNotWanted) => role }.toSeq
-              d.updateFramework(newInfo, suppressedRoles.asJava, constraints.toProto(roleState.keySet))
+              d.updateFramework(newInfo, suppressedRoles.asJava, constraints.filterRoles(roleState.keySet).toProto())
             }
 
           case (IssueRevive(roles), _) =>

--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersState.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersState.scala
@@ -4,7 +4,7 @@ package core.launchqueue.impl
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.update.InstancesSnapshot
 import mesosphere.marathon.core.instance.{Goal, Instance}
-import mesosphere.marathon.core.launchqueue.impl.ReviveOffersState.{OffersWantedInfo, OffersWantedReason, Role}
+import mesosphere.marathon.core.launchqueue.impl.ReviveOffersState.{OffersWantedInfo, OffersWantedReason, Role, shouldUnreserve}
 import mesosphere.marathon.core.launchqueue.impl.ReviveOffersStreamLogic.VersionedRoleState
 import mesosphere.marathon.state.RunSpecConfigRef
 
@@ -20,11 +20,6 @@ case class ReviveOffersState(
     activeDelays: Set[RunSpecConfigRef],
     version: Long
 ) extends StrictLogging {
-
-  /** whether the instance has a reservation that should be freed. */
-  private def shouldUnreserve(instance: Instance): Boolean = {
-    instance.reservation.nonEmpty && instance.state.goal == Goal.Decommissioned && instance.state.condition.isTerminal
-  }
 
   private def copyBumpingVersion(
       instancesWantingOffers: Map[Role, Map[Instance.Id, OffersWantedInfo]] = instancesWantingOffers,
@@ -173,6 +168,12 @@ case class ReviveOffersState(
 }
 
 object ReviveOffersState {
+
+  /** whether the instance has a reservation that should be freed. */
+  def shouldUnreserve(instance: Instance): Boolean = {
+    instance.reservation.nonEmpty && instance.state.goal == Goal.Decommissioned && instance.state.condition.isTerminal
+  }
+
   private[impl] type Role = String
   def empty = ReviveOffersState(Map.empty, Set.empty, 0)
 

--- a/src/main/scala/mesosphere/mesos/Constraints.scala
+++ b/src/main/scala/mesosphere/mesos/Constraints.scala
@@ -6,6 +6,8 @@ import mesosphere.marathon.core.instance.Instance
 import mesosphere.marathon.state.RunSpec
 import mesosphere.marathon.tasks.OfferUtil
 import org.apache.mesos.Protos.{Attribute, Offer, Value}
+import org.apache.mesos.scheduler.Protos.{AttributeConstraint => MesosAttributeConstraint}
+import org.apache.mesos.scheduler.Protos.AttributeConstraint.Selector.PseudoattributeType
 
 import scala.collection.immutable.Seq
 import scala.util.Try
@@ -85,6 +87,15 @@ object Constraints extends StrictLogging {
       case `regionField` => regionReader
       case `zoneField` => zoneReader
       case _ => attributeReader(field)
+    }
+
+  // Converts a field string into a Mesos offer constraint attribute selector.
+  def buildSelectorProto(field: String, builder: MesosAttributeConstraint.Selector.Builder): Unit =
+    field match {
+      case "hostname" | `hostnameField` => builder.setPseudoattributeType(PseudoattributeType.HOSTNAME)
+      case `regionField` => builder.setPseudoattributeType(PseudoattributeType.REGION)
+      case `zoneField` => builder.setPseudoattributeType(PseudoattributeType.ZONE)
+      case _ => builder.setAttributeName(field)
     }
 
   // Regular expressions to determine type based on http://mesos.apache.org/documentation/latest/attributes-resources/

--- a/src/test/java/mesosphere/marathon/core/launchqueue/impl/OfferConstraints.scala
+++ b/src/test/java/mesosphere/marathon/core/launchqueue/impl/OfferConstraints.scala
@@ -1,0 +1,119 @@
+package mesosphere.marathon
+package core.launchqueue.impl
+
+import mesosphere.UnitTest
+import mesosphere.marathon.core.instance.{Instance, TestInstanceBuilder}
+import mesosphere.marathon.core.instance.update.{InstancesSnapshot}
+import mesosphere.marathon.state.{AbsolutePathId, AppDefinition}
+import mesosphere.marathon.core.launchqueue.impl.OfferConstraints._
+
+import mesosphere.mesos.protos.TextAttribute
+import mesosphere.mesos.protos.Implicits._
+
+class OfferConstraintsTest extends UnitTest {
+  "OfferConstraints.State" should {
+    "translate LIKE and UNLIKE into TextMatches/TextNotMatches" in {
+      Given("an app with constraints 'foo:LIKE:bar,foo:UNLIKE:baz'")
+      val like = Protos.Constraint.newBuilder
+        .setField("foo")
+        .setOperator(Protos.Constraint.Operator.LIKE)
+        .setValue("bar")
+        .build
+
+      val unlike = Protos.Constraint.newBuilder
+        .setField("foo")
+        .setOperator(Protos.Constraint.Operator.UNLIKE)
+        .setValue("baz")
+        .build
+
+      val runSpec = AppDefinition(id = AbsolutePathId("/app"), constraints = Set(like, unlike), role = "role")
+
+      When("a scheduled instance is added")
+      val state = OfferConstraints.State.empty.withInstanceAddedOrUpdated(Instance.scheduled(runSpec))
+
+      Then("should produce a constraints group containing 'foo TextMatches bar' and 'foo TextNotMatches baz'")
+      state.roleState shouldBe RoleConstraintState(
+        Map(
+          "role" -> Set(
+            ConstraintGroup(Set(AttributeConstraint("foo", TextMatches("bar")), AttributeConstraint("foo", TextNotMatches("baz"))))
+          )
+        )
+      )
+    }
+
+    "not produce any constraints for a role with an unconstrained app that has a scheduled instance" in {
+      Given("two apps, the first one with 'foo:IS:bar' constraint, the second one unconstrained")
+      val constraint = Protos.Constraint.newBuilder
+        .setField("foo")
+        .setOperator(Protos.Constraint.Operator.IS)
+        .setValue("bar")
+        .build
+
+      val runSpec1 = AppDefinition(id = AbsolutePathId("/app/1"), constraints = Set(constraint), role = "role")
+      val runSpec2 = AppDefinition(id = AbsolutePathId("/app/2"), constraints = Set(), role = "role")
+      val scheduled1 = Instance.scheduled(runSpec1)
+      val scheduled2 = Instance.scheduled(runSpec2)
+
+      When("scheduled instances are added for both apps")
+      val initialState = OfferConstraints.State.empty
+        .withInstanceAddedOrUpdated(scheduled1)
+        .withInstanceAddedOrUpdated(scheduled2)
+
+      Then("no constraints should be produced")
+      initialState.roleState shouldBe RoleConstraintState.empty
+
+      When("the instance running update for an unconstrained app is received")
+      val state = initialState.withInstanceAddedOrUpdated(TestInstanceBuilder(scheduled2).addTaskRunning().getInstance())
+
+      Then("a 'foo TextEquals bar constraint' is produced")
+      state.roleState shouldBe RoleConstraintState(Map("role" -> Set(ConstraintGroup(Set(AttributeConstraint("foo", TextEquals("bar")))))))
+    }
+
+    "correctly handle instance state updates for an app with a MAX_PER constraint" in {
+      Given("an agent with an attribute 'foo:bar' and an app with a 'foo:MAX_PER:2' constraint and 3 instances")
+      val agent = Instance.AgentInfo("agent", None, None, None, Seq(TextAttribute("foo", "bar")))
+
+      val constraint = Protos.Constraint.newBuilder
+        .setField("foo")
+        .setOperator(Protos.Constraint.Operator.MAX_PER)
+        .setValue("2")
+        .build
+
+      val runSpec = AppDefinition(id = AbsolutePathId("/app"), constraints = Set(constraint), role = "role")
+
+      val scheduled1 = Instance.scheduled(runSpec)
+      val scheduled2 = Instance.scheduled(runSpec)
+      val scheduled3 = Instance.scheduled(runSpec)
+
+      def running(scheduled: Instance): Instance =
+        TestInstanceBuilder(scheduled).withAgentInfo(agent).addTaskRunning().getInstance()
+
+      When("created from an instance snapshot with a scheduled instances 1, 2 and 3")
+      val state0 = OfferConstraints.State.empty.withSnapshot(InstancesSnapshot(Seq(scheduled1, scheduled2, scheduled3)))
+
+      Then("should result in a single 'foo Exists' constraint")
+      state0.roleState shouldBe RoleConstraintState(Map("role" -> Set(ConstraintGroup(Set(AttributeConstraint("foo", Exists()))))))
+
+      When("presented with the instance 1 running on an agent with an attribute 'foo:bar'")
+      val state1 = state0.withInstanceAddedOrUpdated(running(scheduled1))
+
+      Then("should still result in a single 'foo Exists' constraint")
+      state1.roleState shouldBe RoleConstraintState(Map("role" -> Set(ConstraintGroup(Set(AttributeConstraint("foo", Exists()))))))
+
+      When("presented with the instance 2 running on an agent with an attribute 'foo:bar'")
+      val state2 = state1.withInstanceAddedOrUpdated(running(scheduled2))
+
+      Then("should add a 'foo TextNotEquals bar' constraint")
+      // NOTE: In presence of `foo TextNotEquals`, `foo Exists` is redundant; in principle, we could avoid emitting it.
+      state2.roleState shouldBe RoleConstraintState(
+        Map("role" -> Set(ConstraintGroup(Set(AttributeConstraint("foo", Exists()), AttributeConstraint("foo", TextNotEquals("bar"))))))
+      )
+
+      When("presented with deletion of the instance 3")
+      val state3 = state2.withInstanceDeleted(scheduled3)
+
+      Then("should lift offer constraints (the role needs no offers and should be suppressed instead)")
+      state3.roleState shouldBe RoleConstraintState.empty
+    }
+  }
+}

--- a/src/test/java/mesosphere/marathon/core/launchqueue/impl/OfferConstraintsStreamLogicTest.scala
+++ b/src/test/java/mesosphere/marathon/core/launchqueue/impl/OfferConstraintsStreamLogicTest.scala
@@ -1,0 +1,223 @@
+package mesosphere.marathon
+package core.launchqueue.impl
+
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.core.instance.Instance
+import mesosphere.marathon.core.instance.update.{InstanceChangeOrSnapshot, InstanceUpdated}
+import mesosphere.marathon.core.launchqueue.impl.OfferConstraints.{RoleConstraintState, ConstraintGroup, AttributeConstraint, TextEquals}
+import mesosphere.marathon.core.launchqueue.impl.ReviveOffersStreamLogic.{IssueRevive, RoleDirective, UpdateFramework}
+import mesosphere.marathon.core.launchqueue.impl.OfferConstraintsStreamLogic
+
+import mesosphere.marathon.state.{AbsolutePathId, AppDefinition}
+import org.scalatest.Inside
+
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration._
+
+class OfferConstraintsStreamLogicTest extends AkkaUnitTest with Inside {
+
+  def appTiedToHostname(hostname: String): AppDefinition = {
+    val constraint = Protos.Constraint.newBuilder
+      .setField("hostname")
+      .setOperator(Protos.Constraint.Operator.IS)
+      .setValue(hostname)
+      .build
+
+    AppDefinition(id = AbsolutePathId("/tied/" + hostname), constraints = Set(constraint), role = "role")
+  }
+
+  "OfferConstraintsFlow" should {
+    "combine 3 events changing offer constraints within the throttle window into a single constraints update" in {
+      Given("an OfferConstraintsFlow with a 200 millis minimum update interval")
+      val offerConstraintsFlow = OfferConstraintsStreamLogic.offerConstraintsFlow(200.millis)
+
+      When("an instance update is offered for each of 3 apps with constraints")
+      val inputSourceQueue = Source.queue[InstanceChangeOrSnapshot](16, OverflowStrategy.fail)
+      val outputSinkQueue = Sink.queue[RoleConstraintState]()
+      val (input, output) = inputSourceQueue.via(offerConstraintsFlow).toMat(outputSinkQueue)(Keep.both).run
+
+      Future
+        .sequence(
+          Seq("foo", "bar", "baz").map { hostname => InstanceUpdated(Instance.scheduled(appTiedToHostname(hostname)), None, Nil) }
+            .map(input.offer(_))
+        )
+        .futureValue
+
+      Then("a single offer constraints update is issued")
+      inside(output.pull().futureValue) {
+        case Some(RoleConstraintState(state)) =>
+          state shouldBe Map(
+            "role" -> Set(
+              ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("foo")))),
+              ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("bar")))),
+              ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("baz"))))
+            )
+          )
+      }
+
+      When("the instance updates stream completes")
+      input.complete()
+
+      Then("no further events are emitted")
+      output.pull().futureValue shouldBe None
+    }
+
+    "convert two events changing constraints that are separated by an interval longer than the throttle window into two updates" in {
+      Given("an OfferConstraintsFlow with a 200 millis minimum update interval")
+      val offerConstraintsFlow = OfferConstraintsStreamLogic.offerConstraintsFlow(200.millis)
+
+      When("two app constraints changes are offered and separated by a 300 millis interval")
+
+      val inputSourceQueue = Source.queue[InstanceChangeOrSnapshot](16, OverflowStrategy.fail)
+      val outputSinkQueue = Sink.queue[RoleConstraintState]()
+      val (input, output) = inputSourceQueue
+        .via(Flow[InstanceChangeOrSnapshot].delay(300.millis))
+        .via(offerConstraintsFlow)
+        .toMat(outputSinkQueue)(Keep.both)
+        .run
+
+      Future
+        .sequence(
+          Seq("foo", "bar").map { hostname => InstanceUpdated(Instance.scheduled(appTiedToHostname(hostname)), None, Nil) }
+            .map(input.offer(_))
+        )
+        .futureValue
+
+      Then("an offer constraints update with constraints of the first app is issued")
+      inside(output.pull().futureValue) {
+        case Some(RoleConstraintState(state)) =>
+          state shouldBe Map("role" -> Set(ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("foo"))))))
+      }
+
+      And("after that, an update with constraints for both apps is issued")
+      inside(output.pull().futureValue) {
+        case Some(RoleConstraintState(state)) =>
+          state shouldBe Map(
+            "role" -> Set(
+              ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("foo")))),
+              ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("bar"))))
+            )
+          )
+      }
+
+      When("the instance updates stream completes")
+      input.complete()
+
+      Then("no further events are emitted")
+      output.pull().futureValue shouldBe None
+    }
+
+    "deduplicate identical updates of offer constraints" in {
+      Given("an OfferConstraintsFlow with a 200 millis minimum update interval")
+      val offerConstraintsFlow = OfferConstraintsStreamLogic.offerConstraintsFlow(200.millis)
+
+      When("two identical instance updates with constraints are offered and separated by a 300 millis interval")
+
+      val inputSourceQueue = Source.queue[InstanceChangeOrSnapshot](16, OverflowStrategy.fail)
+      val outputSinkQueue = Sink.queue[RoleConstraintState]()
+      val (input, output) = inputSourceQueue
+        .via(Flow[InstanceChangeOrSnapshot].delay(300.millis))
+        .via(offerConstraintsFlow)
+        .toMat(outputSinkQueue)(Keep.both)
+        .run
+
+      Future
+        .sequence(
+          Seq("foo", "foo").map { hostname => InstanceUpdated(Instance.scheduled(appTiedToHostname(hostname)), None, Nil) }
+            .map(input.offer(_))
+        )
+        .futureValue
+
+      Then("a single offer constraints update is issued")
+      inside(output.pull().futureValue) {
+        case Some(RoleConstraintState(state)) =>
+          state shouldBe Map("role" -> Set(ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("foo"))))))
+      }
+
+      When("the instance updates stream completes")
+      input.complete()
+
+      Then("no further events are emitted")
+      output.pull().futureValue shouldBe None
+    }
+  }
+
+  val testRoleConstraintsState = RoleConstraintState(
+    Map("role" -> Set(ConstraintGroup(Set(AttributeConstraint("hostname", TextEquals("foo"))))))
+  )
+
+  "OfferConstraintsInjectionFlow" should {
+    "emit no directives before the first UpdateFramework, regardless of constraints updates" in {
+      When("a RoleConstraintsState is received without any role directives")
+
+      val result = Source(Seq[RoleDirective]())
+        .via(OfferConstraintsStreamLogic.offerConstraintsInjectionFlow(Source(Seq(testRoleConstraintsState))))
+        .runWith(Sink.seq)
+        .futureValue
+
+      Then("nothing will be emitted")
+      inside(result) { case Seq() => () }
+    }
+
+    "pair incoming role directives with the latest offer constraints, and re-emit the latest UpdateFramework on constraints update" in {
+      val constraintsUpdatePromise = Promise[RoleConstraintState]()
+      val constraintsUpdates = Source.future(constraintsUpdatePromise.future)
+
+      When("a sequence of UpdateFramework/IssueRevive directives is offered before the constraints update")
+      val updateFramework1 = UpdateFramework(Map("role1" -> OffersWanted), Set.empty, Set.empty)
+      val issueRevive1 = IssueRevive(Set("role1"))
+      val updateFramework2 = UpdateFramework(Map("role2" -> OffersWanted), Set.empty, Set.empty)
+      val issueRevive2 = IssueRevive(Set("role2"))
+
+      val inputSourceQueue = Source.queue[RoleDirective](16, OverflowStrategy.fail)
+      val outputSinkQueue = Sink.queue[(RoleDirective, RoleConstraintState)]()
+
+      val (input, output) = inputSourceQueue
+        .via(OfferConstraintsStreamLogic.offerConstraintsInjectionFlow(constraintsUpdates))
+        .toMat(outputSinkQueue)(Keep.both)
+        .run
+
+      val directives = Seq(updateFramework1, issueRevive1, updateFramework2, issueRevive2)
+      Future.sequence(directives.map(input.offer(_))).futureValue
+
+      Then("directives should be emitted in the same order, each paired with empty offer constraints")
+      directives.map { inputDirective =>
+        inside(output.pull().futureValue) {
+          case Some((directive, constraints)) =>
+            directive shouldBe inputDirective
+            constraints shouldBe OfferConstraints.RoleConstraintState.empty
+        }
+      }
+
+      When("an offer constraints update occurs")
+      constraintsUpdatePromise.success(testRoleConstraintsState)
+
+      Then("the latest UpdateFramework should be re-emitted, paired with the new constraints")
+      inside(output.pull().futureValue) {
+        case Some((directive, constraints)) =>
+          directive shouldBe updateFramework2
+          constraints shouldBe testRoleConstraintsState
+      }
+
+      When("a new UpdateFramework is offered")
+      val updateFramework3 = UpdateFramework(Map("role3" -> OffersWanted), Set.empty, Set.empty)
+      input.offer(updateFramework3).futureValue
+
+      Then("it should be emitted in pair with the updated constraints")
+      inside(output.pull().futureValue) {
+        case Some((directive, constraints)) =>
+          directive shouldBe updateFramework3
+          constraints shouldBe testRoleConstraintsState
+      }
+
+      When("the directives stream completes")
+      input.complete()
+
+      Then("no further events are emitted")
+      output.pull().futureValue shouldBe None
+    }
+
+  }
+}

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActorTest.scala
@@ -158,6 +158,8 @@ class ReviveOffersActorTest extends AkkaUnitTest {
         Future.successful(initialFrameworkInfo),
         defaultRole,
         minReviveOffersInterval = 500.millis,
+        useOfferConstraints = true,
+        minOfferConstraintsUpdateInterval = 500.millis,
         instanceUpdates = instanceUpdates,
         rateLimiterUpdates = delayUpdates,
         driverHolder = driverHolder,

--- a/src/test/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActorTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersActorTest.scala
@@ -167,11 +167,11 @@ class ReviveOffersActorTest extends AkkaUnitTest {
 
     def verifyUnsuppress(): Unit = {
       import org.mockito.Matchers.{eq => mEq}
-      Mockito.verify(driver, invocationTimeout).updateFramework(any, mEq(Nil.asJava))
+      Mockito.verify(driver, invocationTimeout).updateFramework(any, mEq(Nil.asJava), any)
     }
     def verifySuppress(): Unit = {
       import org.mockito.Matchers.{eq => mEq}
-      Mockito.verify(driver, invocationTimeout).updateFramework(any, mEq(Seq(defaultRole).asJava))
+      Mockito.verify(driver, invocationTimeout).updateFramework(any, mEq(Seq(defaultRole).asJava), any)
     }
     def verifyExplicitRevive(timeout: VerificationMode = invocationTimeout): Unit = {
       Mockito.verify(driver, timeout).reviveOffers(Set(defaultRole).asJava)

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -25,7 +25,7 @@ class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonT
   // Offer constraints are disabled to test the rejected offers summary.
   override def marathonArgs: Map[String, String] = Map(
     "failover_timeout" -> "1",
-    "disable_use_offer_constraints" -> ""
+    "disable_mesos_offer_constraints" -> ""
   )
 
   // Configure Mesos to provide the Mesos containerizer with Docker image support.

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/MesosAppIntegrationTest.scala
@@ -22,6 +22,12 @@ import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 class MesosAppIntegrationTest extends AkkaIntegrationTest with EmbeddedMarathonTest with Inside {
+  // Offer constraints are disabled to test the rejected offers summary.
+  override def marathonArgs: Map[String, String] = Map(
+    "failover_timeout" -> "1",
+    "disable_use_offer_constraints" -> ""
+  )
+
   // Configure Mesos to provide the Mesos containerizer with Docker image support.
   override lazy val agentConfig = MesosAgentConfig(
     launcher = "linux",

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -1020,8 +1020,8 @@ trait EmbeddedMarathonTest extends Suite with StrictLogging with ZookeeperServer
 
   override def marathonArgs: Map[String, String] = Map(
     "failover_timeout" -> "1",
-    "use_offer_constraints" -> "",
-    "min_offer_constraints_update_interval" -> "500"
+    "mesos_offer_constraints" -> "",
+    "min_mesos_offer_constraints_update_interval" -> "500"
   )
 }
 

--- a/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
+++ b/tests/integration/src/test/scala/mesosphere/marathon/integration/setup/MarathonTest.scala
@@ -1010,9 +1010,19 @@ trait EmbeddedMarathonTest extends Suite with StrictLogging with ZookeeperServer
    * list of frameworks
    *
    * Until https://issues.apache.org/jira/browse/MESOS-8171 is resolved, we cannot set this value to 0.
+   *
+   * As soon as using Mesos offer constraints is switched on by default,
+   * the `*offer_constraints*` flags can be removed. Until that moment, offer
+   * constraints have to be switched on here (and not in the default options in
+   * `LocalMarathon`), because there are tests that use `LocalMarathon`
+   * for starting older versions of Marathon which do not support this flag.
    */
 
-  override def marathonArgs: Map[String, String] = Map("failover_timeout" -> "1")
+  override def marathonArgs: Map[String, String] = Map(
+    "failover_timeout" -> "1",
+    "use_offer_constraints" -> "",
+    "min_offer_constraints_update_interval" -> "500"
+  )
 }
 
 /**


### PR DESCRIPTION
Now, if the flag `--use_offer_constraints` is set, Marathon will generate Mesos offer constraints from the placement constraints in the RunSpec, taking into account the current active instances in case of UNIQUE and MAX_PER constraints. The offer constraints are passes into Mesos via the UPDATE_FRAMEWORK call; the offer constraints update rate is limited via the 
`--min_offer_constraints_update_interval`.

JIRA issues:
MARATHON-8764