### PR TITLE
MARATHON-8771 don't let to-be-restarted instances constrain placement

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/VersionInfo.scala
+++ b/src/main/scala/mesosphere/marathon/state/VersionInfo.scala
@@ -5,8 +5,11 @@ sealed trait VersionInfo {
   def version: Timestamp
   def lastConfigChangeVersion: Timestamp
 
-  def withScaleOrRestartChange(newVersion: Timestamp): VersionInfo = {
-    VersionInfo.forNewConfig(version).withScaleOrRestartChange(newVersion)
+  def withScaleChange(newVersion: Timestamp): VersionInfo = {
+    VersionInfo.forNewConfig(version).withScaleChange(newVersion)
+  }
+  def withRestartChange(newVersion: Timestamp): VersionInfo = {
+    VersionInfo.forNewConfig(version).withRestartChange(newVersion)
   }
 
   def withConfigChange(newVersion: Timestamp): VersionInfo = {
@@ -44,8 +47,12 @@ object VersionInfo {
 
     override def lastConfigChangeVersion: Timestamp = lastConfigChangeAt
 
-    override def withScaleOrRestartChange(newVersion: Timestamp): VersionInfo = {
+    override def withScaleChange(newVersion: Timestamp): VersionInfo = {
       copy(version = newVersion, lastScalingAt = newVersion)
+    }
+
+    override def withRestartChange(newVersion: Timestamp): VersionInfo = {
+      copy(version = newVersion, lastConfigChangeAt = newVersion)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/state/VersionInfo.scala
+++ b/src/main/scala/mesosphere/marathon/state/VersionInfo.scala
@@ -8,6 +8,7 @@ sealed trait VersionInfo {
   def withScaleChange(newVersion: Timestamp): VersionInfo = {
     VersionInfo.forNewConfig(version).withScaleChange(newVersion)
   }
+
   def withRestartChange(newVersion: Timestamp): VersionInfo = {
     VersionInfo.forNewConfig(version).withRestartChange(newVersion)
   }
@@ -38,10 +39,9 @@ object VersionInfo {
   }
 
   /**
-    * @param version The version timestamp (we are currently assuming that this is the same as lastChangeAt)
-    * @param lastScalingAt The time stamp of the last change including scaling or restart changes
-    * @param lastConfigChangeAt The time stamp of the last change that changed configuration
-    *                           besides scaling or restarting
+    * @param version The version timestamp
+    * @param lastScalingAt The timestamp of the last scaling change
+    * @param lastConfigChangeAt The timestamp of the restart change
     */
   case class FullVersionInfo(version: Timestamp, lastScalingAt: Timestamp, lastConfigChangeAt: Timestamp) extends VersionInfo {
 

--- a/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
@@ -36,10 +36,10 @@ object GroupVersioningUtil extends StrictLogging {
             oldApp.versionInfo.withConfigChange(newVersion = version)
           } else if (oldApp.isOnlyScaleChange(newApp)) {
             logger.info(s"${newApp.id}: scaling op detected for app (oldVersion ${oldApp.versionInfo})")
-            oldApp.versionInfo.withScaleOrRestartChange(newVersion = version)
+            oldApp.versionInfo.withScaleChange(newVersion = version)
           } else if (oldApp.versionInfo != newApp.versionInfo && newApp.versionInfo == VersionInfo.NoVersion) {
             logger.info(s"${newApp.id}: restart detected for app (oldVersion ${oldApp.versionInfo})")
-            oldApp.versionInfo.withScaleOrRestartChange(newVersion = version)
+            oldApp.versionInfo.withRestartChange(newVersion = version)
           } else {
             oldApp.versionInfo
           }
@@ -84,10 +84,10 @@ object GroupVersioningUtil extends StrictLogging {
             oldPod.versionInfo.withConfigChange(newVersion = version)
           } else if (oldPod.isOnlyScaleChange(newPod)) {
             logger.info(s"${newPod.id}: scaling op detected for Pod (oldVersion ${oldPod.versionInfo})")
-            oldPod.versionInfo.withScaleOrRestartChange(newVersion = version)
+            oldPod.versionInfo.withScaleChange(newVersion = version)
           } else if (oldPod.versionInfo != newPod.versionInfo && newPod.versionInfo == VersionInfo.NoVersion) {
             logger.info(s"${newPod.id}: restart detected for Pod (oldVersion ${oldPod.versionInfo})")
-            oldPod.versionInfo.withScaleOrRestartChange(newVersion = version)
+            oldPod.versionInfo.withRestartChange(newVersion = version)
           } else {
             oldPod.versionInfo
           }

--- a/src/test/scala/mesosphere/marathon/state/VersionInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VersionInfoTest.scala
@@ -58,6 +58,23 @@ class VersionInfoTest extends UnitTest {
       )
     }
 
+    "OnlyVersion upgrades to FullVersion on a restart change" in {
+      Given("An OnlyVersion info")
+      val versionInfo = VersionInfo.OnlyVersion(Timestamp(1))
+
+      When("Applying a restart change")
+      val newVersion = versionInfo.withRestartChange(Timestamp(2))
+
+      Then("The version info is promoted to a FullVersion")
+      newVersion should be(
+        FullVersionInfo(
+          version = Timestamp(2),
+          lastScalingAt = Timestamp(1),
+          lastConfigChangeAt = Timestamp(2)
+        )
+      )
+    }
+
     "OnlyVersion upgrades to FullVersion on a config change" in {
       Given("An OnlyVersion info")
       val versionInfo = VersionInfo.OnlyVersion(Timestamp(1))
@@ -96,6 +113,28 @@ class VersionInfoTest extends UnitTest {
       )
     }
 
+    "A restart change on FullVersion only changes lastConfigChangeAt" in {
+      Given("A FullVersionInfo")
+      val versionInfo = VersionInfo.FullVersionInfo(
+        version = Timestamp(1),
+        lastScalingAt = Timestamp(1),
+        lastConfigChangeAt = Timestamp(1)
+      )
+
+      When("Applying a restart change")
+      val newVersion = versionInfo.withRestartChange(Timestamp(2))
+
+      Then("lastConfigChangeAt is updated while lastScalingAt is not")
+      newVersion should be(
+        FullVersionInfo(
+          version = Timestamp(2),
+          lastScalingAt = Timestamp(1),
+          lastConfigChangeAt = Timestamp(2)
+        )
+      )
+      newVersion.lastConfigChangeVersion should equal(Timestamp(2))
+    }
+
     "A config change on FullVersion changes scalingAt, lastConfigChangeAt" in {
       Given("A FullVersionInfo")
       val versionInfo = VersionInfo.FullVersionInfo(
@@ -104,7 +143,7 @@ class VersionInfoTest extends UnitTest {
         lastConfigChangeAt = Timestamp(1)
       )
 
-      When("Applying a scaling change")
+      When("Applying a config change")
       val newVersion = versionInfo.withConfigChange(Timestamp(3))
 
       Then("The version info is promoted to a FullVersion")

--- a/src/test/scala/mesosphere/marathon/state/VersionInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VersionInfoTest.scala
@@ -12,7 +12,7 @@ class VersionInfoTest extends UnitTest {
       val versionOfNoVersion = versionInfo.version
 
       When("Applying a scaling change")
-      val newVersion = versionInfo.withScaleOrRestartChange(Timestamp(1))
+      val newVersion = versionInfo.withScaleChange(Timestamp(1))
 
       Then("The version info is promoted to a FullVersion")
       newVersion should be(
@@ -46,7 +46,7 @@ class VersionInfoTest extends UnitTest {
       val versionInfo = VersionInfo.OnlyVersion(Timestamp(1))
 
       When("Applying a scaling change")
-      val newVersion = versionInfo.withScaleOrRestartChange(Timestamp(2))
+      val newVersion = versionInfo.withScaleChange(Timestamp(2))
 
       Then("The version info is promoted to a FullVersion")
       newVersion should be(
@@ -84,7 +84,7 @@ class VersionInfoTest extends UnitTest {
       )
 
       When("Applying a scaling change")
-      val newVersion = versionInfo.withScaleOrRestartChange(Timestamp(3))
+      val newVersion = versionInfo.withScaleChange(Timestamp(3))
 
       Then("The version info is promoted to a FullVersion")
       newVersion should be(

--- a/src/test/scala/mesosphere/marathon/upgrade/GroupVersioningUtilTest.scala
+++ b/src/test/scala/mesosphere/marathon/upgrade/GroupVersioningUtilTest.scala
@@ -89,7 +89,7 @@ class GroupVersioningUtilTest extends UnitTest with GroupCreation {
       val updated = GroupVersioningUtil.updateVersionInfoForChangedApps(Timestamp(10), nestedApp, nestedAppScaled)
       Then("The timestamp of the app and groups are updated appropriately")
       def update(maybeApp: Option[AppDefinition]): AppDefinition =
-        maybeApp.map(_.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(0)).withScaleOrRestartChange(Timestamp(10)))).get
+        maybeApp.map(_.copy(versionInfo = VersionInfo.forNewConfig(Timestamp(0)).withScaleChange(Timestamp(10)))).get
       updated should equal(
         nestedAppScaled.updateApp(
           AbsolutePathId("/nested/app"),


### PR DESCRIPTION
Quoting timcharper:

> Currently, when Marathon restarts an app and evaluates constraints for
> placement of new instances, it only considers placed instances with the
> same configVersion. For example, if you have a hostname:UNIQUE
> constraint and perform a rolling upgrading, Marathon will allow two
> instances to be placed on the same node as long as their configVersion
> is different.
> When a Marathon app is restarted, however, the version is updated, but
> the configVersion remains the same. This means that Marathon will
> consider to-be-killed instances as part of the input for placements in
> constraints. For things like GROUP_BY, this is leading to the constraint
> ultimately being invalid.

This change seeks to change that behaviour by separating ScaleChanges
and RestartChanges and letting the latter modify `lastConfigChangeAt`.

JIRA issues:

* MARATHON-8771