### PR TITLE
COPS-6533 Fix issue in which PUT /v2/groups ignored the enforceRole setting

### DIFF
--- a/benchmark/src/main/scala/mesosphere/marathon/Builders.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/Builders.scala
@@ -1,0 +1,1 @@
+../../../../../../src/test/scala/mesosphere/marathon/Builders.scala

--- a/benchmark/src/main/scala/mesosphere/marathon/json/JsonSerializeDeserializeBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/json/JsonSerializeDeserializeBenchmark.scala
@@ -40,7 +40,7 @@ class JsonSerializeDeserializeState {
     val value: JsValue = Json.parse(jsonMockContents)
     val groupUpdate: raml.GroupUpdate = Json.fromJson[raml.GroupUpdate](value).get
 
-    val group: RootGroup = RootGroup()
+    val group: RootGroup = RootGroup.empty()
     val appConversionFunc: (raml.App => AppDefinition) = Raml.fromRaml[raml.App, AppDefinition]
 
     GroupConversion(groupUpdate, group, Timestamp.zero).apply(appConversionFunc)

--- a/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/state/RootGroupBenchmark.scala
@@ -68,7 +68,7 @@ class GroupBenchmark {
 
   // Create apps and add them to each group on each level
   def fillRootGroup(): RootGroup = {
-    var tmpGroup = RootGroup()
+    var tmpGroup = RootGroup.empty()
     groupPaths.foreach { groupPath =>
       appIds.foreach { appId =>
         val path = groupPath / s"app-${appId}"

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/DependencyGraphBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/DependencyGraphBenchmark.scala
@@ -7,7 +7,6 @@ import mesosphere.marathon.core.deployment.DeploymentPlan
 import mesosphere.marathon.state._
 import org.openjdk.jmh.annotations.{Group => _, _}
 import org.openjdk.jmh.infra.Blackhole
-
 import scala.util.Random
 
 @State(Scope.Benchmark)
@@ -28,33 +27,33 @@ object DependencyGraphBenchmark {
         }.toVector
       }.toVector
 
-    val subGroups: Map[AbsolutePathId, Group] = groupIds.iterator.map { groupId =>
+    val subGroups = groupIds.map { groupId =>
       val id = AbsolutePathId(s"/supergroup-${superGroupId}/group-${groupId}")
-      id -> Group(id = id)
-    }.toMap
+      Group.empty(id = id)
+    }
 
     val id = AbsolutePathId(s"/supergroup-${superGroupId}")
-    id -> Group(
+    id -> Builders.newGroup.withoutParentAutocreation(
       id = id,
-      groupsById = subGroups
+      groups = subGroups
     )
   }.toMap
 
-  val rootGroup = RootGroup(groupsById = superGroups)
+  val rootGroup = Builders.newRootGroup.withoutParentAutocreation(groups = superGroups.values)
 
-  val upgraded = RootGroup(
-    groupsById = superGroups.map {
+  val upgraded = Builders.newRootGroup.withoutParentAutocreation(
+    groups = superGroups.map {
       case (superGroupId, superGroup) =>
         if (superGroupId == AbsolutePathId("/supergroup-0")) {
-          superGroupId -> Group(
+          Builders.newGroup.withoutParentAutocreation(
             id = superGroupId,
-            groupsById = superGroup.groupsById.map {
+            groups = superGroup.groupsById.map {
               case (id, subGroup) =>
-                id -> Group(id = id)
+                Group.empty(id = id)
             }
           )
         } else {
-          superGroupId -> superGroup
+          superGroup
         }
     }
   )

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/FlatDependencyBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/FlatDependencyBenchmark.scala
@@ -54,21 +54,22 @@ object FlatDependencyBenchmark {
     AbsolutePathId(s"/app-${appId}")
   }.toVector
 
-  val appDefs: Map[AbsolutePathId, AppDefinition] = appPaths.iterator.map { path =>
-    path -> makeApp(path)
-  }.toMap
+  val appDefs: Seq[AppDefinition] = appPaths.map { path =>
+    makeApp(path)
+  }
 
-  val podDefs: Map[AbsolutePathId, PodDefinition] = podPaths.iterator.map { path =>
-    path -> makePod(path)
-  }.toMap
+  val podDefs: Seq[PodDefinition] = podPaths.map { path =>
+    makePod(path)
+  }
 
-  val rootGroup = RootGroup(apps = appDefs, pods = podDefs)
+  val rootGroup = Builders.newRootGroup(apps = appDefs, pods = podDefs)
   def upgraded = {
-    val pathId = AbsolutePathId("/app-901")
-    RootGroup(
-      apps = rootGroup.apps + (pathId -> makeApp(pathId)),
-      pods = rootGroup.pods + (pathId -> makePod(pathId))
-    )
+    val appPathId = AbsolutePathId("/app-901")
+    val podPathId = AbsolutePathId("/pod-901")
+
+    rootGroup
+      .updateApp(appPathId, _ => makeApp(appPathId))
+      .updatePod(podPathId, _ => makePod(podPathId))
   }
 }
 

--- a/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
+++ b/benchmark/src/main/scala/mesosphere/marathon/upgrade/GroupManagerBenchmark.scala
@@ -60,7 +60,7 @@ class GroupBenchmark {
 
   // Create apps and add them to their groups
   def fillRootGroup(): RootGroup = {
-    var tmpGroup = RootGroup()
+    var tmpGroup = RootGroup.empty()
     ids.foreach { appId =>
       val groupPath = childGroupPaths(appId % numberOfGroups)
       val path = groupPath / s"app-${appId}"

--- a/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
+++ b/src/main/scala/mesosphere/marathon/api/GroupApiService.scala
@@ -10,8 +10,10 @@ import mesosphere.marathon.state._
 import scala.async.Async._
 import scala.concurrent.{ExecutionContext, Future}
 
-class GroupApiService(groupManager: GroupManager)(implicit authorizer: Authorizer, executionContext: ExecutionContext)
-    extends StrictLogging {
+class GroupApiService(groupManager: GroupManager)(implicit
+    authorizer: Authorizer,
+    executionContext: ExecutionContext
+) extends StrictLogging {
 
   /**
     * Encapsulates the group update logic that is following:

--- a/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
+++ b/src/main/scala/mesosphere/marathon/raml/GroupConversion.scala
@@ -13,7 +13,8 @@ case class UpdateGroupStructureOp(
     current: CoreGroup,
     timestamp: Timestamp
 ) {
-  def apply(cf: App => AppDefinition): CoreGroup = UpdateGroupStructureOp.execute(groupUpdate, current, timestamp)(cf)
+  def apply(cf: App => AppDefinition): CoreGroup =
+    UpdateGroupStructureOp.execute(groupUpdate, current, timestamp)(cf)
 }
 
 object UpdateGroupStructureOp {
@@ -75,7 +76,8 @@ object UpdateGroupStructureOp {
       pods = Map.empty,
       groupsById = groupsById,
       dependencies = groupUpdate.dependencies.fold(Set.empty[AbsolutePathId])(_.map(PathId(_).canonicalPath(gid))),
-      version = version
+      version = version,
+      enforceRole = groupUpdate.enforceRole
     )
   }
 
@@ -83,8 +85,12 @@ object UpdateGroupStructureOp {
     * Main entrypoint for a group structure update operation.
     * Implements create-or-update-or-delete for a group tree or subtree.
     * Performs both normalization and conversion from RAML model to state model.
+    *
+    * Note - GroupUpdate should be normalized already and default enforceRole applied as appropriate
     */
-  private def execute(groupUpdate: GroupUpdate, current: CoreGroup, timestamp: Timestamp)(implicit cf: App => AppDefinition): CoreGroup = {
+  private def execute(groupUpdate: GroupUpdate, current: CoreGroup, timestamp: Timestamp)(implicit
+      cf: App => AppDefinition
+  ): CoreGroup = {
 
     require(groupUpdate.scaleBy.isEmpty, "For a structural update, no scale should be given.")
     require(groupUpdate.version.isEmpty, "For a structural update, no version should be given.")

--- a/src/main/scala/mesosphere/marathon/state/Group.scala
+++ b/src/main/scala/mesosphere/marathon/state/Group.scala
@@ -10,11 +10,10 @@ import com.wix.accord.dsl._
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.api.v2.validation.AppValidation
 import mesosphere.marathon.core.pod.PodDefinition
-import mesosphere.marathon.state.Group.{defaultApps, defaultDependencies, defaultGroups, defaultPods, defaultVersion}
 import mesosphere.marathon.state.PathId.{StringPathId, validPathWithBase}
 import mesosphere.util.summarize
 
-class Group(
+class Group protected (
     val id: AbsolutePathId,
     val apps: Map[AbsolutePathId, AppDefinition],
     val pods: Map[AbsolutePathId, PodDefinition],
@@ -200,24 +199,20 @@ object Group extends StrictLogging {
 
   def apply(
       id: AbsolutePathId,
-      apps: Map[AbsolutePathId, AppDefinition] = Group.defaultApps,
-      pods: Map[AbsolutePathId, PodDefinition] = Group.defaultPods,
-      groupsById: Map[AbsolutePathId, Group] = Group.defaultGroups,
-      dependencies: Set[AbsolutePathId] = Group.defaultDependencies,
-      version: Timestamp = Group.defaultVersion,
-      enforceRole: Option[Boolean] = None
+      apps: Map[AbsolutePathId, AppDefinition],
+      pods: Map[AbsolutePathId, PodDefinition],
+      groupsById: Map[AbsolutePathId, Group],
+      dependencies: Set[AbsolutePathId],
+      version: Timestamp,
+      enforceRole: Option[Boolean]
   ): Group = {
     val enforceRoleBehaviour = if (id.isTopLevel) enforceRole.orElse(Some(false)) else None
     new Group(id, apps, pods, groupsById, dependencies, version, enforceRoleBehaviour)
   }
 
   def empty(id: AbsolutePathId, enforceRole: Option[Boolean] = None, version: Timestamp = Timestamp(0)): Group =
-    Group(id = id, version = version, enforceRole = enforceRole)
+    Group(id, Map.empty, Map.empty, Map.empty, Set.empty, version = version, enforceRole = enforceRole)
 
-  val defaultApps = Map.empty[AbsolutePathId, AppDefinition]
-  val defaultPods = Map.empty[AbsolutePathId, PodDefinition]
-  val defaultGroups = Map.empty[AbsolutePathId, Group]
-  val defaultDependencies = Set.empty[AbsolutePathId]
   val defaultVersion = Timestamp.now()
 
   def validGroup(base: AbsolutePathId, config: MarathonConf): Validator[Group] =

--- a/src/main/scala/mesosphere/marathon/state/RootGroup.scala
+++ b/src/main/scala/mesosphere/marathon/state/RootGroup.scala
@@ -492,30 +492,18 @@ object RootGroup {
     }
 
   trait NewGroupStrategy {
-    def enforceRoleValue(id: AbsolutePathId): Option[Boolean]
-
     def newGroup(id: AbsolutePathId): Group
   }
 
   object NewGroupStrategy {
 
     object Fail extends NewGroupStrategy {
-      override def enforceRoleValue(id: AbsolutePathId): Option[Boolean] = None
-
       override def newGroup(id: AbsolutePathId): Group = throw new RuntimeException(s"No such group: ${id}")
     }
 
     case class UsingConfig(newGroupEnforceRoleBehavior: NewGroupEnforceRoleBehavior) extends NewGroupStrategy {
-      override def enforceRoleValue(id: AbsolutePathId): Option[Boolean] = {
-        if (id.isTopLevel) {
-          newGroupEnforceRoleBehavior.option
-        } else {
-          None
-        }
-      }
-
       override def newGroup(id: AbsolutePathId): Group =
-        Group.empty(id, enforceRole = enforceRoleValue(id))
+        Group.empty(id, enforceRole = if (id.isTopLevel) newGroupEnforceRoleBehavior.option else None)
     }
   }
 }

--- a/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
+++ b/src/main/scala/mesosphere/marathon/storage/StorageModule.scala
@@ -39,7 +39,7 @@ object StorageModule {
       actorSystem: ActorSystem
   ): StorageModule = {
     val currentConfig = StorageConfig(conf, curatorFramework)
-    apply(metrics, currentConfig, RootGroup.NewGroupStrategy.fromConfig(conf.newGroupEnforceRole()), conf.mesosRole())
+    apply(metrics, currentConfig, RootGroup.NewGroupStrategy.UsingConfig(conf.newGroupEnforceRole()), conf.mesosRole())
   }
 
   def apply(metrics: Metrics, config: StorageConfig, newGroupStrategy: RootGroup.NewGroupStrategy, defaultMesosRole: String)(implicit

--- a/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
+++ b/src/test/scala/mesosphere/marathon/SchedulerActionsTest.scala
@@ -28,7 +28,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
     "Task reconciliation sends known running and staged tasks and empty list" in {
       val f = new Fixture
       val app = AppDefinition(id = AbsolutePathId("/myapp"), role = "*")
-      val rootGroup: RootGroup = RootGroup(apps = Map((app.id, app)))
+      val rootGroup: RootGroup = Builders.newRootGroup(apps = Seq(app))
       val runningInstance = TestInstanceBuilder.newBuilder(app.id).addTaskRunning().getInstance()
       val stagedInstance = TestInstanceBuilder.newBuilder(app.id).addTaskStaged().getInstance()
 
@@ -60,7 +60,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       val f = new Fixture
 
       f.instanceTracker.instancesBySpec() returns Future.successful(InstancesBySpec.empty)
-      f.groupRepo.root() returns Future.successful(RootGroup())
+      f.groupRepo.root() returns Future.successful(RootGroup.empty())
 
       f.scheduler.reconcileTasks(f.driver).futureValue
 
@@ -75,7 +75,7 @@ class SchedulerActionsTest extends AkkaUnitTest {
       val orphanedInstance = TestInstanceBuilder.newBuilder(orphanedApp.id).addTaskRunning().getInstance()
 
       f.instanceTracker.instancesBySpec() returns Future.successful(InstancesBySpec.forInstances(Seq(instance, orphanedInstance)))
-      val rootGroup: RootGroup = RootGroup(apps = Map((app.id, app)))
+      val rootGroup: RootGroup = Builders.newRootGroup(apps = Seq(app))
       f.groupRepo.root() returns Future.successful(rootGroup)
 
       f.scheduler.reconcileTasks(f.driver).futureValue(5.seconds)

--- a/src/test/scala/mesosphere/marathon/api/GroupApiServiceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/GroupApiServiceTest.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.raml.{App, GroupUpdate, Network, NetworkMode}
 import mesosphere.marathon.state._
 import mesosphere.marathon.test.GroupCreation
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state.RootGroup.NewGroupStrategy
 import org.scalatest.Inside
 
 import scala.collection.immutable.Seq

--- a/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
+++ b/src/test/scala/mesosphere/marathon/api/TestGroupManagerFixture.scala
@@ -11,6 +11,7 @@ import mesosphere.marathon.core.group.GroupManagerModule
 import mesosphere.marathon.core.storage.store.impl.memory.InMemoryPersistenceStore
 import mesosphere.marathon.metrics.dummy.DummyMetrics
 import mesosphere.marathon.state.RootGroup
+import mesosphere.marathon.state.RootGroup.NewGroupStrategy
 import mesosphere.marathon.storage.repository.{AppRepository, GroupRepository, InstanceRepository, PodRepository}
 import mesosphere.marathon.test.Mockito
 

--- a/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/AppsResourceTest.scala
@@ -180,7 +180,7 @@ class AppsResourceTest extends AkkaUnitTest with JerseyTest {
 
     val config: AllConf = AllConf.withTestConfig(configArgs: _*)
     val groupManagerFixture: TestGroupManagerFixture = new TestGroupManagerFixture(
-      initialRoot = RootGroup.fromGroup(initialRoot, RootGroup.NewGroupStrategy.fromConfig(config.newGroupEnforceRole()))
+      initialRoot = RootGroup.fromGroup(initialRoot, RootGroup.NewGroupStrategy.UsingConfig(config.newGroupEnforceRole()))
     )
     val groupManager: GroupManager = groupManagerFixture.groupManager
     val groupRepository: GroupRepository = groupManagerFixture.groupRepository
@@ -2449,8 +2449,8 @@ class AppsResourceTest extends AkkaUnitTest with JerseyTest {
 
     "Create a new app inside a top-level group with enforceRole disabled but --new_group_enforce_role=top" in new FixtureWithRealGroupManager(
       configArgs = Seq("--new_group_enforce_role", "top"),
-      initialRoot =
-        Group(id = "/".toAbsolutePath, groupsById = Map("/dev".toAbsolutePath -> Group("/dev".toAbsolutePath, enforceRole = Some(false))))
+      initialRoot = Builders.newGroup
+        .withoutParentAutocreation(id = "/".toAbsolutePath, groups = Seq(Group.empty("/dev".toAbsolutePath, enforceRole = Some(false))))
     ) {
 
       service.deploy(any, any) returns Future.successful(Done)
@@ -2483,8 +2483,8 @@ class AppsResourceTest extends AkkaUnitTest with JerseyTest {
     }
 
     "Create a new app inside a sub-group for which enforceRole is enabled applies the proper group-role default" in new FixtureWithRealGroupManager(
-      initialRoot =
-        Group("/".toAbsolutePath, groupsById = Map("/dev".toAbsolutePath -> Group("/dev".toAbsolutePath, enforceRole = Some(true))))
+      initialRoot = Builders.newGroup
+        .withoutParentAutocreation("/".toAbsolutePath, groups = Seq(Group.empty("/dev".toAbsolutePath, enforceRole = Some(true))))
     ) {
       service.deploy(any, any) returns Future.successful(Done)
 
@@ -2513,8 +2513,8 @@ class AppsResourceTest extends AkkaUnitTest with JerseyTest {
     }
 
     "Create a new app inside a top-level group with enforceRole applies the proper group-role default" in new FixtureWithRealGroupManager(
-      initialRoot =
-        Group("/".toAbsolutePath, groupsById = Map("/dev".toAbsolutePath -> Group("/dev".toAbsolutePath, enforceRole = Some(true))))
+      initialRoot = Builders.newGroup
+        .withoutParentAutocreation("/".toAbsolutePath, groups = Seq(Group.empty("/dev".toAbsolutePath, enforceRole = Some(true))))
     ) {
       service.deploy(any, any) returns Future.successful(Done)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/GroupsResourceTest.scala
@@ -12,6 +12,7 @@ import mesosphere.marathon.core.appinfo._
 import mesosphere.marathon.core.group.GroupManager
 import mesosphere.marathon.raml.{App, GroupUpdate}
 import mesosphere.marathon.state.PathId._
+import mesosphere.marathon.state.RootGroup.NewGroupStrategy
 import mesosphere.marathon.state._
 import mesosphere.marathon.storage.repository.GroupRepository
 import mesosphere.marathon.test.{GroupCreation, JerseyTest}
@@ -43,10 +44,11 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
   case class FixtureWithRealGroupManager(
       initialRoot: Group = Group.empty("/".toAbsolutePath),
       groupInfo: GroupInfoService = mock[GroupInfoService],
-      auth: TestAuthFixture = new TestAuthFixture
+      auth: TestAuthFixture = new TestAuthFixture,
+      newGroupEnforceRoleBehavior: NewGroupEnforceRoleBehavior = NewGroupEnforceRoleBehavior.Top
   ) {
-    val config = AllConf.withTestConfig("--zk_timeout", "3000")
-    val initialRootGroup = RootGroup.fromGroup(initialRoot, RootGroup.NewGroupStrategy.fromConfig(config.newGroupEnforceRole()))
+    val config = AllConf.withTestConfig("--zk_timeout", "3000", "--new_group_enforce_role", newGroupEnforceRoleBehavior.name)
+    val initialRootGroup = RootGroup.fromGroup(initialRoot, RootGroup.NewGroupStrategy.UsingConfig(config.newGroupEnforceRole()))
     val f = new TestGroupManagerFixture(config = config, initialRoot = initialRootGroup)
     val groupRepository: GroupRepository = f.groupRepository
     val groupManager: GroupManager = f.groupManager
@@ -56,7 +58,12 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
     implicit val authorizer = auth.auth
 
     val groupsResource: GroupsResource =
-      new GroupsResource(groupManager, groupInfo, config, new GroupApiService(groupManager))(auth.auth, auth.auth, mat, ctx)
+      new GroupsResource(
+        groupManager,
+        groupInfo,
+        config,
+        new GroupApiService(groupManager)
+      )(auth.auth, auth.auth, mat, ctx)
   }
 
   "GroupsResource" should {
@@ -320,7 +327,7 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
     def groupPaths(rootGroup: RootGroup): Set[String] = {
       rootGroup.transitiveGroups().map(_._1.toString).toSet + rootGroup.id.toString
     }
-    "Creation of a top-level relative group path creates the group in the root" in {
+    "Creation of a top-level relative group path creates the group in the root with the appropriate default enforceRole" in {
       new FixtureWithRealGroupManager(initialRoot = Builders.newRootGroup()) {
         f.service.deploy(any, any).returns(Future(Done))
         When("creating a group without an absolute path")
@@ -332,9 +339,9 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
         }
         response.getStatus shouldBe 201
         val rootGroup = groupManager.rootGroup()
-        println(rootGroup)
         // Before MARATHON-8017 was fixed, the above post would create the group as /relative/relative
         groupPaths(rootGroup) shouldBe Set("/", "/relative")
+        rootGroup.group("/relative".toAbsolutePath).get.enforceRole shouldBe Some(true)
       }
     }
 
@@ -439,6 +446,48 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
       }
     }
 
+    "Allows group updates on the root group and respects enforceRole setting and default" in {
+      new FixtureWithRealGroupManager(
+        initialRoot = Builders.newRootGroup(),
+        newGroupEnforceRoleBehavior = NewGroupEnforceRoleBehavior.Top
+      ) {
+        val body = """
+        {
+          "groups": [
+            {
+              "id": "dev"
+            },
+            {
+              "id": "prod",
+              "enforceRole": true
+            },
+            {
+              "id": "public",
+              "enforceRole": false
+            }
+          ]
+        }"""
+        f.service.deploy(any, any).returns(Future(Done))
+
+        val response = asyncRequest { r =>
+          groupsResource.update("", false, false, body.getBytes, auth.request, r)
+        }
+        response.getStatus shouldBe 200
+
+        val rootGroup = groupManager.rootGroup()
+        rootGroup.group("/dev".toAbsolutePath).get.enforceRole shouldBe Some(
+          true
+        ) withClue ("/dev should default to enforceRole: true with NewGroupEnforceRoleBehavior")
+        rootGroup.group("/prod".toAbsolutePath).get.enforceRole shouldBe Some(
+          true
+        ) withClue ("/prod should set to enforceRole: true per the JSON")
+        rootGroup.group("/public".toAbsolutePath).get.enforceRole shouldBe Some(
+          false
+        ) withClue ("/public should set to enforceRole: false per the JSON")
+      }
+
+    }
+
     "Allow batch creation of a top-level group with enforce role and apps" in {
       new FixtureWithRealGroupManager(initialRoot = Builders.newRootGroup()) {
         val body =
@@ -475,9 +524,9 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
 
     "Fail a batch update when apps are modified and enforceRole is changed for an unrelated group" in {
       new FixtureWithRealGroupManager(
-        initialRoot = Group(
+        initialRoot = Builders.newGroup.withoutParentAutocreation(
           "/".toAbsolutePath,
-          groupsById = Map("/dev".toAbsolutePath -> Group(id = AbsolutePathId("/dev"), enforceRole = Some(false)))
+          groups = Seq(Group.empty(id = AbsolutePathId("/dev"), enforceRole = Some(false)))
         )
       ) {
         val body =
@@ -512,8 +561,8 @@ class GroupsResourceTest extends AkkaUnitTest with GroupCreation with JerseyTest
     }
 
     "allow an update to enforceRole when id is not specified" in {
-      val group = Group("/dev".toAbsolutePath, enforceRole = Some(false))
-      new FixtureWithRealGroupManager(initialRoot = RootGroup(groupsById = Map(group.id -> group))) {
+      val group = Group.empty("/dev".toAbsolutePath, enforceRole = Some(false))
+      new FixtureWithRealGroupManager(initialRoot = Builders.newRootGroup(groups = Seq(group))) {
         val body = """{"enforceRole": true}"""
         f.service.deploy(any, any).returns(Future(Done))
 

--- a/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/PodsResourceTest.scala
@@ -2181,7 +2181,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       service: MarathonSchedulerService
   ) extends GroupCreation {
 
-    def prepareGroup(groupId: String, pods: Map[AbsolutePathId, PodDefinition] = Group.defaultPods): Unit = {
+    def prepareGroup(groupId: String, pods: Map[AbsolutePathId, PodDefinition] = Map.empty): Unit = {
       val groupPath = AbsolutePathId(groupId)
 
       val group = createGroup(groupPath, pods = pods)
@@ -2250,7 +2250,7 @@ class PodsResourceTest extends AkkaUnitTest with Mockito with JerseyTest {
       val podStatusService = mock[PodStatusService]
 
       val groupManagerFixture: TestGroupManagerFixture = new TestGroupManagerFixture(
-        initialRoot = RootGroup.fromGroup(initialRoot, RootGroup.NewGroupStrategy.fromConfig(config.newGroupEnforceRole()))
+        initialRoot = RootGroup.fromGroup(initialRoot, RootGroup.NewGroupStrategy.UsingConfig(config.newGroupEnforceRole()))
       )
       val killService: TaskKiller = mock[TaskKiller]
       val podManager = new PodManagerImpl(groupManagerFixture.groupManager)

--- a/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/json/GroupUpdateTest.scala
@@ -79,7 +79,9 @@ class GroupUpdateTest extends UnitTest {
       When("The update is performed")
       val normalized = GroupNormalization(noEnabledFeatures, initialRootGroup).updateNormalization(PathId.root).normalized(update)
       val result: RootGroup =
-        initialRootGroup.updatedWith(GroupConversion(normalized, initialRootGroup, timestamp).apply(appConversionFunc))
+        initialRootGroup.updatedWith(
+          GroupConversion(normalized, initialRootGroup, timestamp).apply(appConversionFunc)
+        )
 
       validate(result)(RootGroup.validRootGroup(noEnabledFeatures)).isSuccess should be(true)
 
@@ -125,7 +127,7 @@ class GroupUpdateTest extends UnitTest {
       val normalized =
         GroupNormalization(noEnabledFeatures, Builders.newRootGroup()).updateNormalization(AbsolutePathId("/test")).normalized(update)
       val next = GroupConversion(normalized, current, timestamp).apply(appConversionFunc)
-      val result = RootGroup(groupsById = Map(next.id -> next))
+      val result = Builders.newRootGroup(groups = Seq(next))
 
       validate(result)(RootGroup.validRootGroup(noEnabledFeatures)).isSuccess should be(true)
 

--- a/src/test/scala/mesosphere/marathon/api/v2/validation/GroupValidationTest.scala
+++ b/src/test/scala/mesosphere/marathon/api/v2/validation/GroupValidationTest.scala
@@ -28,7 +28,7 @@ class GroupValidationTest extends UnitTest with ValidationTestLike {
     }
 
     "disallows changes to enforceRole if other services are modified with the request" in {
-      val originalGroup = RootGroup.empty().putGroup(Group(AbsolutePathId("/dev"), enforceRole = Some(false)))
+      val originalGroup = RootGroup.empty().putGroup(Group.empty(AbsolutePathId("/dev"), enforceRole = Some(false)))
       val groupValidator = Group.validNestedGroupUpdateWithBase(AbsolutePathId("/"), originalGroup, servicesGloballyModified = true)
 
       val update = raml.GroupUpdate(id = Some("/dev"), enforceRole = Some(true))
@@ -39,7 +39,7 @@ class GroupValidationTest extends UnitTest with ValidationTestLike {
     }
 
     "allows changes to enforceRole if other services are not modified with the request" in {
-      val originalGroup = RootGroup.empty().putGroup(Group(AbsolutePathId("/dev"), enforceRole = Some(false)))
+      val originalGroup = RootGroup.empty().putGroup(Group.empty(AbsolutePathId("/dev"), enforceRole = Some(false)))
       val groupValidator = Group.validNestedGroupUpdateWithBase(AbsolutePathId("/"), originalGroup, servicesGloballyModified = false)
 
       val update = raml.GroupUpdate(id = Some("/dev"), enforceRole = Some(true))

--- a/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
+++ b/src/test/scala/mesosphere/marathon/core/deployment/impl/DeploymentPlanRevertTest.scala
@@ -346,7 +346,7 @@ class DeploymentPlanRevertTest extends UnitTest with GroupCreation {
             val id = "/withdeps".toAbsolutePath // withdeps still exists because of the subgroup
             createGroup(
               id,
-              apps = Group.defaultApps,
+              apps = Map.empty,
               groups = Set(createGroup(id / "some")),
               dependencies = Set() // dependencies were introduce with first deployment, should be gone now
             )

--- a/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/RootGroupTest.scala
@@ -12,7 +12,7 @@ import mesosphere.marathon.test.GroupCreation
 
 class RootGroupTest extends UnitTest with GroupCreation {
   val emptyConfig = AllConf.withTestConfig()
-  val emptyRootGroup = RootGroup.empty(newGroupStrategy = RootGroup.NewGroupStrategy.fromConfig(NewGroupEnforceRoleBehavior.Off))
+  val emptyRootGroup = RootGroup.empty(newGroupStrategy = RootGroup.NewGroupStrategy.UsingConfig(NewGroupEnforceRoleBehavior.Off))
 
   "A Group" should {
 
@@ -20,17 +20,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group with two subgroups")
       val app1 = AppDefinition(AbsolutePathId("/test/group1/app1"), role = "*", cmd = Some("sleep"))
       val app2 = AppDefinition(AbsolutePathId("/test/group2/app2"), role = "*", cmd = Some("sleep"))
-      val current = createRootGroup(
-        groups = Set(
-          createGroup(
-            "/test".toAbsolutePath,
-            groups = Set(
-              createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
-              createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
-            )
-          )
-        )
-      )
+      val current = Builders.newRootGroup(apps = Seq(app1, app2))
 
       When("an app with a specific path is requested")
       val path = AbsolutePathId("/test/group1/app1")
@@ -42,7 +32,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "find an app without a parent" in {
       Given("an existing root group with an app without a parent")
       val app = AppDefinition(AbsolutePathId("/app"), role = "*", cmd = Some("sleep"))
-      val current = createRootGroup(apps = Map(app.id -> app))
+      val current = Builders.newRootGroup(apps = Seq(app))
 
       When("an app with a specific path is requested")
       val path = AbsolutePathId("/app")
@@ -55,17 +45,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group with two subgroups")
       val app1 = AppDefinition(AbsolutePathId("/test/group1/app1"), role = "*", cmd = Some("sleep"))
       val app2 = AppDefinition(AbsolutePathId("/test/group2/app2"), role = "*", cmd = Some("sleep"))
-      val current = createRootGroup(
-        groups = Set(
-          createGroup(
-            "/test".toAbsolutePath,
-            groups = Set(
-              createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
-              createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
-            )
-          )
-        )
-      )
+      val current = Builders.newRootGroup(apps = Seq(app1, app2))
 
       When("a group with a specific path is requested")
       val path = AbsolutePathId("/test/group1/unknown")
@@ -78,17 +58,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group with two subgroups")
       val app1 = AppDefinition(AbsolutePathId("/test/group1/app1"), role = "*", cmd = Some("sleep"))
       val app2 = AppDefinition(AbsolutePathId("/test/group2/app2"), role = "*", cmd = Some("sleep"))
-      val current = createRootGroup(
-        groups = Set(
-          createGroup(
-            "/test".toAbsolutePath,
-            groups = Set(
-              createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
-              createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
-            )
-          )
-        )
-      )
+      val current = Builders.newRootGroup(apps = Seq(app1, app2))
 
       When("a group with a specific path is requested")
       val path = AbsolutePathId("/test/group1")
@@ -101,17 +71,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("an existing group with two subgroups")
       val app1 = AppDefinition(AbsolutePathId("/test/group1/app1"), role = "*", cmd = Some("sleep"))
       val app2 = AppDefinition(AbsolutePathId("/test/group2/app2"), role = "*", cmd = Some("sleep"))
-      val current = createRootGroup(
-        groups = Set(
-          createGroup(
-            "/test".toAbsolutePath,
-            groups = Set(
-              createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
-              createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
-            )
-          )
-        )
-      )
+      val current = Builders.newRootGroup(apps = Seq(app1, app2))
 
       When("a group with a specific path is requested")
       val path = AbsolutePathId("/test/unknown")
@@ -122,7 +82,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "can delete a node based in the path" in {
       Given("an existing group with two subgroups")
-      val current = createRootGroup().makeGroup("/test/foo/one".toAbsolutePath).makeGroup("/test/bla/two".toAbsolutePath)
+      val current = Builders.newRootGroup(groupIds = Seq("/test/foo/one".toAbsolutePath, "/test/bla/two".toAbsolutePath))
 
       When("a node will be deleted based on path")
       val rootGroup = current.removeGroup("/test/foo".toAbsolutePath)
@@ -136,17 +96,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("a group with subgroups")
       val app1 = AppDefinition(AbsolutePathId("/test/group1/app1"), role = "*", cmd = Some("sleep"))
       val app2 = AppDefinition(AbsolutePathId("/test/group2/app2"), role = "*", cmd = Some("sleep"))
-      val current = createRootGroup(
-        groups = Set(
-          createGroup(
-            "/test".toAbsolutePath,
-            groups = Set(
-              createGroup("/test/group1".toAbsolutePath, Map(app1.id -> app1)),
-              createGroup("/test/group2".toAbsolutePath, Map(app2.id -> app2))
-            )
-          )
-        )
-      )
+      val current = Builders.newRootGroup(apps = Seq(app1, app2))
 
       When("a non existing path is requested")
       val path = AbsolutePathId("/test/group3/group4/group5")
@@ -177,9 +127,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
       Given("an existing group /some/nested which does not directly or indirectly contain apps")
       val current =
-        createRootGroup()
-          .makeGroup("/some/nested/path".toAbsolutePath)
-          .makeGroup("/some/nested/path2".toAbsolutePath)
+        Builders.newRootGroup(groupIds = Seq("/some/nested/path".toAbsolutePath, "/some/nested/path2".toAbsolutePath))
 
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2")
@@ -203,14 +151,10 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "cannot replace a group with apps by an app definition" in {
       Given("an existing group /some/nested which does contain an app")
       val current =
-        createRootGroup()
-          .makeGroup("/some/nested/path".toAbsolutePath)
-          .makeGroup("/some/nested/path2".toAbsolutePath)
-          .updateApp(
-            AbsolutePathId("/some/nested/path2/app"),
-            _ => AppDefinition(AbsolutePathId("/some/nested/path2/app"), role = "*", cmd = Some("true")),
-            Timestamp.now()
-          )
+        Builders.newRootGroup(
+          groupIds = Seq("/some/nested/path".toAbsolutePath, "/some/nested/path2".toAbsolutePath),
+          apps = Seq(AppDefinition(AbsolutePathId("/some/nested/path2/app"), role = "*", cmd = Some("true")))
+        )
 
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2")
@@ -238,14 +182,10 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "cannot replace a group with pods by an app definition" in {
       Given("an existing group /some/nested which does contain an pod")
       val current =
-        createRootGroup()
-          .makeGroup("/some/nested/path".toAbsolutePath)
-          .makeGroup("/some/nested/path2".toAbsolutePath)
-          .updatePod(
-            AbsolutePathId("/some/nested/path2/pod"),
-            _ => PodDefinition(id = AbsolutePathId("/some/nested/path2/pod"), role = "*"),
-            Timestamp.now()
-          )
+        Builders.newRootGroup(
+          groupIds = Seq("/some/nested/path".toAbsolutePath, "/some/nested/path2".toAbsolutePath),
+          pods = Seq(PodDefinition(id = AbsolutePathId("/some/nested/path2/pod"), role = "*"))
+        )
 
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2")
@@ -274,14 +214,10 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "cannot replace a group with pods by an pod definition" in {
       Given("an existing group /some/nested which does contain an pod")
       val current =
-        createRootGroup()
-          .makeGroup("/some/nested/path".toAbsolutePath)
-          .makeGroup("/some/nested/path2".toAbsolutePath)
-          .updatePod(
-            AbsolutePathId("/some/nested/path2/pod"),
-            _ => PodDefinition(id = AbsolutePathId("/some/nested/path2/pod"), role = "*"),
-            Timestamp.now()
-          )
+        Builders.newRootGroup(
+          groupIds = Seq("/some/nested/path".toAbsolutePath, "/some/nested/path2".toAbsolutePath),
+          pods = Seq(PodDefinition(id = AbsolutePathId("/some/nested/path2/pod"), role = "*"))
+        )
 
       current.transitiveGroupsById.keys.map(_.toString) should be(
         Set("/", "/some", "/some/nested", "/some/nested/path", "/some/nested/path2")
@@ -656,11 +592,10 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "Group with app in wrong group is not valid" in {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(AbsolutePathId("/root"), role = "*", cmd = Some("test"))
-      val invalid = createRootGroup(
-        groups = Set(
-          createGroup(AbsolutePathId("nested"), apps = Map(app.id -> app), validate = false)
-        ),
-        validate = false
+      val invalid = Builders.newRootGroup.withoutParentAutocreation(
+        groups = Seq(
+          Builders.newGroup.withoutParentAutocreation(AbsolutePathId("nested"), apps = Seq(app))
+        )
       )
 
       When("group is validated")
@@ -672,17 +607,13 @@ class RootGroupTest extends UnitTest with GroupCreation {
 
     "Group with group in wrong group is not valid" in {
       Given("Group with nested app of wrong path")
-      val invalid = createRootGroup(
-        groups = Set(
-          createGroup(
+      val invalid = Builders.newRootGroup.withoutParentAutocreation(
+        groups = Seq(
+          Builders.newGroup.withoutParentAutocreation(
             AbsolutePathId("nested"),
-            groups = Set(
-              createGroup(AbsolutePathId("/root"), validate = false)
-            ),
-            validate = false
+            groups = Seq(Builders.newGroup.withoutParentAutocreation(AbsolutePathId("/root")))
           )
-        ),
-        validate = false
+        )
       )
 
       When("group is validated")
@@ -695,7 +626,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
     "Root Group with app in wrong group is not valid (Regression for #4901)" in {
       Given("Group with nested app of wrong path")
       val app = AppDefinition(AbsolutePathId("/foo/bla"), role = "*", cmd = Some("test"))
-      val invalid = RootGroup(apps = Map(app.id -> app))
+      val invalid = Builders.newRootGroup.withoutParentAutocreation(apps = Seq(app))
 
       When("group is validated")
       val invalidResult = validate(invalid)(RootGroup.validRootGroup(emptyConfig))
@@ -708,7 +639,7 @@ class RootGroupTest extends UnitTest with GroupCreation {
       Given("Group with nested app of correct path")
       val app = AppDefinition(AbsolutePathId("/nested/foo"), role = "*", cmd = Some("test"))
       val valid =
-        RootGroup(groupsById = Map(AbsolutePathId("/nested") -> createGroup(AbsolutePathId("/nested"), apps = Map(app.id -> app))))
+        Builders.newRootGroup(groups = Seq(Builders.newGroup.withoutParentAutocreation(AbsolutePathId("/nested"), apps = Seq(app))))
 
       When("group is validated")
       val validResult = validate(valid)(RootGroup.validRootGroup(emptyConfig))

--- a/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
+++ b/src/test/scala/mesosphere/marathon/tasks/InstanceOpFactoryImplTest.scala
@@ -216,7 +216,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
 
     "enforceRole property is propagated to task environment for pods" in {
       val f = new Fixture
-      f.rootGroup = f.rootGroup.putGroup(Group(AbsolutePathId("/dev"), enforceRole = Some(true)))
+      f.rootGroup = f.rootGroup.putGroup(Group.empty(AbsolutePathId("/dev"), enforceRole = Some(true)))
       val podId = AbsolutePathId("/dev/testing")
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(podId, f.clock.now()).getInstance()
@@ -245,7 +245,7 @@ class InstanceOpFactoryImplTest extends UnitTest with Inside {
 
     "enforceRole property is propagated to task environment for apps" in {
       val f = new Fixture
-      f.rootGroup = f.rootGroup.putGroup(Group(AbsolutePathId("/dev"), enforceRole = Some(true)))
+      f.rootGroup = f.rootGroup.putGroup(Group.empty(AbsolutePathId("/dev"), enforceRole = Some(true)))
       val appId = AbsolutePathId("/dev/testing")
       val offer = MarathonTestHelper.makeBasicOffer().build()
       val instance = TestInstanceBuilder.newBuilderWithLaunchedTask(appId, f.clock.now()).getInstance()

--- a/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
+++ b/src/test/scala/mesosphere/marathon/test/GroupCreation.scala
@@ -8,10 +8,10 @@ import com.wix.accord
 trait GroupCreation {
   @deprecated("Prefer Builders.newRootGroup instead", since = "1.9")
   def createRootGroup(
-      apps: Map[AbsolutePathId, AppDefinition] = Group.defaultApps,
-      pods: Map[AbsolutePathId, PodDefinition] = Group.defaultPods,
+      apps: Map[AbsolutePathId, AppDefinition] = Map.empty,
+      pods: Map[AbsolutePathId, PodDefinition] = Map.empty,
       groups: Set[Group] = Set.empty,
-      dependencies: Set[AbsolutePathId] = Group.defaultDependencies,
+      dependencies: Set[AbsolutePathId] = Set.empty,
       version: Timestamp = Group.defaultVersion,
       validate: Boolean = true,
       enabledFeatures: Set[String] = Set.empty,
@@ -22,7 +22,7 @@ trait GroupCreation {
       pods,
       groups.iterator.map(group => group.id -> group).toMap,
       dependencies,
-      RootGroup.NewGroupStrategy.fromConfig(newGroupEnforceRole),
+      RootGroup.NewGroupStrategy.UsingConfig(newGroupEnforceRole),
       version
     )
 
@@ -40,10 +40,10 @@ trait GroupCreation {
 
   def createGroup(
       id: AbsolutePathId,
-      apps: Map[AbsolutePathId, AppDefinition] = Group.defaultApps,
-      pods: Map[AbsolutePathId, PodDefinition] = Group.defaultPods,
+      apps: Map[AbsolutePathId, AppDefinition] = Map.empty,
+      pods: Map[AbsolutePathId, PodDefinition] = Map.empty,
       groups: Set[Group] = Set.empty,
-      dependencies: Set[AbsolutePathId] = Group.defaultDependencies,
+      dependencies: Set[AbsolutePathId] = Set.empty,
       version: Timestamp = Group.defaultVersion,
       validate: Boolean = true,
       enabledFeatures: Set[String] = Set.empty,


### PR DESCRIPTION
Also, remove the default values for Group and RootGroup production model constructors so that this type of issue does not reoccur.

JIRA Issues: MARATHON-8770