### PR TITLE
Bump MesosDebian to the 1.11-dev snapshot package.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -145,7 +145,7 @@ object Dependency {
     val WixAccord = "0.7.6"
 
     // Version of Mesos to use when building docker image or testing packages
-    val MesosDebian = "1.10.0-0.1.1225.pre.20200327gitbeaf0cd84"
+    val MesosDebian = "1.11.0-0.1.1416.pre.20201006gitc28fd3a93"
 
     // test deps versions
     val JMH = "1.19"


### PR DESCRIPTION
This makes it possible to use CSI External Volumes and Constraints-based offer filtering in the integration tests.

JIRA issues:
MARATHON-8764