### PR TITLE
refactor: reuse withConfigChange for restarts

### DIFF
--- a/src/main/scala/mesosphere/marathon/state/VersionInfo.scala
+++ b/src/main/scala/mesosphere/marathon/state/VersionInfo.scala
@@ -9,10 +9,6 @@ sealed trait VersionInfo {
     VersionInfo.forNewConfig(version).withScaleChange(newVersion)
   }
 
-  def withRestartChange(newVersion: Timestamp): VersionInfo = {
-    VersionInfo.forNewConfig(version).withRestartChange(newVersion)
-  }
-
   def withConfigChange(newVersion: Timestamp): VersionInfo = {
     VersionInfo.forNewConfig(newVersion)
   }
@@ -51,8 +47,8 @@ object VersionInfo {
       copy(version = newVersion, lastScalingAt = newVersion)
     }
 
-    override def withRestartChange(newVersion: Timestamp): VersionInfo = {
-      copy(version = newVersion, lastConfigChangeAt = newVersion)
+    override def withConfigChange(newVersion: Timestamp): VersionInfo = {
+      copy(version = newVersion, lastScalingAt = newVersion, lastConfigChangeAt = newVersion)
     }
   }
 

--- a/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
+++ b/src/main/scala/mesosphere/marathon/upgrade/GroupVersioningUtil.scala
@@ -39,7 +39,7 @@ object GroupVersioningUtil extends StrictLogging {
             oldApp.versionInfo.withScaleChange(newVersion = version)
           } else if (oldApp.versionInfo != newApp.versionInfo && newApp.versionInfo == VersionInfo.NoVersion) {
             logger.info(s"${newApp.id}: restart detected for app (oldVersion ${oldApp.versionInfo})")
-            oldApp.versionInfo.withRestartChange(newVersion = version)
+            oldApp.versionInfo.withConfigChange(newVersion = version)
           } else {
             oldApp.versionInfo
           }
@@ -87,7 +87,7 @@ object GroupVersioningUtil extends StrictLogging {
             oldPod.versionInfo.withScaleChange(newVersion = version)
           } else if (oldPod.versionInfo != newPod.versionInfo && newPod.versionInfo == VersionInfo.NoVersion) {
             logger.info(s"${newPod.id}: restart detected for Pod (oldVersion ${oldPod.versionInfo})")
-            oldPod.versionInfo.withRestartChange(newVersion = version)
+            oldPod.versionInfo.withConfigChange(newVersion = version)
           } else {
             oldPod.versionInfo
           }

--- a/src/test/scala/mesosphere/marathon/state/VersionInfoTest.scala
+++ b/src/test/scala/mesosphere/marathon/state/VersionInfoTest.scala
@@ -58,23 +58,6 @@ class VersionInfoTest extends UnitTest {
       )
     }
 
-    "OnlyVersion upgrades to FullVersion on a restart change" in {
-      Given("An OnlyVersion info")
-      val versionInfo = VersionInfo.OnlyVersion(Timestamp(1))
-
-      When("Applying a restart change")
-      val newVersion = versionInfo.withRestartChange(Timestamp(2))
-
-      Then("The version info is promoted to a FullVersion")
-      newVersion should be(
-        FullVersionInfo(
-          version = Timestamp(2),
-          lastScalingAt = Timestamp(1),
-          lastConfigChangeAt = Timestamp(2)
-        )
-      )
-    }
-
     "OnlyVersion upgrades to FullVersion on a config change" in {
       Given("An OnlyVersion info")
       val versionInfo = VersionInfo.OnlyVersion(Timestamp(1))
@@ -111,28 +94,6 @@ class VersionInfoTest extends UnitTest {
           lastConfigChangeAt = Timestamp(1)
         )
       )
-    }
-
-    "A restart change on FullVersion only changes lastConfigChangeAt" in {
-      Given("A FullVersionInfo")
-      val versionInfo = VersionInfo.FullVersionInfo(
-        version = Timestamp(1),
-        lastScalingAt = Timestamp(1),
-        lastConfigChangeAt = Timestamp(1)
-      )
-
-      When("Applying a restart change")
-      val newVersion = versionInfo.withRestartChange(Timestamp(2))
-
-      Then("lastConfigChangeAt is updated while lastScalingAt is not")
-      newVersion should be(
-        FullVersionInfo(
-          version = Timestamp(2),
-          lastScalingAt = Timestamp(1),
-          lastConfigChangeAt = Timestamp(2)
-        )
-      )
-      newVersion.lastConfigChangeVersion should equal(Timestamp(2))
     }
 
     "A config change on FullVersion changes scalingAt, lastConfigChangeAt" in {


### PR DESCRIPTION
Summary:

as the significant bit is updating `lastConfigChangeAt`, we can also use `withConfigChange` for restarts. that `version` and `lastScalingAt` are then updated along should not hurt.

JIRA issues:

- MARATHON-8771