### PR TITLE
Fix issue in which suppress/revives were delayed

### DIFF
--- a/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
+++ b/src/main/scala/mesosphere/marathon/core/launchqueue/impl/ReviveOffersStreamLogic.scala
@@ -7,7 +7,7 @@ import akka.stream.scaladsl.Flow
 import com.typesafe.scalalogging.StrictLogging
 import mesosphere.marathon.core.instance.update.{InstanceChangeOrSnapshot, InstanceDeleted, InstanceUpdated, InstancesSnapshot}
 import mesosphere.marathon.state.RunSpecConfigRef
-import mesosphere.marathon.stream.TimedEmitter
+import mesosphere.marathon.stream.{RateLimiterFlow, TimedEmitter}
 
 import scala.concurrent.duration._
 
@@ -143,6 +143,6 @@ object ReviveOffersStreamLogic extends StrictLogging {
       .via(suppressOrReviveFromDiff)
       .via(handleIgnoreSuppress(enableSuppress = enableSuppress))
       .via(deduplicateSuppress)
-      .throttle(1, minReviveOffersInterval)
+      .via(RateLimiterFlow.apply(minReviveOffersInterval))
   }
 }

--- a/src/main/scala/mesosphere/marathon/stream/RateLimiterFlow.scala
+++ b/src/main/scala/mesosphere/marathon/stream/RateLimiterFlow.scala
@@ -1,0 +1,75 @@
+package mesosphere.marathon
+package stream
+
+import java.time.{Clock, Duration => JavaDuration}
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+import akka.stream.stage._
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+
+import scala.compat.java8.DurationConverters
+import scala.concurrent.duration.FiniteDuration
+
+class RateLimiterFlow[U] private (rate: FiniteDuration, clock: Clock) extends GraphStage[FlowShape[U, U]] {
+  val input = Inlet[U]("rate-limiter-input")
+  val output = Outlet[U]("rate-limiter-output")
+
+  override val shape = FlowShape(input, output)
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with StageLogging {
+
+      var nextPullAllowed = clock.instant()
+
+      setHandler(
+        input,
+        new InHandler {
+          override def onPush(): Unit = {
+            push(output, grab(input))
+          }
+        }
+      )
+
+      setHandler(
+        output,
+        new OutHandler {
+          override def onPull(): Unit = {
+            val now = clock.instant()
+            if (now.isBefore(nextPullAllowed)) {
+              val pendingTime = JavaDuration.between(now, nextPullAllowed)
+              scheduleOnce("pull", DurationConverters.toScala(pendingTime))
+            } else {
+              doPull()
+            }
+          }
+        }
+      )
+
+      private def doPull(): Unit = {
+        pull(input)
+        nextPullAllowed = clock.instant().plus(DurationConverters.toJava(rate))
+      }
+
+      override def onTimer(timerKey: Any): Unit = {
+        timerKey match {
+          case "pull" =>
+            doPull()
+          case other =>
+            log.error(s"Bug! We received a timer key ${other} that was not of type TimerKey")
+        }
+      }
+    }
+}
+
+object RateLimiterFlow {
+
+  /**
+    * A component similar to Akka stream's built-in throttle, with the important difference that it does not buffer a
+    * single element while the rate is exceeded.
+    *
+    * @param rate The time to wait between each pull
+    * @param clock Clock used to judge the current time when calculating delays. Note, advancing this clock has no effect on already-scheduled delays
+    */
+  def apply[U](rate: FiniteDuration, clock: Clock = Clock.systemUTC()): Flow[U, U, NotUsed] =
+    Flow.fromGraph(new RateLimiterFlow[U](rate, clock))
+}

--- a/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
+++ b/src/test/scala/mesosphere/marathon/stream/RateLimiterFlowTest.scala
@@ -1,0 +1,74 @@
+package mesosphere.marathon
+package stream
+
+import java.time.{Instant, Duration => JavaDuration}
+
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import mesosphere.AkkaUnitTest
+import mesosphere.marathon.test.SettableClock
+
+import scala.concurrent.duration._
+
+class RateLimiterFlowTest extends AkkaUnitTest {
+  "does not delay the very first element" in {
+    val clock = new SettableClock()
+
+    // if the first element is delayed, then the buffer will receive back-pressure signal and it will be dropped
+    Source(List(1, 2))
+      .buffer(1, OverflowStrategy.dropTail)
+      .via(RateLimiterFlow[Int](100.millis, clock))
+      .runWith(Sink.seq)
+      .futureValue
+      .shouldBe(Seq(1, 2))
+  }
+
+  "delay the pulling of elements by the specified rate" in {
+    val clock = new SettableClock()
+
+    Given("a stream connected to a rate limiter flow with a rate limit of 1/100ms")
+    val (input, output) =
+      Source
+        .queue[Int](16, OverflowStrategy.fail)
+        .via(RateLimiterFlow[Int](100.millis, clock))
+        .toMat(Sink.queue())(Keep.both)
+        .run
+
+    val start = Instant.now()
+    When("the first element is published")
+    input.offer(1)
+
+    Then("it should take less than 100ms to come through")
+    output.pull().futureValue shouldBe Some(1)
+    val e1Time = Instant.now
+    JavaDuration.between(start, e1Time).toMillis should be < 100L
+
+    When("another element is published at the same time")
+    input.offer(2)
+    Then("it should take more than 100ms from the start to come through")
+    output.pull().futureValue shouldBe Some(2)
+    val e2Time = Instant.now
+    JavaDuration.between(start, e2Time).toMillis should be >= 100L
+
+    When("the clock is advanced by 200 ms")
+    clock.advanceBy(200.millis)
+    And("element 3 is published")
+    input.offer(3)
+
+    Then("then element 3 is received less than 100ms after element 2")
+    output.pull().futureValue shouldBe Some(3)
+    val e3Time = Instant.now
+    JavaDuration.between(e2Time, e3Time).toMillis should be >= 100L
+  }
+
+  "not deliver a termination signal until all elements are processed" in {
+    val input = List(1, 2, 3, 4, 5)
+    val output = Source(List(1, 2, 3, 4, 5))
+      .via(RateLimiterFlow[Int](50.millis))
+      .runWith(Sink.seq)
+      .futureValue
+
+    output shouldBe input
+  }
+
+}

--- a/src/test/scala/mesosphere/marathon/test/SettableClock.scala
+++ b/src/test/scala/mesosphere/marathon/test/SettableClock.scala
@@ -3,6 +3,7 @@ package test
 
 import java.time._
 
+import scala.compat.java8.DurationConverters
 import scala.concurrent.duration.FiniteDuration
 
 object SettableClock {
@@ -24,11 +25,17 @@ class SettableClock(private[this] var clock: Clock = SettableClock.defaultJavaCl
 
   override def withZone(zoneId: ZoneId): Clock = new SettableClock(clock.withZone(zoneId))
 
+  @deprecated("Use advanceBy instead")
   def +=(duration: FiniteDuration): Unit = plus(duration)
 
+  def advanceBy(duration: FiniteDuration): this.type =
+    plus(DurationConverters.toJava(duration))
+
+  @deprecated("Use advanceBy instead")
   def plus(duration: FiniteDuration): this.type =
     plus(Duration.ofMillis(duration.toMillis))
 
+  @deprecated("Use advanceBy instead")
   def plus(duration: Duration): this.type = {
     clock = Clock.offset(clock, duration)
     subscribers.foreach(_())


### PR DESCRIPTION
The debounce logic would retain old state during backpressure, causing
old state to be acted upon after min-revive-offers-interval expired.

We switch to RateLimiterFlow which does not retain an element on
backpressure.

JIRA Issues: MARATHON-8775
